### PR TITLE
Return Images Relevant to the Requester

### DIFF
--- a/pkg/handler/region/region.go
+++ b/pkg/handler/region/region.go
@@ -359,7 +359,7 @@ func (c *Client) ListImages(ctx context.Context, organizationID, regionID string
 		return nil, errors.OAuth2ServerError("failed to create region provider").WithError(err)
 	}
 
-	result, err := provider.Images(ctx)
+	result, err := provider.Images(ctx, organizationID)
 	if err != nil {
 		return nil, errors.OAuth2ServerError("failed to list images").WithError(err)
 	}

--- a/pkg/providers/kubernetes/provider.go
+++ b/pkg/providers/kubernetes/provider.go
@@ -194,7 +194,7 @@ func (p *Provider) Flavors(ctx context.Context) (types.FlavorList, error) {
 }
 
 // Images lists all available images.
-func (p *Provider) Images(ctx context.Context) (types.ImageList, error) {
+func (p *Provider) Images(ctx context.Context, organizationID string) (types.ImageList, error) {
 	return nil, ErrUnimplmented
 }
 

--- a/pkg/providers/openstack/provider.go
+++ b/pkg/providers/openstack/provider.go
@@ -351,7 +351,7 @@ func (p *Provider) Flavors(ctx context.Context) (types.FlavorList, error) {
 }
 
 // Images lists all available images.
-func (p *Provider) Images(ctx context.Context) (types.ImageList, error) {
+func (p *Provider) Images(ctx context.Context, organizationID string) (types.ImageList, error) {
 	imageService, err := p.image(ctx)
 	if err != nil {
 		return nil, err
@@ -361,6 +361,12 @@ func (p *Provider) Images(ctx context.Context) (types.ImageList, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Filter images that either have no organisation ID or match the requested one.
+	resources = slices.DeleteFunc(resources, func(image images.Image) bool {
+		value := image.Properties["unikorn:organization:id"]
+		return value != nil && value != organizationID
+	})
 
 	result := make(types.ImageList, len(resources))
 

--- a/pkg/providers/types/interfaces.go
+++ b/pkg/providers/types/interfaces.go
@@ -33,7 +33,7 @@ type Provider interface {
 	// Flavors list all available flavors.
 	Flavors(ctx context.Context) (FlavorList, error)
 	// Images lists all available images.
-	Images(ctx context.Context) (ImageList, error)
+	Images(ctx context.Context, organizationID string) (ImageList, error)
 	// CreateIdentity creates a new identity for cloud infrastructure.
 	CreateIdentity(ctx context.Context, identity *unikornv1.Identity) error
 	// DeleteIdentity cleans up an identity for cloud infrastructure.


### PR DESCRIPTION
## Description
The list images endpoint now filters results based on the new attributes in `image.properties` to return images relevant to the requester.
- If the attribute `unikorn:organization:id` is absent, the image is treated as public and accessible to all users.
- If the attribute `unikorn:organization:id` is present, the image is only returned when the requester's ACL organization ID matches the image's organization ID.