### PR TITLE
Fix Security Group Rules Filtering

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -380,8 +380,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDProjectsProjectIDIdentities
 		return
 	}
 
-	// TODO: filtering???
-	result, err := securitygrouprule.New(h.client, h.namespace).List(r.Context(), organizationID)
+	result, err := securitygrouprule.New(h.client, h.namespace).List(r.Context(), organizationID, securityGroupID)
 	if err != nil {
 		errors.HandleError(w, r, err)
 		return

--- a/pkg/handler/securitygrouprule/client.go
+++ b/pkg/handler/securitygrouprule/client.go
@@ -235,13 +235,14 @@ func (c *Client) GetRaw(ctx context.Context, organizationID, projectID, security
 }
 
 // List returns an ordered list of all resources in scope.
-func (c *Client) List(ctx context.Context, organizationID string) (openapi.SecurityGroupRulesRead, error) {
+func (c *Client) List(ctx context.Context, organizationID, securityGroupID string) (openapi.SecurityGroupRulesRead, error) {
 	result := &unikornv1.SecurityGroupRuleList{}
 
 	options := &client.ListOptions{
 		Namespace: c.namespace,
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			coreconstants.OrganizationLabel: organizationID,
+			constants.SecurityGroupLabel:    securityGroupID,
 		}),
 	}
 


### PR DESCRIPTION
## Description
This PR fixes the "list security group rules by security group" API so that it correctly returns only the rules associated with the specified security group. Previously, the API returned all security group rules within the organisation because it was not passing the security group ID filter to the upstream API request.

## Implementation
This implementation takes a slightly different approach compared to other resource listing APIs. In those cases, the filter is usually applied after fetching all resources, by parsing the tag filter and comparing it against resource tags. That approach doesn't work here because security group rules do not include the security group ID in their tags, and the security group ID is obtained directly from the request handler rather than through the tag filter parameter.

To make it consistent with the existing pattern, we would need to construct the tag filter from the security group ID in one of the layers and manually define the tag filter parameter (rather than generating it from the OpenAPI spec), since we are unlikely to change the API spec (even if made backward compatible) purely to make it look consistent with the other implementations.