### PR TITLE
fix(openstack): return 404 when image not found in cache

### DIFF
--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -679,6 +679,10 @@ func (p *Provider) GetImage(ctx context.Context, organizationID, imageID string)
 
 	image, err := p.imageCache.Get(imageID)
 	if err != nil {
+		if errors.Is(err, cache.ErrNotFound) {
+			return nil, fmt.Errorf("%w: image %s", coreerrors.ErrResourceNotFound, imageID)
+		}
+
 		return nil, err
 	}
 

--- a/test/api/suites/images_test.go
+++ b/test/api/suites/images_test.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	invalidUUID           = "invalid-uuid"
+	nonExistentImageID    = "00000000-0000-0000-0000-000000000000"
 	ubuntuNobleAMD64Image = "https://s3.glo1.nscale.com/os-images/noble-server-cloudimg-amd64.raw"
 )
 
@@ -62,6 +63,15 @@ var _ = Describe("Image Management", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(images).NotTo(BeEmpty())
 				GinkgoWriter.Printf("Found %d images for region %s\n", len(images), config.RegionID)
+			})
+		})
+	})
+
+	Context("When deleting an image", func() {
+		Describe("Given an image ID that does not exist in the cache", func() {
+			It("should return not found", func() {
+				err := regionClient.DeleteImage(ctx, config.OrgID, config.RegionID, nonExistentImageID)
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

- DELETE `/images/{imageID}` was returning a 500 instead of a 404 when the image ID was not found in the cache
- `openstack.Provider.GetImage` was returning the raw `cache.ErrNotFound` unwrapped, causing the handler's `errors.Is(err, coreerrors.ErrResourceNotFound)` check to miss
- Wrap `cache.ErrNotFound` as `coreerrors.ErrResourceNotFound` before returning

## Test plan

- [x] Added integration test passes

Closes INST-843