### PR TITLE
Add Server to Network References

### DIFF
--- a/charts/region/templates/server-controller/clusterrole.yaml
+++ b/charts/region/templates/server-controller/clusterrole.yaml
@@ -22,6 +22,7 @@ rules:
 - apiGroups:
   - region.unikorn-cloud.org
   resources:
+  - networks
   - securitygroups
   verbs:
   - list


### PR DESCRIPTION
If you try to delete a network when it still has servers (ports) attached then it will throw an error.  We can prevent these from being surfaced by adding references from the server to the network to inhibit deletion until we are done with them.