### PR TITLE
Regenerate CRDs

### DIFF
--- a/charts/region/crds/region.unikorn-cloud.org_servers.yaml
+++ b/charts/region/crds/region.unikorn-cloud.org_servers.yaml
@@ -125,6 +125,10 @@ spec:
                   - id
                   type: object
                 type: array
+              sshCertificateAuthorityID:
+                description: SSHCertificateAuthorityID is an optional project scoped
+                  OpenSSH user CA trust anchor.
+                type: string
               tags:
                 description: |-
                   Tags are an abitrary list of key/value pairs that a client


### PR DESCRIPTION
The robots seem to have lost the CRD update that enables SSH CA functionality.  Coupled with the fact that the CI jobs didn't spot it either.  This essentially adds in the SSH CA field to server CRD.