### PR TITLE
Generate secure passwords for OpenStack

### DIFF
--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -19,6 +19,8 @@ package openstack
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"math/big"
@@ -55,7 +57,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -924,7 +925,13 @@ func (p *Provider) provisionUser(ctx context.Context, identityService *IdentityC
 	}
 
 	name := identityResourceName(identity)
-	password := string(uuid.NewUUID())
+
+	b := make([]byte, 9)
+	if _, err := rand.Read(b); err != nil {
+		return err
+	}
+
+	password := base64.RawURLEncoding.EncodeToString(b)
 	_, credentials := p.openstack.regionSnapshot()
 
 	user, err := identityService.CreateUser(ctx, credentials.domainID, name, password)


### PR DESCRIPTION
Instead of relying on a UUID, generate a (more) cryptographically secure password and crucially one that is shorter in length, thus saving a ton of noise in the Keystone logs regarding passwords being too long.