### PR TITLE
Make provider bootstrap explicit and cache-safe

### DIFF
--- a/charts/region/templates/api/clusterrole.yaml
+++ b/charts/region/templates/api/clusterrole.yaml
@@ -32,6 +32,7 @@ rules:
   - securitygrouprules
   - servers
   - filestorages
+  - sshcertificateauthorities
   verbs:
   - list
   - watch

--- a/charts/region/templates/identity-controller/clusterrole.yaml
+++ b/charts/region/templates/identity-controller/clusterrole.yaml
@@ -43,6 +43,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - get
   - list
   - watch
 - apiGroups:

--- a/charts/region/templates/network-controller/clusterrole.yaml
+++ b/charts/region/templates/network-controller/clusterrole.yaml
@@ -53,6 +53,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - get
   - list
   - watch
 - apiGroups:

--- a/charts/region/templates/security-group-controller/clusterrole.yaml
+++ b/charts/region/templates/security-group-controller/clusterrole.yaml
@@ -54,6 +54,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - get
   - list
   - watch
 - apiGroups:

--- a/charts/region/templates/server-controller/clusterrole.yaml
+++ b/charts/region/templates/server-controller/clusterrole.yaml
@@ -84,6 +84,7 @@ rules:
   resources:
   - secrets
   verbs:
+  - get
   - list
   - watch
   - create

