### PR TITLE
Remove provider.Kind(), which is not used

### DIFF
--- a/pkg/providers/internal/kubernetes/provider.go
+++ b/pkg/providers/internal/kubernetes/provider.go
@@ -142,11 +142,6 @@ func (p *Provider) regionClient(ctx context.Context) (client.Client, error) {
 	return client, nil
 }
 
-// Kind returns the provider kind.
-func (p *Provider) Kind() unikornv1.Provider {
-	return unikornv1.ProviderKubernetes
-}
-
 // Flavors list all available flavors.
 func (p *Provider) Flavors(ctx context.Context) (types.FlavorList, error) {
 	client, err := p.regionClient(ctx)

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -447,11 +447,6 @@ func (p *Provider) privilegedNetworkFromServicePrincipal(ctx context.Context, id
 	return client, nil
 }
 
-// Kind returns the provider kind.
-func (p *Provider) Kind() unikornv1.Provider {
-	return unikornv1.ProviderOpenstack
-}
-
 // Region returns the provider's region.
 func (p *Provider) Region(ctx context.Context) (*unikornv1.Region, error) {
 	// Get the newest version of the region.

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -355,11 +355,6 @@ func (p *Provider) loadBalancerFromServicePrincipal(ctx context.Context, identit
 	return client, nil
 }
 
-// Kind returns the provider kind.
-func (p *Provider) Kind() unikornv1.Provider {
-	return unikornv1.ProviderOpenstack
-}
-
 // Region returns the provider's region.
 func (p *Provider) Region(ctx context.Context) (*unikornv1.Region, error) {
 	region, _, err := p.openstack.regionRefresh(ctx)

--- a/pkg/providers/internal/simulated/provider.go
+++ b/pkg/providers/internal/simulated/provider.go
@@ -107,10 +107,6 @@ func New(_ context.Context, cli client.Client, region *unikornv1.Region) (*Provi
 	}, nil
 }
 
-func (p *Provider) Kind() unikornv1.Provider {
-	return unikornv1.ProviderSimulated
-}
-
 func (p *Provider) Region(_ context.Context) (*unikornv1.Region, error) {
 	return p.region, nil
 }


### PR DESCRIPTION
I think these methods were added in a previous formulation, which matched provider implementations to requests by asking for `Kind()`. The region to provider dispatch uses a type assertion now.
