### PR TITLE
Add load balancer controller scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ CONTROLLERS = \
   unikorn-identity-controller \
   unikorn-network-controller \
   unikorn-security-group-controller \
+  unikorn-load-balancer-controller \
   unikorn-server-controller \
   unikorn-region-monitor
 

--- a/charts/region/templates/_helpers.tpl
+++ b/charts/region/templates/_helpers.tpl
@@ -29,6 +29,10 @@ v{{ .Chart.Version }}
 {{- .Values.securityGroupController.image | default (printf "%s/unikorn-security-group-controller:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default (include "unikorn.defaultTag" .))) }}
 {{- end }}
 
+{{- define "unikorn.loadBalancerControllerImage" -}}
+{{- .Values.loadBalancerController.image | default (printf "%s/unikorn-load-balancer-controller:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default (include "unikorn.defaultTag" .))) }}
+{{- end }}
+
 {{- define "unikorn.securityGroupRuleControllerImage" -}}
 {{- .Values.securityGroupRuleController.image | default (printf "%s/unikorn-security-group-rule-controller:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default (include "unikorn.defaultTag" .))) }}
 {{- end }}

--- a/charts/region/templates/load-balancer-controller/clusterrole.yaml
+++ b/charts/region/templates/load-balancer-controller/clusterrole.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-load-balancer-controller
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+rules:
+# Orchestrate Unikorn resources (my job).
+- apiGroups:
+  - region.unikorn-cloud.org
+  resources:
+  - identities
+  - openstackidentities
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - region.unikorn-cloud.org
+  resources:
+  - loadbalancers
+  verbs:
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - region.unikorn-cloud.org
+  resources:
+  - loadbalancers/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - region.unikorn-cloud.org
+  resources:
+  - regions
+  verbs:
+  - list
+  - watch
+  - get

--- a/charts/region/templates/load-balancer-controller/clusterrolebinding.yaml
+++ b/charts/region/templates/load-balancer-controller/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-load-balancer-controller
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-load-balancer-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-load-balancer-controller

--- a/charts/region/templates/load-balancer-controller/deployment.yaml
+++ b/charts/region/templates/load-balancer-controller/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-load-balancer-controller
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-load-balancer-controller
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-load-balancer-controller
+    spec:
+      containers:
+      - name: {{ .Release.Name }}-load-balancer-controller
+        image: {{ include "unikorn.loadBalancerControllerImage" . }}
+        args:
+        {{- include "unikorn.core.flags" . | nindent 8 }}
+        {{- include "unikorn.otlp.flags" . | nindent 8 }}
+        {{- include "unikorn.identity.flags" . | nindent 8 }}
+        {{- include "unikorn.mtls.flags" . | nindent 8 }}
+        ports:
+        - name: http
+          containerPort: 6080
+        - name: prometheus
+          containerPort: 8080
+        - name: pprof
+          containerPort: 6060
+        resources:
+          {{- .Values.loadBalancerController.resources | toYaml | nindent 10 }}
+        securityContext:
+          readOnlyRootFilesystem: true
+      serviceAccountName: {{ .Release.Name }}-load-balancer-controller
+      securityContext:
+        runAsNonRoot: true

--- a/charts/region/templates/load-balancer-controller/role.yaml
+++ b/charts/region/templates/load-balancer-controller/role.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-load-balancer-controller
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+rules:
+# Controller prerequisites.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update

--- a/charts/region/templates/load-balancer-controller/rolebinding.yaml
+++ b/charts/region/templates/load-balancer-controller/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-load-balancer-controller
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-load-balancer-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-load-balancer-controller

--- a/charts/region/templates/load-balancer-controller/serviceaccount.yaml
+++ b/charts/region/templates/load-balancer-controller/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-load-balancer-controller
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+{{- with ( include "unikorn.imagePullSecrets" . ) }}
+imagePullSecrets:
+{{ . }}
+{{- end }}

--- a/charts/region/values.schema.json
+++ b/charts/region/values.schema.json
@@ -80,20 +80,6 @@
     "image": {
       "type": "string"
     },
-    "loadBalancerController": {
-      "type": "object",
-      "properties": {
-        "image": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "resources": {
-          "type": "object"
-        }
-      }
-    },
     "region": {
       "type": "object",
       "required": [

--- a/charts/region/values.schema.json
+++ b/charts/region/values.schema.json
@@ -80,6 +80,20 @@
     "image": {
       "type": "string"
     },
+    "loadBalancerController": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resources": {
+          "type": "object"
+        }
+      }
+    },
     "region": {
       "type": "object",
       "required": [

--- a/charts/region/values.yaml
+++ b/charts/region/values.yaml
@@ -176,6 +176,15 @@ serverController:
       cpu: 100m
       memory: 100Mi
 
+loadBalancerController:
+  # Allow override of the controller image.
+  image: ~
+  # Allows resource limits to be set.
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+
 # Sets the DNS hosts/X.509 Certs.
 region:
   host: region.unikorn-cloud.org

--- a/cmd/unikorn-load-balancer-controller/main.go
+++ b/cmd/unikorn-load-balancer-controller/main.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/unikorn-cloud/core/pkg/manager"
+	loadbalancer "github.com/unikorn-cloud/region/pkg/managers/load-balancer"
+)
+
+func main() {
+	manager.Run(&loadbalancer.Factory{})
+}

--- a/docker/unikorn-load-balancer-controller/.dockerignore
+++ b/docker/unikorn-load-balancer-controller/.dockerignore
@@ -1,0 +1,2 @@
+*
+!bin/*-linux-gnu/unikorn-load-balancer-controller

--- a/docker/unikorn-load-balancer-controller/Dockerfile
+++ b/docker/unikorn-load-balancer-controller/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcr.io/distroless/static:nonroot
+
+# This is implcitly created by 'docker buildx build'
+ARG TARGETARCH
+
+COPY bin/${TARGETARCH}-linux-gnu/unikorn-load-balancer-controller /
+
+ENTRYPOINT ["/unikorn-load-balancer-controller"]

--- a/pkg/managers/load-balancer/manager.go
+++ b/pkg/managers/load-balancer/manager.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalancer
+
+import (
+	coreclient "github.com/unikorn-cloud/core/pkg/client"
+	coremanager "github.com/unikorn-cloud/core/pkg/manager"
+	"github.com/unikorn-cloud/core/pkg/manager/options"
+	"github.com/unikorn-cloud/core/pkg/util"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/managers"
+	loadbalancer "github.com/unikorn-cloud/region/pkg/provisioners/managers/load-balancer"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Factory provides methods that can build a type specific controller.
+type Factory struct {
+	managers.ProvidersInit
+}
+
+var _ interface {
+	coremanager.ControllerFactory
+	coremanager.ControllerInitializer
+} = &Factory{}
+
+// Metadata returns the application, version and revision.
+func (*Factory) Metadata() util.ServiceDescriptor {
+	return constants.ServiceDescriptor()
+}
+
+// Options returns any options to be added to the CLI flags and passed to the reconciler.
+func (*Factory) Options() coremanager.ControllerOptions {
+	return &loadbalancer.Options{}
+}
+
+// Reconciler returns a new reconciler instance.
+func (f *Factory) Reconciler(options *options.Options, controllerOptions coremanager.ControllerOptions, manager manager.Manager) reconcile.Reconciler {
+	return coremanager.NewReconciler(options, controllerOptions, manager, f.ProvisionerCreate(loadbalancer.New))
+}
+
+// RegisterWatches adds any watches that would trigger a reconcile.
+func (*Factory) RegisterWatches(manager manager.Manager, controller controller.Controller) error {
+	// Any changes to the load balancer spec, trigger a reconcile.
+	if err := controller.Watch(source.Kind(manager.GetCache(), &unikornv1.LoadBalancer{}, &handler.TypedEnqueueRequestForObject[*unikornv1.LoadBalancer]{}, &predicate.TypedGenerationChangedPredicate[*unikornv1.LoadBalancer]{})); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Schemes allows controllers to add types to the client beyond
+// the defaults defined in this repository.
+func (*Factory) Schemes() []coreclient.SchemeAdder {
+	return []coreclient.SchemeAdder{
+		unikornv1.AddToScheme,
+	}
+}

--- a/pkg/provisioners/managers/load-balancer/provisioner.go
+++ b/pkg/provisioners/managers/load-balancer/provisioner.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalancer
+
+import (
+	"context"
+
+	"github.com/spf13/pflag"
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	coreclient "github.com/unikorn-cloud/core/pkg/client"
+	"github.com/unikorn-cloud/core/pkg/manager"
+	"github.com/unikorn-cloud/core/pkg/provisioners"
+	identityclient "github.com/unikorn-cloud/identity/pkg/client"
+	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/providers"
+	"github.com/unikorn-cloud/region/pkg/provisioners/internal/base"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Options allows access to CLI options in the provisioner.
+type Options struct {
+	// identityOptions allow the identity host and CA to be set.
+	identityOptions *identityclient.Options
+	// clientOptions give access to client certificate information for controller-to-API calls.
+	clientOptions coreclient.HTTPClientOptions
+}
+
+func (o *Options) AddFlags(f *pflag.FlagSet) {
+	if o.identityOptions == nil {
+		o.identityOptions = identityclient.NewOptions()
+	}
+
+	o.identityOptions.AddFlags(f)
+	o.clientOptions.AddFlags(f)
+}
+
+// Provisioner encapsulates control plane provisioning.
+type Provisioner struct {
+	provisioners.Metadata
+	// loadbalancer is the load balancer we're provisioning.
+	loadbalancer *unikornv1.LoadBalancer
+	// options are documented for the type.
+	options *Options
+
+	// Base gives this type methods for getting identities and providers.
+	base.Base
+}
+
+// New returns a new initialized provisioner object.
+func New(options manager.ControllerOptions, providers providers.Providers) provisioners.ManagerProvisioner {
+	o, _ := options.(*Options)
+
+	return &Provisioner{
+		loadbalancer: &unikornv1.LoadBalancer{},
+		options:      o,
+		Base: base.Base{
+			Providers: providers,
+		},
+	}
+}
+
+// Ensure the ManagerProvisioner interface is implemented.
+var _ provisioners.ManagerProvisioner = &Provisioner{}
+
+func (p *Provisioner) Object() unikornv1core.ManagableResourceInterface {
+	return p.loadbalancer
+}
+
+func (p *Provisioner) identityClient(ctx context.Context) (identityapi.ClientWithResponsesInterface, error) {
+	client, err := coreclient.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return identityclient.New(client, p.options.identityOptions, &p.options.clientOptions).ControllerClient(ctx, p.loadbalancer)
+}
+
+// Provision implements the Provision interface.
+func (p *Provisioner) Provision(ctx context.Context) error {
+	log.FromContext(ctx).Info("load balancer provision (scaffold, no-op)", "name", p.loadbalancer.Name, "namespace", p.loadbalancer.Namespace)
+
+	return provisioners.ErrYield
+}
+
+// Deprovision implements the Provision interface.
+func (p *Provisioner) Deprovision(ctx context.Context) error {
+	log.FromContext(ctx).Info("load balancer deprovision", "name", p.loadbalancer.Name, "namespace", p.loadbalancer.Namespace)
+
+	return nil
+}

--- a/pkg/provisioners/managers/load-balancer/provisioner.go
+++ b/pkg/provisioners/managers/load-balancer/provisioner.go
@@ -100,7 +100,21 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 // Deprovision implements the Provision interface.
 func (p *Provisioner) Deprovision(ctx context.Context) error {
-	log.FromContext(ctx).Info("load balancer deprovision", "name", p.loadbalancer.Name, "namespace", p.loadbalancer.Namespace)
+	log.FromContext(ctx).Info("load balancer deprovision (release quota allocation)", "name", p.loadbalancer.Name, "namespace", p.loadbalancer.Namespace)
+
+	cli, err := coreclient.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	api, err := p.identityClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := identityclient.NewAllocations(cli, api).Delete(ctx, p.loadbalancer); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/provisioners/managers/load-balancer/provisioner.go
+++ b/pkg/provisioners/managers/load-balancer/provisioner.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/spf13/pflag"
+
 	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
 	"github.com/unikorn-cloud/core/pkg/manager"


### PR DESCRIPTION
## Summary

Introduces a skeleton controller for the v2 `LoadBalancer` CRD:

- New `unikorn-load-balancer-controller` binary, factory, and stub provisioner (`Provision` yields; no provider wiring yet).
- Helm chart deployment with service account and RBAC (role, rolebinding, clusterrole, clusterrolebinding) mirroring the network controller.
- `Deprovision` releases the identity quota allocation created by the API handler saga, closing the quota leak for deleted load balancers.

## Test plan

- [ ] `make validate lint generate test-unit`
- [ ] `helm template charts/region ...` renders the new load-balancer-controller resources
- [ ] Existing `test/api/suites/loadbalancers_test.go` integration suite passes