### PR TITLE
Add Identity References to Projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ REVISION := $(shell git rev-parse HEAD)
 # want to be amd64.
 CONTROLLERS = \
   unikorn-region-controller \
+  unikorn-region-project-consumer \
   unikorn-identity-controller \
   unikorn-network-controller \
   unikorn-security-group-controller \

--- a/charts/region/templates/_helpers.tpl
+++ b/charts/region/templates/_helpers.tpl
@@ -5,6 +5,10 @@ Create the container images
 {{- .Values.server.image | default (printf "%s/unikorn-region-controller:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default .Chart.Version)) }}
 {{- end }}
 
+{{- define "unikorn.projectConsumerImage" -}}
+{{- .Values.projectConsumer.image | default (printf "%s/unikorn-region-project-consumer:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default .Chart.Version)) }}
+{{- end }}
+
 {{- define "unikorn.regionMonitorImage" -}}
 {{- .Values.monitor.image | default (printf "%s/unikorn-region-monitor:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default .Chart.Version)) }}
 {{- end }}

--- a/charts/region/templates/project-consumer/clusterrole.yaml
+++ b/charts/region/templates/project-consumer/clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-project-consumer
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+rules:
+# Orchestrate Unikorn resources (my job).
+- apiGroups:
+  - identity.unikorn-cloud.org
+  resources:
+  - projects
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - region.unikorn-cloud.org
+  resources:
+  - identities
+  verbs:
+  - list
+  - watch
+  - delete

--- a/charts/region/templates/project-consumer/clusterrolebinding.yaml
+++ b/charts/region/templates/project-consumer/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-project-consumer
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-project-consumer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-project-consumer

--- a/charts/region/templates/project-consumer/deployment.yaml
+++ b/charts/region/templates/project-consumer/deployment.yaml
@@ -1,27 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-identity-controller
+  name: {{ .Release.Name }}-project-consumer
   labels:
     {{- include "unikorn.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-identity-controller
+      app: {{ .Release.Name }}-project-consumer
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-identity-controller
+        app: {{ .Release.Name }}-project-consumer
     spec:
       containers:
-      - name: {{ .Release.Name }}-identity-controller
-        image: {{ include "unikorn.identityControllerImage" . }}
+      - name: {{ .Release.Name }}-project-consumer
+        image: {{ include "unikorn.projectConsumerImage" . }}
         args:
         {{- include "unikorn.core.flags" . | nindent 8 }}
-        {{- include "unikorn.otlp.flags" . | nindent 8 }}
-        {{- include "unikorn.mtls.flags" . | nindent 8 }}
-        {{- include "unikorn.identity.flags" . | nindent 8 }}
         ports:
         - name: http
           containerPort: 6080
@@ -30,9 +27,9 @@ spec:
         - name: pprof
           containerPort: 6060
         resources:
-          {{- .Values.identityController.resources | toYaml | nindent 10 }}
+          {{- .Values.projectConsumer.resources | toYaml | nindent 10 }}
         securityContext:
           readOnlyRootFilesystem: true
-      serviceAccountName: {{ .Release.Name }}-identity-controller
+      serviceAccountName: {{ .Release.Name }}-project-consumer
       securityContext:
         runAsNonRoot: true

--- a/charts/region/templates/project-consumer/role.yaml
+++ b/charts/region/templates/project-consumer/role.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-project-consumer
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+rules:
+# Controller prerequisites.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update

--- a/charts/region/templates/project-consumer/rolebinding.yaml
+++ b/charts/region/templates/project-consumer/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-project-consumer
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-project-consumer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-project-consumer

--- a/charts/region/templates/project-consumer/serviceaccount.yaml
+++ b/charts/region/templates/project-consumer/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-project-consumer
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+{{- with ( include "unikorn.imagePullSecrets" . ) }}
+imagePullSecrets:
+{{ . }}
+{{- end }}

--- a/charts/region/values.yaml
+++ b/charts/region/values.yaml
@@ -113,6 +113,16 @@ monitor:
       cpu: 100m
       memory: 100Mi
 
+# Project event consumer.
+projectConsumer:
+  # Allow override of the controller image.
+  image: ~
+  # Allows resource limits to be set.
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+
 # Identity controller configuration.
 identityController:
   # Allow override of the controller image.

--- a/cmd/unikorn-region-project-consumer/main.go
+++ b/cmd/unikorn-region-project-consumer/main.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+
+	"github.com/unikorn-cloud/core/pkg/client"
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	"github.com/unikorn-cloud/core/pkg/messaging/consumer"
+	"github.com/unikorn-cloud/core/pkg/messaging/kubernetes"
+	identityv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+
+	klog "k8s.io/klog/v2"
+
+	cr "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func main() {
+	var namespace string
+
+	pflag.StringVar(&namespace, "namespace", "", "Namespace the service is running in.")
+
+	zapOptions := &zap.Options{}
+	zapOptions.BindFlags(flag.CommandLine)
+
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
+	pflag.Parse()
+
+	logr := zap.New(zap.UseFlagOptions(zapOptions))
+
+	log.SetLogger(logr)
+	klog.SetLogger(logr)
+
+	logger := log.Log.WithName("init")
+	logger.Info("service starting", "application", constants.Application, "version", constants.Version, "revision", constants.Revision)
+
+	ctx := cr.SetupSignalHandler()
+
+	// The consumer will listen for project deletion events and propagate them to
+	// any root resources that have a corresponding project label.
+	cli, err := client.New(ctx, regionv1.AddToScheme)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	consumer := consumer.NewCascadingDelete(cli, &regionv1.IdentityList{}, consumer.WithNamespace(namespace), consumer.WithResourceLabel(coreconstants.ProjectLabel))
+
+	scheme, err := client.NewScheme(identityv1.AddToScheme)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if err := kubernetes.New(cr.GetConfigOrDie(), scheme, &identityv1.Project{}, consumer).Run(ctx); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/docker/unikorn-region-project-consumer/.dockerignore
+++ b/docker/unikorn-region-project-consumer/.dockerignore
@@ -1,0 +1,2 @@
+*
+!bin/*-linux-gnu/unikorn-region-project-consumer

--- a/docker/unikorn-region-project-consumer/Dockerfile
+++ b/docker/unikorn-region-project-consumer/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcr.io/distroless/static:nonroot
+
+# This is implcitly created by 'docker buildx build'
+ARG TARGETARCH
+
+COPY bin/${TARGETARCH}-linux-gnu/unikorn-region-project-consumer /
+
+ENTRYPOINT ["/unikorn-region-project-consumer"]

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spjmurray/go-util v0.1.3
 	github.com/stretchr/testify v1.10.0
-	github.com/unikorn-cloud/core v1.8.0
-	github.com/unikorn-cloud/identity v1.8.0
+	github.com/unikorn-cloud/core v1.8.1-0.20251002152732-a609f82fbccc
+	github.com/unikorn-cloud/identity v1.8.1-0.20251002154230-366e16d438e6
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0
@@ -21,6 +21,7 @@ require (
 	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
+	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/yaml v1.4.0
@@ -103,7 +104,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/apiextensions-apiserver v0.32.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,10 +168,10 @@ github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v1.8.0 h1:eFfoDTe5Qc23tsFWya0zki29jV9nHcnW6SveXIAadHs=
-github.com/unikorn-cloud/core v1.8.0/go.mod h1:KZLGw/EyZWjem4c80QF70KqpHIT7MAk7o6L4VAWsnGM=
-github.com/unikorn-cloud/identity v1.8.0 h1:PTohg9AFb5hQGxQOHKEOUn6N2rNZVIqz2osMT4DkdPk=
-github.com/unikorn-cloud/identity v1.8.0/go.mod h1:l3W2tBRfTY7GCb/D1g3VlmDCDVNJump3OUl6svrrWW8=
+github.com/unikorn-cloud/core v1.8.1-0.20251002152732-a609f82fbccc h1:XVPkF5iHR+wPO8ih+TpzaZI8+BSLbkDmvF7GcSMPx3E=
+github.com/unikorn-cloud/core v1.8.1-0.20251002152732-a609f82fbccc/go.mod h1:KZLGw/EyZWjem4c80QF70KqpHIT7MAk7o6L4VAWsnGM=
+github.com/unikorn-cloud/identity v1.8.1-0.20251002154230-366e16d438e6 h1:OSrmpmxiyX9xWhuKCltuu04OnYIj2FzUjYbdkv/Jofs=
+github.com/unikorn-cloud/identity v1.8.1-0.20251002154230-366e16d438e6/go.mod h1:l3W2tBRfTY7GCb/D1g3VlmDCDVNJump3OUl6svrrWW8=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 	"path"
+
+	"github.com/unikorn-cloud/identity/pkg/client"
 )
 
 var (
@@ -42,6 +44,13 @@ var (
 // call out ot other micro services.
 func VersionString() string {
 	return fmt.Sprintf("%s/%s (revision/%s)", Application, Version, Revision)
+}
+
+func ServiceDescriptor() client.ServiceDescriptor {
+	return client.ServiceDescriptor{
+		ServiceName:    Application,
+		ServiceVersion: Version,
+	}
 }
 
 const (

--- a/pkg/managers/identity/manager.go
+++ b/pkg/managers/identity/manager.go
@@ -44,7 +44,7 @@ func (*Factory) Metadata() (string, string, string) {
 
 // Options returns any options to be added to the CLI flags and passed to the reconciler.
 func (*Factory) Options() coremanager.ControllerOptions {
-	return nil
+	return &identity.Options{}
 }
 
 // Reconciler returns a new reconciler instance.


### PR DESCRIPTION
Networks will very shortly be top level user created things, and as such will need to be deleted on project deletion.  We need to inhibit project deletion until we know all networks are cleaned up, so we add references to the root node, the cloud identity, to pull this off.