### PR TITLE
feat: migrate region auth wiring to passport

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"time"
 
 	chi "github.com/go-chi/chi/v5"
 	"github.com/spf13/pflag"
@@ -77,7 +78,7 @@ type Server struct {
 	newIdentityHTTPClient func(cli client.Client, identityOptions *identityclient.Options, clientOptions *coreclient.HTTPClientOptions) (*http.Client, error)
 
 	// newAuthorizer allows passport authorizer construction to be overridden in tests.
-	newAuthorizer func(httpClient *http.Client, identityHost string, uniAuthorizer openapimiddleware.Authorizer) (openapimiddleware.Authorizer, error)
+	newAuthorizer func(verifier *openapimiddlewarepassport.Verifier, uniAuthorizer openapimiddleware.Authorizer, tokenExchange openapimiddlewarepassport.TokenExchange) (openapimiddleware.Authorizer, error)
 }
 
 func (s *Server) AddFlags(flags *pflag.FlagSet) {
@@ -105,6 +106,8 @@ func (s *Server) SetupOpenTelemetry(ctx context.Context) error {
 	return s.CoreOptions.SetupOpenTelemetry(ctx)
 }
 
+// authorizer builds the API authorizer by composing passport middleware around
+// the existing remote uni authorizer.
 func (s *Server) authorizer(kubeClient client.Client) (openapimiddleware.Authorizer, error) {
 	newUniAuthorizer := s.newUniAuthorizer
 	if newUniAuthorizer == nil {
@@ -130,14 +133,26 @@ func (s *Server) authorizer(kubeClient client.Client) (openapimiddleware.Authori
 		return nil, fmt.Errorf("failed to initialize identity HTTP client: %w", err)
 	}
 
+	var (
+		identityHost     = s.IdentityOptions.Host()
+		jwksURL          = openapimiddlewarepassport.JWKSURL(identityHost)
+		tokenExchangeURL = openapimiddlewarepassport.TokenExchangeURL(identityHost)
+		keySource        = openapimiddlewarepassport.NewCachedHTTPKeySource(httpClient, jwksURL, time.Minute)
+		verifier         = openapimiddlewarepassport.NewVerifier(keySource)
+		tokenExchange    = openapimiddlewarepassport.NewHTTPTokenExchange(httpClient, tokenExchangeURL)
+	)
+
 	newAuthorizer := s.newAuthorizer
 	if newAuthorizer == nil {
-		newAuthorizer = func(httpClient *http.Client, identityHost string, uniAuthorizer openapimiddleware.Authorizer) (openapimiddleware.Authorizer, error) {
-			return openapimiddlewarepassport.NewAuthorizer(httpClient, identityHost, uniAuthorizer, nil)
+		newAuthorizer = func(verifier *openapimiddlewarepassport.Verifier, uniAuthorizer openapimiddleware.Authorizer, tokenExchange openapimiddlewarepassport.TokenExchange) (openapimiddleware.Authorizer, error) {
+			// Passport handles passport verification/token exchange and uses the
+			// uni authorizer for ACL lookups and fallback authorization when
+			// exchange is unavailable for non-passport tokens.
+			return openapimiddlewarepassport.NewAuthorizer(verifier, uniAuthorizer, tokenExchange)
 		}
 	}
 
-	authorizer, err := newAuthorizer(httpClient, s.IdentityOptions.Host(), uniAuthorizer)
+	authorizer, err := newAuthorizer(verifier, uniAuthorizer, tokenExchange)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize passport authorizer: %w", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,6 +37,7 @@ import (
 	identityclient "github.com/unikorn-cloud/identity/pkg/client"
 	"github.com/unikorn-cloud/identity/pkg/middleware/audit"
 	openapimiddleware "github.com/unikorn-cloud/identity/pkg/middleware/openapi"
+	openapimiddlewarepassport "github.com/unikorn-cloud/identity/pkg/middleware/openapi/passport"
 	openapimiddlewareremote "github.com/unikorn-cloud/identity/pkg/middleware/openapi/remote"
 	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/handler"
@@ -68,6 +69,15 @@ type Server struct {
 
 	// OpenAPIOptions are for OpenAPI processing.
 	OpenAPIOptions openapimiddleware.Options
+
+	// newUniAuthorizer allows base authorizer construction to be overridden in tests.
+	newUniAuthorizer func(cli client.Client, identityOptions *identityclient.Options, clientOptions *coreclient.HTTPClientOptions) (openapimiddleware.Authorizer, error)
+
+	// newIdentityHTTPClient allows HTTP client construction to be overridden in tests.
+	newIdentityHTTPClient func(cli client.Client, identityOptions *identityclient.Options, clientOptions *coreclient.HTTPClientOptions) (*http.Client, error)
+
+	// newAuthorizer allows passport authorizer construction to be overridden in tests.
+	newAuthorizer func(httpClient *http.Client, identityHost string, uniAuthorizer openapimiddleware.Authorizer) (openapimiddleware.Authorizer, error)
 }
 
 func (s *Server) AddFlags(flags *pflag.FlagSet) {
@@ -93,6 +103,46 @@ func (s *Server) SetupLogging() {
 // TODO: move config into an otel specific options struct.
 func (s *Server) SetupOpenTelemetry(ctx context.Context) error {
 	return s.CoreOptions.SetupOpenTelemetry(ctx)
+}
+
+func (s *Server) authorizer(kubeClient client.Client) (openapimiddleware.Authorizer, error) {
+	newUniAuthorizer := s.newUniAuthorizer
+	if newUniAuthorizer == nil {
+		newUniAuthorizer = func(kubeClient client.Client, identityOptions *identityclient.Options, httpClientOptions *coreclient.HTTPClientOptions) (openapimiddleware.Authorizer, error) {
+			return openapimiddlewareremote.NewAuthorizer(kubeClient, identityOptions, httpClientOptions)
+		}
+	}
+
+	uniAuthorizer, err := newUniAuthorizer(kubeClient, s.IdentityOptions, &s.ClientOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize uni authorizer: %w", err)
+	}
+
+	newIdentityHTTPClient := s.newIdentityHTTPClient
+	if newIdentityHTTPClient == nil {
+		newIdentityHTTPClient = func(kubeClient client.Client, identityOptions *identityclient.Options, httpClientOptions *coreclient.HTTPClientOptions) (*http.Client, error) {
+			return identityclient.New(kubeClient, identityOptions, httpClientOptions).HTTPClient(context.Background())
+		}
+	}
+
+	httpClient, err := newIdentityHTTPClient(kubeClient, s.IdentityOptions, &s.ClientOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize identity HTTP client: %w", err)
+	}
+
+	newAuthorizer := s.newAuthorizer
+	if newAuthorizer == nil {
+		newAuthorizer = func(httpClient *http.Client, identityHost string, uniAuthorizer openapimiddleware.Authorizer) (openapimiddleware.Authorizer, error) {
+			return openapimiddlewarepassport.NewAuthorizer(httpClient, identityHost, uniAuthorizer, nil)
+		}
+	}
+
+	authorizer, err := newAuthorizer(httpClient, s.IdentityOptions.Host(), uniAuthorizer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize passport authorizer: %w", err)
+	}
+
+	return authorizer, nil
 }
 
 func (s *Server) GetServer(ctx context.Context, client client.Client) (*http.Server, error) {
@@ -144,7 +194,7 @@ func (s *Server) GetServer(ctx context.Context, client client.Client) (*http.Ser
 	router.NotFound(http.HandlerFunc(handler.NotFound))
 	router.MethodNotAllowed(http.HandlerFunc(handler.MethodNotAllowed))
 
-	authorizer, err := openapimiddlewareremote.NewAuthorizer(client, s.IdentityOptions, &s.ClientOptions)
+	authorizer, err := s.authorizer(client)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:testpackage
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	coreclient "github.com/unikorn-cloud/core/pkg/client"
+	identityclient "github.com/unikorn-cloud/identity/pkg/client"
+	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
+	openapimiddleware "github.com/unikorn-cloud/identity/pkg/middleware/openapi"
+	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	errTestUniAuthorizer = errors.New("uni authorizer error")
+	errTestHTTPClient    = errors.New("http client error")
+	errTestAuthorizer    = errors.New("passport authorizer error")
+)
+
+type stubAuthorizer struct{}
+
+func (a *stubAuthorizer) Authorize(_ *openapi3filter.AuthenticationInput) (*authorization.Info, error) {
+	return &authorization.Info{}, nil
+}
+
+func (a *stubAuthorizer) GetACL(_ context.Context, _ string) (*identityopenapi.Acl, error) {
+	return &identityopenapi.Acl{}, nil
+}
+
+func TestServer_Authorizer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses configured constructor", func(t *testing.T) {
+		t.Parallel()
+
+		server := &Server{
+			IdentityOptions: identityclient.NewOptions(),
+		}
+
+		var (
+			calledUniAuthorizer bool
+			calledHTTPClient    bool
+			calledAuthorizer    bool
+			httpClient          = &http.Client{}
+			uniAuthorizer       = &stubAuthorizer{}
+			stub                = &stubAuthorizer{}
+		)
+
+		server.newUniAuthorizer = func(kubeClient client.Client, identityOptions *identityclient.Options, httpClientOptions *coreclient.HTTPClientOptions) (openapimiddleware.Authorizer, error) {
+			calledUniAuthorizer = true
+
+			assert.Nil(t, kubeClient)
+			assert.Same(t, server.IdentityOptions, identityOptions)
+			assert.Same(t, &server.ClientOptions, httpClientOptions)
+
+			return uniAuthorizer, nil
+		}
+
+		server.newIdentityHTTPClient = func(kubeClient client.Client, identityOptions *identityclient.Options, httpClientOptions *coreclient.HTTPClientOptions) (*http.Client, error) {
+			calledHTTPClient = true
+
+			assert.Nil(t, kubeClient)
+			assert.Same(t, server.IdentityOptions, identityOptions)
+			assert.Same(t, &server.ClientOptions, httpClientOptions)
+
+			return httpClient, nil
+		}
+
+		server.newAuthorizer = func(httpClientArg *http.Client, identityHost string, uniAuthorizerArg openapimiddleware.Authorizer) (openapimiddleware.Authorizer, error) {
+			calledAuthorizer = true
+
+			assert.Same(t, httpClient, httpClientArg)
+			assert.Equal(t, server.IdentityOptions.Host(), identityHost)
+			assert.Same(t, uniAuthorizer, uniAuthorizerArg)
+
+			return stub, nil
+		}
+
+		authorizer, err := server.authorizer(nil)
+		require.NoError(t, err)
+		assert.True(t, calledUniAuthorizer)
+		assert.True(t, calledHTTPClient)
+		assert.True(t, calledAuthorizer)
+		assert.Same(t, stub, authorizer)
+	})
+
+	t.Run("wraps uni authorizer errors", func(t *testing.T) {
+		t.Parallel()
+
+		s := &Server{
+			IdentityOptions: identityclient.NewOptions(),
+		}
+
+		s.newUniAuthorizer = func(_ client.Client, _ *identityclient.Options, _ *coreclient.HTTPClientOptions) (openapimiddleware.Authorizer, error) {
+			return nil, errTestUniAuthorizer
+		}
+
+		_, err := s.authorizer(nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errTestUniAuthorizer)
+		assert.Contains(t, err.Error(), "failed to initialize uni authorizer")
+	})
+
+	t.Run("wraps HTTP client errors", func(t *testing.T) {
+		t.Parallel()
+
+		s := &Server{
+			IdentityOptions: identityclient.NewOptions(),
+		}
+
+		s.newUniAuthorizer = func(_ client.Client, _ *identityclient.Options, _ *coreclient.HTTPClientOptions) (openapimiddleware.Authorizer, error) {
+			return &stubAuthorizer{}, nil
+		}
+
+		s.newIdentityHTTPClient = func(_ client.Client, _ *identityclient.Options, _ *coreclient.HTTPClientOptions) (*http.Client, error) {
+			return nil, errTestHTTPClient
+		}
+
+		_, err := s.authorizer(nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errTestHTTPClient)
+		assert.Contains(t, err.Error(), "failed to initialize identity HTTP client")
+	})
+
+	t.Run("wraps passport authorizer errors", func(t *testing.T) {
+		t.Parallel()
+
+		s := &Server{
+			IdentityOptions: identityclient.NewOptions(),
+		}
+
+		s.newUniAuthorizer = func(_ client.Client, _ *identityclient.Options, _ *coreclient.HTTPClientOptions) (openapimiddleware.Authorizer, error) {
+			return &stubAuthorizer{}, nil
+		}
+
+		s.newIdentityHTTPClient = func(_ client.Client, _ *identityclient.Options, _ *coreclient.HTTPClientOptions) (*http.Client, error) {
+			return &http.Client{}, nil
+		}
+
+		s.newAuthorizer = func(_ *http.Client, _ string, _ openapimiddleware.Authorizer) (openapimiddleware.Authorizer, error) {
+			return nil, errTestAuthorizer
+		}
+
+		_, err := s.authorizer(nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errTestAuthorizer)
+		assert.Contains(t, err.Error(), "failed to initialize passport authorizer")
+	})
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -31,6 +31,7 @@ import (
 	identityclient "github.com/unikorn-cloud/identity/pkg/client"
 	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
 	openapimiddleware "github.com/unikorn-cloud/identity/pkg/middleware/openapi"
+	openapimiddlewarepassport "github.com/unikorn-cloud/identity/pkg/middleware/openapi/passport"
 	identityopenapi "github.com/unikorn-cloud/identity/pkg/openapi"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,12 +92,12 @@ func TestServer_Authorizer(t *testing.T) {
 			return httpClient, nil
 		}
 
-		server.newAuthorizer = func(httpClientArg *http.Client, identityHost string, uniAuthorizerArg openapimiddleware.Authorizer) (openapimiddleware.Authorizer, error) {
+		server.newAuthorizer = func(verifierArg *openapimiddlewarepassport.Verifier, uniAuthorizerArg openapimiddleware.Authorizer, tokenExchangeArg openapimiddlewarepassport.TokenExchange) (openapimiddleware.Authorizer, error) {
 			calledAuthorizer = true
 
-			assert.Same(t, httpClient, httpClientArg)
-			assert.Equal(t, server.IdentityOptions.Host(), identityHost)
+			assert.NotNil(t, verifierArg)
 			assert.Same(t, uniAuthorizer, uniAuthorizerArg)
+			assert.NotNil(t, tokenExchangeArg)
 
 			return stub, nil
 		}
@@ -162,7 +163,7 @@ func TestServer_Authorizer(t *testing.T) {
 			return &http.Client{}, nil
 		}
 
-		s.newAuthorizer = func(_ *http.Client, _ string, _ openapimiddleware.Authorizer) (openapimiddleware.Authorizer, error) {
+		s.newAuthorizer = func(_ *openapimiddlewarepassport.Verifier, _ openapimiddleware.Authorizer, _ openapimiddlewarepassport.TokenExchange) (openapimiddleware.Authorizer, error) {
 			return nil, errTestAuthorizer
 		}
 


### PR DESCRIPTION
## Description

This PR updates `uni-region` API auth wiring to use passport middleware, and adds focused unit tests in `pkg/server/server_test.go` to verify constructor wiring and wrapped initialization errors. 