### PR TITLE
Add provider-layer load balancer interface

### DIFF
--- a/pkg/providers/internal/openstack/loadbalancer.go
+++ b/pkg/providers/internal/openstack/loadbalancer.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"context"
+	"errors"
+
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+)
+
+var errLoadBalancerUnsupported = errors.New("load balancer provider support not implemented")
+
+func (p *Provider) CreateLoadBalancer(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.LoadBalancer) error {
+	return errLoadBalancerUnsupported
+}
+
+func (p *Provider) DeleteLoadBalancer(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.LoadBalancer) error {
+	return errLoadBalancerUnsupported
+}

--- a/pkg/providers/internal/simulated/provider.go
+++ b/pkg/providers/internal/simulated/provider.go
@@ -31,6 +31,7 @@ import (
 	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
 	"github.com/unikorn-cloud/core/pkg/util/cache"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -333,6 +334,105 @@ func (p *Provider) CreateSecurityGroup(_ context.Context, _ *unikornv1.Identity,
 
 func (p *Provider) DeleteSecurityGroup(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.SecurityGroup) error {
 	return unsupported("DeleteSecurityGroup")
+}
+
+func deterministicIPv4Address(prefix net.IPNet, seed string) (*unikornv1core.IPv4Address, error) {
+	networkIP := prefix.IP.To4()
+	if networkIP == nil {
+		return nil, fmt.Errorf("%w: prefix %s is not IPv4", coreerrors.ErrConsistency, prefix.String())
+	}
+
+	ones, bits := prefix.Mask.Size()
+	if bits != net.IPv4len*8 {
+		return nil, fmt.Errorf("%w: prefix %s is not IPv4", coreerrors.ErrConsistency, prefix.String())
+	}
+
+	hostBits := bits - ones
+	if hostBits < 2 {
+		return nil, fmt.Errorf("%w: prefix %s has no usable host addresses", coreerrors.ErrConsistency, prefix.String())
+	}
+
+	usableHostCount := big.NewInt(1)
+	usableHostCount.Lsh(usableHostCount, uint(hostBits))
+	usableHostCount.Sub(usableHostCount, big.NewInt(2))
+
+	hash := uuid.NewSHA1(uuid.NameSpaceURL, []byte(seed))
+	offset := big.NewInt(0).SetBytes(hash[:])
+	offset.Mod(offset, usableHostCount)
+	offset.Add(offset, big.NewInt(1))
+
+	ip := big.NewInt(0).SetBytes(networkIP.Mask(prefix.Mask))
+	ip.Add(ip, offset)
+
+	addressBytes := ip.Bytes()
+	address := make(net.IP, net.IPv4len)
+	copy(address[net.IPv4len-len(addressBytes):], addressBytes)
+
+	return &unikornv1core.IPv4Address{IP: address}, nil
+}
+
+func documentationPublicIPPrefix() net.IPNet {
+	return net.IPNet{
+		IP:   net.IPv4(198, 51, 100, 0).To4(),
+		Mask: net.CIDRMask(24, 32),
+	}
+}
+
+func (p *Provider) loadBalancerNetwork(ctx context.Context, loadBalancer *unikornv1.LoadBalancer) (*unikornv1.Network, error) {
+	networkID, ok := loadBalancer.Labels[constants.NetworkLabel]
+	if !ok || networkID == "" {
+		return nil, fmt.Errorf("%w: load balancer %s missing network label", coreerrors.ErrConsistency, loadBalancer.Name)
+	}
+
+	if p.client == nil {
+		return nil, fmt.Errorf("%w: kubernetes client not configured", coreerrors.ErrConsistency)
+	}
+
+	network := &unikornv1.Network{}
+	if err := p.client.Get(ctx, client.ObjectKey{Namespace: loadBalancer.Namespace, Name: networkID}, network); err != nil {
+		return nil, fmt.Errorf("%w: get network %s for load balancer %s: %w", coreerrors.ErrConsistency, networkID, loadBalancer.Name, err)
+	}
+
+	return network, nil
+}
+
+func (p *Provider) CreateLoadBalancer(ctx context.Context, _ *unikornv1.Identity, loadBalancer *unikornv1.LoadBalancer) error {
+	if loadBalancer.Spec.RequestedVIPAddress != nil {
+		loadBalancer.Status.VIPAddress = loadBalancer.Spec.RequestedVIPAddress.DeepCopy()
+	} else {
+		network, err := p.loadBalancerNetwork(ctx, loadBalancer)
+		if err != nil {
+			return err
+		}
+
+		if network.Spec.Prefix == nil {
+			return fmt.Errorf("%w: network %s missing prefix", coreerrors.ErrConsistency, network.Name)
+		}
+
+		vipAddress, err := deterministicIPv4Address(network.Spec.Prefix.IPNet, fmt.Sprintf("simulated-loadbalancer-vip/%s/%s", network.Spec.Prefix.String(), loadBalancer.Name))
+		if err != nil {
+			return err
+		}
+
+		loadBalancer.Status.VIPAddress = vipAddress
+	}
+
+	if loadBalancer.Spec.PublicIP {
+		publicIP, err := deterministicIPv4Address(documentationPublicIPPrefix(), fmt.Sprintf("simulated-loadbalancer-publicip/%s", loadBalancer.Name))
+		if err != nil {
+			return err
+		}
+
+		loadBalancer.Status.PublicIP = publicIP
+	} else {
+		loadBalancer.Status.PublicIP = nil
+	}
+
+	return nil
+}
+
+func (p *Provider) DeleteLoadBalancer(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.LoadBalancer) error {
+	return nil
 }
 
 func (p *Provider) CreateServer(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.Server, _ *types.ServerCreateOptions) error {

--- a/pkg/providers/internal/simulated/provider.go
+++ b/pkg/providers/internal/simulated/provider.go
@@ -371,6 +371,8 @@ func deterministicIPv4Address(prefix net.IPNet, seed string) (*unikornv1core.IPv
 	return &unikornv1core.IPv4Address{IP: address}, nil
 }
 
+// documentationPublicIPPrefix returns RFC 5737 TEST-NET-2 for deterministic,
+// non-routable simulated public IP allocation.
 func documentationPublicIPPrefix() net.IPNet {
 	return net.IPNet{
 		IP:   net.IPv4(198, 51, 100, 0).To4(),

--- a/pkg/providers/internal/simulated/provider_test.go
+++ b/pkg/providers/internal/simulated/provider_test.go
@@ -23,17 +23,27 @@ import (
 	"github.com/stretchr/testify/require"
 
 	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	unikorncoreclient "github.com/unikorn-cloud/core/pkg/client"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/providers/internal/simulated"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func newProvider(t *testing.T) *simulated.Provider {
+func newProvider(t *testing.T, objects ...client.Object) *simulated.Provider {
 	t.Helper()
 
-	provider, err := simulated.New(t.Context(), nil, &unikornv1.Region{
+	scheme, err := unikorncoreclient.NewScheme(unikornv1.AddToScheme)
+	require.NoError(t, err)
+
+	providerClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+	provider, err := simulated.New(t.Context(), providerClient, &unikornv1.Region{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simulated-region",
 			Namespace: "default",
@@ -45,6 +55,37 @@ func newProvider(t *testing.T) *simulated.Provider {
 	require.NoError(t, err)
 
 	return provider
+}
+
+func networkFixture(t *testing.T, name, cidr string) *unikornv1.Network {
+	t.Helper()
+
+	_, prefix, err := net.ParseCIDR(cidr)
+	require.NoError(t, err)
+
+	return &unikornv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: unikornv1.NetworkSpec{
+			Prefix: &unikornv1core.IPv4Prefix{
+				IPNet: *prefix,
+			},
+		},
+	}
+}
+
+func loadBalancerFixture(name string) *unikornv1.LoadBalancer {
+	return &unikornv1.LoadBalancer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				constants.NetworkLabel: "test-network",
+			},
+		},
+	}
 }
 
 func TestFlavors(t *testing.T) {
@@ -142,6 +183,107 @@ func TestCreateNetwork(t *testing.T) {
 	require.Equal(t, "10.32.0.16", network.Status.Openstack.StorageRange.Start.String())
 	require.Equal(t, "10.32.0.127", network.Status.Openstack.StorageRange.End.String())
 	require.NoError(t, provider.DeleteNetwork(t.Context(), &unikornv1.Identity{}, network))
+}
+
+func TestCreateLoadBalancerRequestedVIPPassthrough(t *testing.T) {
+	t.Parallel()
+
+	provider := newProvider(t)
+	requestedVIP := &unikornv1core.IPv4Address{IP: net.ParseIP("10.32.0.50").To4()}
+	loadBalancer := loadBalancerFixture("loadbalancer-requested")
+	loadBalancer.Spec.RequestedVIPAddress = requestedVIP
+
+	require.NoError(t, provider.CreateLoadBalancer(t.Context(), &unikornv1.Identity{}, loadBalancer))
+	require.NotNil(t, loadBalancer.Status.VIPAddress)
+	require.Equal(t, "10.32.0.50", loadBalancer.Status.VIPAddress.String())
+
+	require.NoError(t, provider.CreateLoadBalancer(t.Context(), &unikornv1.Identity{}, loadBalancer))
+	require.NotNil(t, loadBalancer.Status.VIPAddress)
+	require.Equal(t, "10.32.0.50", loadBalancer.Status.VIPAddress.String())
+}
+
+func TestCreateLoadBalancerDerivedVIPDeterministic(t *testing.T) {
+	t.Parallel()
+
+	network := networkFixture(t, "test-network", "10.32.0.0/24")
+	provider := newProvider(t, network)
+	loadBalancer := loadBalancerFixture("loadbalancer-derived")
+
+	require.NoError(t, provider.CreateLoadBalancer(t.Context(), &unikornv1.Identity{}, loadBalancer))
+	require.NotNil(t, loadBalancer.Status.VIPAddress)
+	require.Equal(t, "10.32.0.91", loadBalancer.Status.VIPAddress.String())
+	require.True(t, network.Spec.Prefix.Contains(loadBalancer.Status.VIPAddress.IP))
+
+	firstVIP := loadBalancer.Status.VIPAddress.String()
+
+	require.NoError(t, provider.CreateLoadBalancer(t.Context(), &unikornv1.Identity{}, loadBalancer))
+	require.NotNil(t, loadBalancer.Status.VIPAddress)
+	require.Equal(t, firstVIP, loadBalancer.Status.VIPAddress.String())
+}
+
+func TestCreateLoadBalancerPublicIPDeterministic(t *testing.T) {
+	t.Parallel()
+
+	network := networkFixture(t, "test-network", "10.32.0.0/24")
+	provider := newProvider(t, network)
+	loadBalancer := loadBalancerFixture("loadbalancer-public")
+	loadBalancer.Spec.PublicIP = true
+
+	require.NoError(t, provider.CreateLoadBalancer(t.Context(), &unikornv1.Identity{}, loadBalancer))
+	require.NotNil(t, loadBalancer.Status.PublicIP)
+	require.Equal(t, "198.51.100.108", loadBalancer.Status.PublicIP.String())
+
+	documentationPrefix := net.IPNet{
+		IP:   net.IPv4(198, 51, 100, 0).To4(),
+		Mask: net.CIDRMask(24, 32),
+	}
+	require.True(t, documentationPrefix.Contains(loadBalancer.Status.PublicIP.IP))
+
+	firstPublicIP := loadBalancer.Status.PublicIP.String()
+
+	require.NoError(t, provider.CreateLoadBalancer(t.Context(), &unikornv1.Identity{}, loadBalancer))
+	require.NotNil(t, loadBalancer.Status.PublicIP)
+	require.Equal(t, firstPublicIP, loadBalancer.Status.PublicIP.String())
+}
+
+func TestCreateLoadBalancerPublicIPDisabled(t *testing.T) {
+	t.Parallel()
+
+	network := networkFixture(t, "test-network", "10.32.0.0/24")
+	provider := newProvider(t, network)
+	loadBalancer := loadBalancerFixture("loadbalancer-private")
+	loadBalancer.Status.PublicIP = &unikornv1core.IPv4Address{IP: net.ParseIP("198.51.100.99").To4()}
+
+	require.NoError(t, provider.CreateLoadBalancer(t.Context(), &unikornv1.Identity{}, loadBalancer))
+	require.Nil(t, loadBalancer.Status.PublicIP)
+}
+
+func TestDeleteLoadBalancerIdempotent(t *testing.T) {
+	t.Parallel()
+
+	provider := newProvider(t)
+	loadBalancer := loadBalancerFixture("loadbalancer-delete")
+	loadBalancer.Status.VIPAddress = &unikornv1core.IPv4Address{IP: net.ParseIP("10.32.0.60").To4()}
+	loadBalancer.Status.PublicIP = &unikornv1core.IPv4Address{IP: net.ParseIP("198.51.100.60").To4()}
+
+	require.NoError(t, provider.DeleteLoadBalancer(t.Context(), &unikornv1.Identity{}, loadBalancer))
+	require.Equal(t, "10.32.0.60", loadBalancer.Status.VIPAddress.String())
+	require.Equal(t, "198.51.100.60", loadBalancer.Status.PublicIP.String())
+
+	require.NoError(t, provider.DeleteLoadBalancer(t.Context(), &unikornv1.Identity{}, loadBalancer))
+	require.Equal(t, "10.32.0.60", loadBalancer.Status.VIPAddress.String())
+	require.Equal(t, "198.51.100.60", loadBalancer.Status.PublicIP.String())
+}
+
+func TestCreateLoadBalancerFailsWhenNetworkMissing(t *testing.T) {
+	t.Parallel()
+
+	provider := newProvider(t)
+	loadBalancer := loadBalancerFixture("loadbalancer-missing-network")
+
+	err := provider.CreateLoadBalancer(t.Context(), &unikornv1.Identity{}, loadBalancer)
+	require.Error(t, err)
+	require.Nil(t, loadBalancer.Status.VIPAddress)
 }
 
 func ptrTo[T any](v T) *T {

--- a/pkg/providers/types/interfaces.go
+++ b/pkg/providers/types/interfaces.go
@@ -82,6 +82,13 @@ type SecurityGroup interface {
 	DeleteSecurityGroup(ctx context.Context, identity *unikornv1.Identity, securityGroup *unikornv1.SecurityGroup) error
 }
 
+type LoadBalancer interface {
+	// CreateLoadBalancer creates a new load balancer.
+	CreateLoadBalancer(ctx context.Context, identity *unikornv1.Identity, loadBalancer *unikornv1.LoadBalancer) error
+	// DeleteLoadBalancer deletes a load balancer.
+	DeleteLoadBalancer(ctx context.Context, identity *unikornv1.Identity, loadBalancer *unikornv1.LoadBalancer) error
+}
+
 type Server interface {
 	// CreateServer creates a new server.
 	CreateServer(ctx context.Context, identity *unikornv1.Identity, server *unikornv1.Server, options *ServerCreateOptions) error
@@ -127,6 +134,7 @@ type Provider interface {
 	Identity
 	Network
 	SecurityGroup
+	LoadBalancer
 	Server
 	ServerConsole
 	ServerSnapshot

--- a/pkg/providers/types/mock/interfaces.go
+++ b/pkg/providers/types/mock/interfaces.go
@@ -382,6 +382,57 @@ func (mr *MockSecurityGroupMockRecorder) DeleteSecurityGroup(ctx, identity, secu
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockSecurityGroup)(nil).DeleteSecurityGroup), ctx, identity, securityGroup)
 }
 
+// MockLoadBalancer is a mock of LoadBalancer interface.
+type MockLoadBalancer struct {
+	ctrl     *gomock.Controller
+	recorder *MockLoadBalancerMockRecorder
+}
+
+// MockLoadBalancerMockRecorder is the mock recorder for MockLoadBalancer.
+type MockLoadBalancerMockRecorder struct {
+	mock *MockLoadBalancer
+}
+
+// NewMockLoadBalancer creates a new mock instance.
+func NewMockLoadBalancer(ctrl *gomock.Controller) *MockLoadBalancer {
+	mock := &MockLoadBalancer{ctrl: ctrl}
+	mock.recorder = &MockLoadBalancerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockLoadBalancer) EXPECT() *MockLoadBalancerMockRecorder {
+	return m.recorder
+}
+
+// CreateLoadBalancer mocks base method.
+func (m *MockLoadBalancer) CreateLoadBalancer(ctx context.Context, identity *v1alpha1.Identity, loadBalancer *v1alpha1.LoadBalancer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateLoadBalancer", ctx, identity, loadBalancer)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateLoadBalancer indicates an expected call of CreateLoadBalancer.
+func (mr *MockLoadBalancerMockRecorder) CreateLoadBalancer(ctx, identity, loadBalancer any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancer", reflect.TypeOf((*MockLoadBalancer)(nil).CreateLoadBalancer), ctx, identity, loadBalancer)
+}
+
+// DeleteLoadBalancer mocks base method.
+func (m *MockLoadBalancer) DeleteLoadBalancer(ctx context.Context, identity *v1alpha1.Identity, loadBalancer *v1alpha1.LoadBalancer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLoadBalancer", ctx, identity, loadBalancer)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLoadBalancer indicates an expected call of DeleteLoadBalancer.
+func (mr *MockLoadBalancerMockRecorder) DeleteLoadBalancer(ctx, identity, loadBalancer any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancer", reflect.TypeOf((*MockLoadBalancer)(nil).DeleteLoadBalancer), ctx, identity, loadBalancer)
+}
+
 // MockServer is a mock of Server interface.
 type MockServer struct {
 	ctrl     *gomock.Controller
@@ -700,6 +751,20 @@ func (mr *MockProviderMockRecorder) CreateImage(ctx, image, uri any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateImage", reflect.TypeOf((*MockProvider)(nil).CreateImage), ctx, image, uri)
 }
 
+// CreateLoadBalancer mocks base method.
+func (m *MockProvider) CreateLoadBalancer(ctx context.Context, identity *v1alpha1.Identity, loadBalancer *v1alpha1.LoadBalancer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateLoadBalancer", ctx, identity, loadBalancer)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateLoadBalancer indicates an expected call of CreateLoadBalancer.
+func (mr *MockProviderMockRecorder) CreateLoadBalancer(ctx, identity, loadBalancer any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoadBalancer", reflect.TypeOf((*MockProvider)(nil).CreateLoadBalancer), ctx, identity, loadBalancer)
+}
+
 // CreateNetwork mocks base method.
 func (m *MockProvider) CreateNetwork(ctx context.Context, identity *v1alpha1.Identity, network *v1alpha1.Network) error {
 	m.ctrl.T.Helper()
@@ -783,6 +848,20 @@ func (m *MockProvider) DeleteImage(ctx context.Context, imageID string) error {
 func (mr *MockProviderMockRecorder) DeleteImage(ctx, imageID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteImage", reflect.TypeOf((*MockProvider)(nil).DeleteImage), ctx, imageID)
+}
+
+// DeleteLoadBalancer mocks base method.
+func (m *MockProvider) DeleteLoadBalancer(ctx context.Context, identity *v1alpha1.Identity, loadBalancer *v1alpha1.LoadBalancer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLoadBalancer", ctx, identity, loadBalancer)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLoadBalancer indicates an expected call of DeleteLoadBalancer.
+func (mr *MockProviderMockRecorder) DeleteLoadBalancer(ctx, identity, loadBalancer any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancer", reflect.TypeOf((*MockProvider)(nil).DeleteLoadBalancer), ctx, identity, loadBalancer)
 }
 
 // DeleteNetwork mocks base method.


### PR DESCRIPTION
## Summary
Add load balancer create/delete methods to the provider contract and regenerate the provider mocks.
Implement deterministic simulated-provider load balancer VIP/public IP behavior with focused unit coverage for requested VIPs, derived VIPs, public IP allocation, idempotent delete, and missing-network failures.
Add temporary OpenStack load balancer stubs so the provider still satisfies the expanded interface until real support lands.

## Verification
make touch
make license
make validate
make lint
make generate
make test-unit