### PR TITLE
First go at plan-changes skill

### DIFF
--- a/.claude/skills/plan-changes/SKILL.md
+++ b/.claude/skills/plan-changes/SKILL.md
@@ -4,7 +4,7 @@ description:
 ---
 
 When starting an implementation from a design, before making edits,
-first work out with the user a series of changes to achieve the
+first work out with the user a series of commits to achieve the
 design.
 
 **Plan as commits**
@@ -16,14 +16,29 @@ specify each diff exactly, just the series of steps.
 Each commit should make a single logical change. For example, a
 refactor, or the addition of interrelated API definitions.
 
-It may be necessary to refactor a package or introduce an abstraction,
-to make a later change possible. Prefer refactoring to adding
-abstractions.
+**Generated code**
+
+Changes to generated code should go in the commit that provoked the
+regeneration. A common example is
+pkg/openapi/router.go, generated from server.spec.yaml in the same
+directory.
+
+To make the code compile after regenerating code, it may
+be necessary to fill in stubs.
+
+**Ordering the changes**
+
+Think about which steps depend on which others. It may be necessary to
+refactor a package or introduce an abstraction, to make a later change
+possible. Prefer refactoring to adding abstractions.
 
 A commit should come with proof that it works, or at least a
-justification. This will often be a test. The plan should include an
-outline of how to test each change. Refactors may need additional
-tests to prove they have not changed behaviour.
+justification. This will often be a test. With each step the plan
+should include an outline of how to test the change made in the
+commit.
+
+Refactors may need additional tests to prove they have not changed
+behaviour. You should think about what it is necessary to demonstrate.
 
 The code should compile and pass tests after each commit. Strive to
 make each commit safe to merge to main branch on its own. This may not

--- a/.claude/skills/plan-changes/SKILL.md
+++ b/.claude/skills/plan-changes/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: plan changes
+description: 
+---
+
+When starting an implementation from a design, before making edits,
+first work out with the user a series of changes to achieve the
+design.
+
+**Plan as commits**
+
+The plan consists of a series of commits that are self-contained, and
+when all applied, implement the design. The plan does not have to
+specify each diff exactly, just the series of steps.
+
+Each commit should make a single logical change. For example, a
+refactor, or the addition of interrelated API definitions.
+
+It may be necessary to refactor a package or introduce an abstraction,
+to make a later change possible. Prefer refactoring to adding
+abstractions.
+
+A commit should come with proof that it works, or at least a
+justification. This will often be a test. The plan should include an
+outline of how to test each change. Refactors may need additional
+tests to prove they have not changed behaviour.
+
+The code should compile and pass tests after each commit. Strive to
+make each commit safe to merge to main branch on its own. This may not
+always be possible: when not, explain why not and work on mitigations
+with the user.
+
+**Backward-compatibility**
+
+Most changes should be backward-compatible. In practice this may mean
+introducing new API or struct fields alongside old ones, and
+converting between them. Migrations generally go like this:
+
+1. Introduce a new field or API surface, and convert between it and
+   the old one
+2. Port callers to the new API or field
+3. Deprecate the old API


### PR DESCRIPTION
This is me free-styling more or less. The points I wanted to get through to the machine are:

 - each commit should stand alone, including proof that it works

 - front-load refactoring when needed ("make the change easy; then make the easy change")

I think the sensible entry point for the skill is when you have a design already. If you're not starting with a design, it's hard to plan because you don't have a well-defined end point. It's fine to do exploratory work first (maybe that's another skill ...), then come back to this skill with the resulting design.