--- a/pkg/managers/providers.go
+++ b/pkg/managers/providers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/unikorn-cloud/core/pkg/provisioners"
 	"github.com/unikorn-cloud/region/pkg/providers"
 
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -38,7 +39,14 @@ type ProvidersInit struct {
 var _ coremanager.ControllerInitializer = &ProvidersInit{}
 
 func (f *ProvidersInit) Initialize(ctx context.Context, mgr manager.Manager, opts *options.Options) error {
-	providers, err := providers.New(ctx, mgr.GetAPIReader(), mgr.GetClient(), opts.Namespace, providers.Options{})
+	// The manager cache is not started during factory initialization, so provider warm-up
+	// must use a direct client rather than the manager's cache-backed client.
+	cli, err := crclient.New(mgr.GetConfig(), crclient.Options{Scheme: mgr.GetScheme()})
+	if err != nil {
+		return err
+	}
+
+	providers, err := providers.New(ctx, cli, mgr.GetClient(), opts.Namespace, providers.Options{})
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -138,19 +138,34 @@ type Options struct {
 	WarmImageCache bool
 }
 
-func New(ctx context.Context, cli client.Client, region *unikornv1.Region, opts Options) (*Provider, error) {
-	p := &Provider{
-		client: cli,
-		openstack: &openStackClients{
-			client:  cli,
-			_region: region,
-		},
-		vlanAllocator: vlan.New(cli, region),
-	}
-
-	if err := p.openstack.serviceClientRefresh(ctx); err != nil {
+// New constructs an OpenStack provider.
+//
+// Provider construction has two phases:
+// 1. Bootstrap service-client state with initClient before any controller cache exists.
+// 2. Return a provider that retains runtimeClient for all subsequent Kubernetes reads.
+//
+// This makes the bootstrap/runtime boundary explicit: direct reads are used only while
+// building the initial OpenStack client state, and normal provider operation switches
+// back to the runtime client immediately afterwards.
+func New(ctx context.Context, initClient client.Client, runtimeClient client.Client, region *unikornv1.Region, opts Options) (*Provider, error) {
+	bootstrapState, err := bootstrapServiceClientState(ctx, initClient, region)
+	if err != nil {
 		return nil, err
 	}
+
+	p := &Provider{
+		client: runtimeClient,
+		openstack: &openStackClients{
+			client:  runtimeClient,
+			_region: region,
+		},
+		vlanAllocator: vlan.New(runtimeClient, region),
+	}
+
+	// Install the bootstrapped OpenStack client state onto the long-lived runtime wrapper.
+	// After this point, Kubernetes reads flow through runtimeClient and no bootstrap-only
+	// client is retained by the provider.
+	p.openstack.install(bootstrapState)
 
 	if opts.WarmImageCache {
 		imageCacheOptions := &cache.RefreshAheadCacheOptions{

--- a/pkg/providers/internal/openstack/serviceclients.go
+++ b/pkg/providers/internal/openstack/serviceclients.go
@@ -50,11 +50,128 @@ type openStackClients struct {
 	lock sync.Mutex
 }
 
+// serviceClientState is the fully-initialized OpenStack client state for a region.
+// It is separate from openStackClients so bootstrap can build the derived state
+// once and then install it onto the long-lived runtime wrapper.
+type serviceClientState struct {
+	region      *unikornv1.Region
+	secret      *corev1.Secret
+	credentials *providerCredentials
+	identity    *IdentityClient
+	compute     *ComputeClient
+	image       *ImageClient
+	network     NetworkingInterface
+}
+
+// bootstrapServiceClientState performs the direct Kubernetes reads needed to build
+// the initial OpenStack service clients before a controller manager cache exists.
+// This is the only place that should require uncached Kubernetes access during
+// provider construction.
+func bootstrapServiceClientState(ctx context.Context, cli client.Client, region *unikornv1.Region) (*serviceClientState, error) {
+	currentRegion := &unikornv1.Region{}
+
+	if err := cli.Get(ctx, client.ObjectKey{Namespace: region.Namespace, Name: region.Name}, currentRegion); err != nil {
+		return nil, err
+	}
+
+	secretKey := client.ObjectKey{
+		Namespace: currentRegion.Spec.Openstack.ServiceAccountSecret.Namespace,
+		Name:      currentRegion.Spec.Openstack.ServiceAccountSecret.Name,
+	}
+
+	secret := &corev1.Secret{}
+
+	if err := cli.Get(ctx, secretKey, secret); err != nil {
+		return nil, err
+	}
+
+	return newServiceClientState(ctx, currentRegion, secret)
+}
+
+// newServiceClientState constructs the OpenStack service clients from already-read
+// Kubernetes objects. Keeping this logic in one place ensures bootstrap and runtime
+// refresh build the same client state.
+func newServiceClientState(ctx context.Context, region *unikornv1.Region, secret *corev1.Secret) (*serviceClientState, error) {
+	domainID, ok := secret.Data["domain-id"]
+	if !ok {
+		return nil, fmt.Errorf("%w: domain-id", coreerrors.ErrKey)
+	}
+
+	userID, ok := secret.Data["user-id"]
+	if !ok {
+		return nil, fmt.Errorf("%w: user-id", coreerrors.ErrKey)
+	}
+
+	password, ok := secret.Data["password"]
+	if !ok {
+		return nil, fmt.Errorf("%w: password", coreerrors.ErrKey)
+	}
+
+	projectID, ok := secret.Data["project-id"]
+	if !ok {
+		return nil, fmt.Errorf("%w: project-id", coreerrors.ErrKey)
+	}
+
+	credentials := &providerCredentials{
+		endpoint:  region.Spec.Openstack.Endpoint,
+		domainID:  string(domainID),
+		projectID: string(projectID),
+		userID:    string(userID),
+		password:  string(password),
+	}
+
+	// The identity client needs to have "manager" powers, so it create projects and
+	// users within a domain without full admin.
+	identity, err := NewIdentityClient(ctx, NewDomainScopedPasswordProvider(region.Spec.Openstack.Endpoint, string(userID), string(password), string(domainID)))
+	if err != nil {
+		return nil, err
+	}
+
+	// Everything else gets a default view when bound to a project as a "member".
+	// Sadly, domain scoped accesses do not work by default any longer.
+	providerClient := NewPasswordProvider(region.Spec.Openstack.Endpoint, string(userID), string(password), string(projectID))
+
+	compute, err := NewComputeClient(ctx, providerClient, region.Spec.Openstack.Compute)
+	if err != nil {
+		return nil, err
+	}
+
+	image, err := NewImageClient(ctx, providerClient, region.Spec.Openstack.Image)
+	if err != nil {
+		return nil, err
+	}
+
+	network, err := NewNetworkClient(ctx, providerClient, region.Spec.Openstack.Network)
+	if err != nil {
+		return nil, err
+	}
+
+	return &serviceClientState{
+		region:      region,
+		secret:      secret,
+		credentials: credentials,
+		identity:    identity,
+		compute:     compute,
+		image:       image,
+		network:     network,
+	}, nil
+}
+
+// install replaces the cached service-client state on the runtime wrapper.
+// The wrapper keeps its Kubernetes client; only the derived OpenStack state is swapped.
+func (c *openStackClients) install(state *serviceClientState) {
+	c._region = state.region
+	c._secret = state.secret
+	c._credentials = state.credentials
+	c._identity = state.identity
+	c._compute = state.compute
+	c._image = state.image
+	c._network = state.network
+}
+
 // serviceClientRefresh updates clients if they need to e.g. in the event
 // of a configuration update.
 // NOTE: you MUST get the lock before calling this function.
-//
-//nolint:cyclop
 func (c *openStackClients) serviceClientRefresh(ctx context.Context) error {
 	refresh := false
 
@@ -92,71 +209,12 @@ func (c *openStackClients) serviceClientRefresh(ctx context.Context) error {
 		return nil
 	}
 
-	// Create the core credential provider.
-	domainID, ok := secret.Data["domain-id"]
-	if !ok {
-		return fmt.Errorf("%w: domain-id", coreerrors.ErrKey)
-	}
-
-	userID, ok := secret.Data["user-id"]
-	if !ok {
-		return fmt.Errorf("%w: user-id", coreerrors.ErrKey)
-	}
-
-	password, ok := secret.Data["password"]
-	if !ok {
-		return fmt.Errorf("%w: password", coreerrors.ErrKey)
-	}
-
-	projectID, ok := secret.Data["project-id"]
-	if !ok {
-		return fmt.Errorf("%w: project-id", coreerrors.ErrKey)
-	}
-
-	credentials := &providerCredentials{
-		endpoint:  region.Spec.Openstack.Endpoint,
-		domainID:  string(domainID),
-		projectID: string(projectID),
-		userID:    string(userID),
-		password:  string(password),
-	}
-
-	// The identity client needs to have "manager" powers, so it create projects and
-	// users within a domain without full admin.
-	identity, err := NewIdentityClient(ctx, NewDomainScopedPasswordProvider(region.Spec.Openstack.Endpoint, string(userID), string(password), string(domainID)))
+	state, err := newServiceClientState(ctx, region, secret)
 	if err != nil {
 		return err
 	}
 
-	// Everything else gets a default view when bound to a project as a "member".
-	// Sadly, domain scoped accesses do not work by default any longer.
-	providerClient := NewPasswordProvider(region.Spec.Openstack.Endpoint, string(userID), string(password), string(projectID))
-
-	compute, err := NewComputeClient(ctx, providerClient, region.Spec.Openstack.Compute)
-	if err != nil {
-		return err
-	}
-
-	image, err := NewImageClient(ctx, providerClient, region.Spec.Openstack.Image)
-	if err != nil {
-		return err
-	}
-
-	network, err := NewNetworkClient(ctx, providerClient, region.Spec.Openstack.Network)
-	if err != nil {
-		return err
-	}
-
-	// Save the current configuration for checking next time.
-	c._region = region
-	c._secret = secret
-	c._credentials = credentials
-
-	// Seve the clients
-	c._identity = identity
-	c._compute = compute
-	c._image = image
-	c._network = network
+	c.install(state)
 
 	return nil
 }

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -59,7 +59,6 @@ func ProviderToServerError(err error) error {
 }
 
 type providersImpl struct {
-	reader    client.Reader
 	client    client.Client
 	namespace string
 	opts      Options
@@ -73,15 +72,18 @@ type Options struct {
 	WarmImageCache bool
 }
 
-// New creates and synchronously initializes all region providers. The chosen behaviour
-// is to fail on initialization failure, the reasoning is that during upgrade an old version
-// of the service should be running to handle traffic, and we'd rather not have something
+// New creates and synchronously initializes all region providers. Startup-time region
+// discovery and provider construction use initClient so bootstrap reads can happen
+// before a controller manager cache has started, while the returned provider set retains
+// runtimeClient for normal cached operation after startup. The chosen behaviour is to
+// fail on initialization failure, the reasoning is that during upgrade an old version of
+// the service should be running to handle traffic, and we'd rather not have something
 // put into production that is known to be broken. Regions discovered after startup are
 // loaded on demand and then shared for subsequent lookups.
-func New(ctx context.Context, reader client.Reader, c client.Client, namespace string, opts Options) (Providers, error) {
+func New(ctx context.Context, initClient client.Client, runtimeClient client.Client, namespace string, opts Options) (Providers, error) {
 	var regions unikornv1.RegionList
 
-	if err := reader.List(ctx, &regions, &client.ListOptions{Namespace: namespace}); err != nil {
+	if err := initClient.List(ctx, &regions, &client.ListOptions{Namespace: namespace}); err != nil {
 		return nil, fmt.Errorf("%w: failed to list regions", err)
 	}
 
@@ -90,7 +92,7 @@ func New(ctx context.Context, reader client.Reader, c client.Client, namespace s
 	// TODO: we can avoid long warm ups in future by doing this concurrently
 	// if it becomes too slow.
 	for i := range regions.Items {
-		provider, err := newProvider(ctx, c, &regions.Items[i], opts)
+		provider, err := newProvider(ctx, initClient, runtimeClient, &regions.Items[i], opts)
 		if err != nil {
 			return nil, err
 		}
@@ -99,8 +101,7 @@ func New(ctx context.Context, reader client.Reader, c client.Client, namespace s
 	}
 
 	providers := &providersImpl{
-		reader:    reader,
-		client:    c,
+		client:    runtimeClient,
 		namespace: namespace,
 		opts:      opts,
 		cache:     cache,
@@ -109,17 +110,19 @@ func New(ctx context.Context, reader client.Reader, c client.Client, namespace s
 	return providers, nil
 }
 
-// newProvider a new Provider.
-func newProvider(ctx context.Context, client client.Client, region *unikornv1.Region, opts Options) (types.CommonProvider, error) {
+// newProvider constructs a provider for a region. initClient is used only for
+// startup-time bootstrap work that cannot rely on a started manager cache, while
+// runtimeClient is retained by the provider for normal operation afterwards.
+func newProvider(ctx context.Context, initClient client.Client, runtimeClient client.Client, region *unikornv1.Region, opts Options) (types.CommonProvider, error) {
 	switch region.Spec.Provider {
 	case unikornv1.ProviderKubernetes:
-		return kubernetes.New(ctx, client, region)
+		return kubernetes.New(ctx, runtimeClient, region)
 	case unikornv1.ProviderOpenstack:
-		return openstack.New(ctx, client, region, openstack.Options{
+		return openstack.New(ctx, initClient, runtimeClient, region, openstack.Options{
 			WarmImageCache: opts.WarmImageCache,
 		})
 	case unikornv1.ProviderSimulated:
-		return simulated.New(ctx, client, region)
+		return simulated.New(ctx, runtimeClient, region)
 	}
 
 	return nil, ErrRegionProviderUnimplemented
@@ -171,7 +174,7 @@ func (p *providersImpl) load(ctx context.Context, regionID string) (types.Common
 
 	region := &unikornv1.Region{}
 
-	if err := p.reader.Get(ctx, client.ObjectKey{Namespace: p.namespace, Name: regionID}, region); err != nil {
+	if err := p.client.Get(ctx, client.ObjectKey{Namespace: p.namespace, Name: regionID}, region); err != nil {
 		if client.IgnoreNotFound(err) == nil {
 			return nil, ErrRegionNotFound
 		}
@@ -179,7 +182,7 @@ func (p *providersImpl) load(ctx context.Context, regionID string) (types.Common
 		return nil, fmt.Errorf("%w: failed to get region", err)
 	}
 
-	provider, err := newProvider(ctx, p.client, region, p.opts)
+	provider, err := newProvider(ctx, p.client, p.client, region, p.opts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/providers_test.go
+++ b/pkg/providers/providers_test.go
@@ -55,15 +55,14 @@ func TestLookupCommonLoadsRegionOnMiss(t *testing.T) {
 		},
 	}
 
-	reader := fake.NewClientBuilder().WithScheme(scheme).Build()
 	runtimeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	providerSet, err := providers.New(ctx, reader, runtimeClient, namespace, providers.Options{})
+	providerSet, err := providers.New(ctx, runtimeClient, runtimeClient, namespace, providers.Options{})
 	if err != nil {
 		t.Fatalf("creating providers: %v", err)
 	}
 
-	if err := reader.Create(ctx, region); err != nil {
+	if err := runtimeClient.Create(ctx, region); err != nil {
 		t.Fatalf("creating region after startup: %v", err)
 	}
 
@@ -71,7 +70,7 @@ func TestLookupCommonLoadsRegionOnMiss(t *testing.T) {
 		t.Fatalf("lookup on miss: %v", err)
 	}
 
-	if err := reader.Delete(ctx, region); err != nil {
+	if err := runtimeClient.Delete(ctx, region); err != nil {
 		t.Fatalf("deleting region after lazy load: %v", err)
 	}
 


### PR DESCRIPTION
Adding ControllerInitializer to the controller startup path exposed a latent assumption in region provider construction: ProvidersInit.Initialize was calling providers.New before manager.Start, but providers.New eagerly constructs providers for every Region and the OpenStack provider constructor immediately performs Kubernetes Get calls while refreshing its service clients. With mgr.GetClient() in that path, controller startup failed with 'the cache is not started, can not read objects' because the manager cache does not exist yet at factory initialization time.

The first pass at fixing that swapped in a direct uncached client too broadly. That removed the startup cache failure, but it also changed long-lived provider objects to use uncached reads during normal controller operation. In practice that surfaced as the identity controller attempting direct API-server gets for OpenstackIdentity resources, which changed the RBAC requirements and was not the intended design.

This change makes the startup/runtime split explicit:
- providers.New now accepts an init client and a runtime client
- startup region discovery and provider bootstrap use the init client before any controller cache exists
- returned providers retain the runtime client for normal cached operation after startup
- the OpenStack provider now bootstraps a named service-client state and installs it onto the long-lived runtime wrapper, making the handoff from direct reads to cached reads obvious in code

The controller ClusterRoles keep the matching secrets/get RBAC change because OpenStack bootstrap still performs real Secret Get calls during initialization.

This PR also keeps the existing API ClusterRole change from the worktree, adding sshcertificateauthorities to the list/watch rule.

Verification:
- make test-unit: passed
- make lint: blocked only by existing go.mod local replace directives for ../core and ../identity