### PR TITLE
Fix Security Group Deletion

### DIFF
--- a/charts/region/crds/region.unikorn-cloud.org_servers.yaml
+++ b/charts/region/crds/region.unikorn-cloud.org_servers.yaml
@@ -217,8 +217,6 @@ spec:
               publicIP:
                 description: PublicIP is the public IP address of the server.
                 type: string
-            required:
-            - phase
             type: object
         required:
         - spec

--- a/charts/region/templates/server-controller/clusterrole.yaml
+++ b/charts/region/templates/server-controller/clusterrole.yaml
@@ -14,11 +14,19 @@ rules:
   - openstackidentities
   - networks
   - openstacknetworks
-  - securitygroups
   - openstacksecuritygroups
   verbs:
   - list
   - watch
+# Manage references.
+- apiGroups:
+  - region.unikorn-cloud.org
+  resources:
+  - securitygroups
+  verbs:
+  - list
+  - watch
+  - update
 - apiGroups:
   - region.unikorn-cloud.org
   resources:

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spjmurray/go-util v0.1.3
 	github.com/stretchr/testify v1.10.0
-	github.com/unikorn-cloud/core v1.7.0
-	github.com/unikorn-cloud/identity v1.7.0
+	github.com/unikorn-cloud/core v1.7.1-0.20250925125816-d2484bd7848d
+	github.com/unikorn-cloud/identity v1.7.1-0.20250924144813-5629afb944f9
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -168,10 +168,10 @@ github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v1.7.0 h1:X248cvQ7guJu9tQ2qLNlmZzlooTKIEokjlEsk75XY6Y=
-github.com/unikorn-cloud/core v1.7.0/go.mod h1:fMkv/mXFw7N6V+SV1Pd9WSs6HqP02IdM2iECNxewZ9Q=
-github.com/unikorn-cloud/identity v1.7.0 h1:k4J+fbxlAqmFIRbXfEPJRF2zGY/useay2zRg12W4jJM=
-github.com/unikorn-cloud/identity v1.7.0/go.mod h1:MNlj8LyEHAWWZ+CLoBnjgk5AViTY7OVyGDQ2M1N/dTo=
+github.com/unikorn-cloud/core v1.7.1-0.20250925125816-d2484bd7848d h1:yCyLzFf4yyyVU3HY197BfFEBcHw0AMvaS3iAMJfL3gM=
+github.com/unikorn-cloud/core v1.7.1-0.20250925125816-d2484bd7848d/go.mod h1:+eILRQ0z60IzauRIqzS9MvirzIhMLdSK+wI/CRgvXe8=
+github.com/unikorn-cloud/identity v1.7.1-0.20250924144813-5629afb944f9 h1:G1ZIdurXxeJXMSzwn780EM2RoDi/2o0ZfDTSoac/98k=
+github.com/unikorn-cloud/identity v1.7.1-0.20250924144813-5629afb944f9/go.mod h1:9v0e908IVxZ6IXT62a6QuoNfnLZiu8b+K+IBYsaAW2I=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -692,7 +692,7 @@ type ServerStatus struct {
 	// Current service state of a cluster manager.
 	Conditions []unikornv1core.Condition `json:"conditions,omitempty"`
 	// Phase is the current lifecycle phase of the server.
-	Phase InstanceLifecyclePhase `json:"phase"`
+	Phase InstanceLifecyclePhase `json:"phase,omitempty"`
 	// PrivateIP is the private IP address of the server.
 	PrivateIP *string `json:"privateIP,omitempty"`
 	// PublicIP is the public IP address of the server.

--- a/pkg/provisioners/managers/identity/provisioner.go
+++ b/pkg/provisioners/managers/identity/provisioner.go
@@ -26,10 +26,6 @@ import (
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/handler/region"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // Provisioner encapsulates control plane provisioning.
@@ -56,7 +52,7 @@ func (p *Provisioner) Object() unikornv1core.ManagableResourceInterface {
 
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
-	cli, err := coreclient.ProvisionerClientFromContext(ctx)
+	cli, err := coreclient.FromContext(ctx)
 	if err != nil {
 		return err
 	}
@@ -75,12 +71,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 // Deprovision implements the Provision interface.
 func (p *Provisioner) Deprovision(ctx context.Context) error {
-	// Wait for any owned resources to be cleaned up first.
-	if controllerutil.ContainsFinalizer(p.identity, metav1.FinalizerDeleteDependents) {
-		return provisioners.ErrYield
-	}
-
-	cli, err := coreclient.ProvisionerClientFromContext(ctx)
+	cli, err := coreclient.FromContext(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/provisioners/managers/network/provisioner.go
+++ b/pkg/provisioners/managers/network/provisioner.go
@@ -29,10 +29,7 @@ import (
 	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/handler/region"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -76,7 +73,7 @@ func (p *Provisioner) getIdentity(ctx context.Context, cli client.Client) (*unik
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
-	cli, err := coreclient.ProvisionerClientFromContext(ctx)
+	cli, err := coreclient.FromContext(ctx)
 	if err != nil {
 		return err
 	}
@@ -121,12 +118,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 // Deprovision implements the Provision interface.
 func (p *Provisioner) Deprovision(ctx context.Context) error {
-	// Wait for any owned resources to be cleaned up first.
-	if controllerutil.ContainsFinalizer(p.network, metav1.FinalizerDeleteDependents) {
-		return provisioners.ErrYield
-	}
-
-	cli, err := coreclient.ProvisionerClientFromContext(ctx)
+	cli, err := coreclient.FromContext(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/provisioners/managers/security-group/provisioner.go
+++ b/pkg/provisioners/managers/security-group/provisioner.go
@@ -29,10 +29,7 @@ import (
 	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/handler/region"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -76,7 +73,7 @@ func (p *Provisioner) getIdentity(ctx context.Context, cli client.Client) (*unik
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
-	cli, err := coreclient.ProvisionerClientFromContext(ctx)
+	cli, err := coreclient.FromContext(ctx)
 	if err != nil {
 		return err
 	}
@@ -119,12 +116,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 // Deprovision implements the Provision interface.
 func (p *Provisioner) Deprovision(ctx context.Context) error {
-	// Wait for any owned resources to be cleaned up first.
-	if controllerutil.ContainsFinalizer(p.securitygroup, metav1.FinalizerDeleteDependents) {
-		return provisioners.ErrYield
-	}
-
-	cli, err := coreclient.ProvisionerClientFromContext(ctx)
+	cli, err := coreclient.FromContext(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As it stands security groups will be deleted when identities are, and will error until all server ports stop using them.  This adds server references to security groups (and keeps then in sync) to mostly prevent this (there are abviously some races, but less so now).  This will allow security groups to be independently managed from clusters and instances in the very near future.