### PR TITLE
Add Monitor Boilerplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ CONTROLLERS = \
   unikorn-network-controller \
   unikorn-security-group-controller \
   unikorn-security-group-rule-controller \
-  unikorn-server-controller
+  unikorn-server-controller \
+  unikorn-region-monitor
 
 # Release will do cross compliation of all images for the 'all' target.
 # Note we aren't fucking about with docker here because that opens up a

--- a/charts/region/templates/_helpers.tpl
+++ b/charts/region/templates/_helpers.tpl
@@ -5,6 +5,10 @@ Create the container images
 {{- .Values.image | default (printf "%s/unikorn-region-controller:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default .Chart.Version)) }}
 {{- end }}
 
+{{- define "unikorn.regionMonitorImage" -}}
+{{- .Values.monitor.image | default (printf "%s/unikorn-region-monitor:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default .Chart.Version)) }}
+{{- end }}
+
 {{- define "unikorn.identityControllerImage" -}}
 {{- .Values.identityController.image | default (printf "%s/unikorn-identity-controller:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default .Chart.Version)) }}
 {{- end }}

--- a/charts/region/templates/monitor/clusterrole.yaml
+++ b/charts/region/templates/monitor/clusterrole.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-monitor
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+rules:
+# Manage kubernetes clusters and control planes (my job).
+- apiGroups:
+  - region.unikorn-cloud.org
+  resources:
+  - regions
+  - servers
+  - networks
+  - openstackservers
+  - openstacknetworks
+  verbs:
+  - list
+  - watch
+# Update status conditions
+- apiGroups:
+  - region.unikorn-cloud.org
+  resources:
+  - servers/status
+  - networks/status
+  verbs:
+  - patch
+# Get region credentials.
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch

--- a/charts/region/templates/monitor/clusterrolebinding.yaml
+++ b/charts/region/templates/monitor/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-monitor
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-monitor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-monitor

--- a/charts/region/templates/monitor/deployment.yaml
+++ b/charts/region/templates/monitor/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-monitor
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-monitor
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-monitor
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-monitor
+        image: {{ include "unikorn.regionMonitorImage" . }}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+      serviceAccountName: {{ .Release.Name }}-monitor
+      securityContext:
+        runAsNonRoot: true

--- a/charts/region/templates/monitor/serviceaccount.yaml
+++ b/charts/region/templates/monitor/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-monitor
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+{{- with ( include "unikorn.imagePullSecrets" . ) }}
+imagePullSecrets:
+{{ . }}
+{{- end }}

--- a/charts/region/values.yaml
+++ b/charts/region/values.yaml
@@ -97,6 +97,11 @@ organization: nscaledev
 # Allows override of the global default image.
 # image:
 
+# Monitor configuration.
+monitor:
+  # Allow override of the controller image.
+  image: ~
+
 # Identity controller configuration.
 identityController:
   # Allow override of the controller image.

--- a/cmd/unikorn-region-monitor/main.go
+++ b/cmd/unikorn-region-monitor/main.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2024-2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/pflag"
+
+	coreclient "github.com/unikorn-cloud/core/pkg/client"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/monitor"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func main() {
+	// Initialize components with legacy flags.
+	zapOptions := &zap.Options{}
+	zapOptions.BindFlags(flag.CommandLine)
+
+	// Initialize components with flags, then parse them.
+	monitorOptions := &monitor.Options{}
+	monitorOptions.AddFlags(pflag.CommandLine)
+
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+
+	// Get logging going first, log sinks will expect JSON formatted output for everything.
+	log.SetLogger(zap.New(zap.UseFlagOptions(zapOptions)))
+
+	logger := log.Log.WithName(constants.Application)
+
+	// Hello World!
+	logger.Info("service starting", "application", constants.Application, "version", constants.Version, "revision", constants.Revision)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Register a signal handler to trigger a graceful shutdown.
+	stop := make(chan os.Signal, 1)
+
+	signal.Notify(stop, syscall.SIGTERM)
+
+	go func() {
+		<-stop
+
+		// Cancel anything hanging off the root context.
+		cancel()
+	}()
+
+	client, err := coreclient.New(ctx, unikornv1.AddToScheme)
+	if err != nil {
+		logger.Error(err, "failed to create client")
+
+		return
+	}
+
+	monitor.Run(ctx, client, monitorOptions)
+}

--- a/docker/unikorn-region-monitor/.dockerignore
+++ b/docker/unikorn-region-monitor/.dockerignore
@@ -1,0 +1,2 @@
+*
+!bin/*-linux-gnu/unikorn-region-monitor

--- a/docker/unikorn-region-monitor/Dockerfile
+++ b/docker/unikorn-region-monitor/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcr.io/distroless/static:nonroot
+
+# This is implcitly created by 'docker buildx build'
+ARG TARGETARCH
+
+COPY bin/${TARGETARCH}-linux-gnu/unikorn-region-monitor /
+
+ENTRYPOINT ["/unikorn-region-monitor"]

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024-2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package monitor
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Options allow modification of parameters via the CLI.
+type Options struct {
+	// pollPeriod defines how often to run.  There's no harm in having it
+	// run with high frequency, reads are all cached.  It's mostly down to
+	// burning CPU unnecessarily.
+	pollPeriod time.Duration
+}
+
+// AddFlags registers option flags with pflag.
+func (o *Options) AddFlags(flags *pflag.FlagSet) {
+	flags.DurationVar(&o.pollPeriod, "poll-period", time.Minute, "Period to poll for updates")
+}
+
+// Checker is an interface that monitors must implement.
+type Checker interface {
+	// Check does whatever the checker is checking for.
+	Check(ctx context.Context) error
+}
+
+// Run sits in an infinite loop, polling every so often.
+func Run(ctx context.Context, c client.Client, o *Options) {
+	log := log.FromContext(ctx)
+
+	ticker := time.NewTicker(o.pollPeriod)
+	defer ticker.Stop()
+
+	checkers := []Checker{}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for _, checker := range checkers {
+				if err := checker.Check(ctx); err != nil {
+					log.Error(err, "check failed")
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
We need to periodically poll the provider backend to get the server health status so this can then be propagated to the compute service.