### PR TITLE
test: fail on teardown errors instead of logging warnings

### DIFF
--- a/test/api/suites/filestorage_test.go
+++ b/test/api/suites/filestorage_test.go
@@ -118,9 +118,7 @@ var _ = Describe("File Storage Management", func() {
 			AfterEach(func() {
 				if testStorageID != "" {
 					GinkgoWriter.Printf("Cleaning up test list storage: %s\n", testStorageID)
-					if err := regionClient.DeleteFileStorage(ctx, testStorageID); err != nil {
-						GinkgoWriter.Printf("Warning: Failed to cleanup test storage %s: %v\n", testStorageID, err)
-					}
+					Expect(regionClient.DeleteFileStorage(ctx, testStorageID)).To(Succeed())
 				}
 			})
 		})
@@ -296,6 +294,7 @@ var _ = Describe("File Storage Management", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				GinkgoWriter.Printf("Deleted file storage: %s\n", filestorageID)
+				filestorageID = "" // suppress cleanup — already deleted
 			})
 
 			It("should not find the deleted file storage resource", func() {
@@ -318,9 +317,7 @@ var _ = Describe("File Storage Management", func() {
 		AfterAll(func() {
 			if filestorageID != "" {
 				GinkgoWriter.Printf("Cleaning up test filestorage: %s\n", filestorageID)
-				if err := regionClient.DeleteFileStorage(ctx, filestorageID); err != nil {
-					GinkgoWriter.Printf("Warning: Failed to cleanup filestorage %s: %v\n", filestorageID, err)
-				}
+				Expect(regionClient.DeleteFileStorage(ctx, filestorageID)).To(Succeed())
 			}
 		})
 	})
@@ -612,6 +609,7 @@ var _ = Describe("File Storage Management", func() {
 					Should(Equal(0), "Network should be deleted")
 
 				GinkgoWriter.Printf("Confirmed network deleted: %s\n", networkID)
+				networkID = "" // suppress cleanup — already deleted
 			})
 		})
 
@@ -619,9 +617,7 @@ var _ = Describe("File Storage Management", func() {
 			// Delete storage first to detach from network
 			if filestorageID != "" {
 				GinkgoWriter.Printf("Cleaning up test filestorage: %s\n", filestorageID)
-				if err := regionClient.DeleteFileStorage(ctx, filestorageID); err != nil {
-					GinkgoWriter.Printf("Warning: Failed to cleanup filestorage %s: %v\n", filestorageID, err)
-				}
+				Expect(regionClient.DeleteFileStorage(ctx, filestorageID)).To(Succeed())
 			}
 
 			if networkID != "" {
@@ -635,9 +631,7 @@ var _ = Describe("File Storage Management", func() {
 						"Storage should be deleted before network cleanup")
 
 				GinkgoWriter.Printf("Cleaning up test network: %s\n", networkID)
-				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil {
-					GinkgoWriter.Printf("Warning: Failed to cleanup network %s: %v\n", networkID, err)
-				}
+				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
 			}
 		})
 	})

--- a/test/api/suites/images_test.go
+++ b/test/api/suites/images_test.go
@@ -84,9 +84,7 @@ var _ = Describe("Image Management", Ordered, func() {
 				return
 			}
 			GinkgoWriter.Printf("Cleaning up image %s\n", customImageID)
-			if err := regionClient.DeleteImage(ctx, config.OrgID, config.RegionID, customImageID); err != nil {
-				GinkgoWriter.Printf("Failed to clean up image %s: %v\n", customImageID, err)
-			}
+			Expect(regionClient.DeleteImage(ctx, config.OrgID, config.RegionID, customImageID)).To(Succeed())
 		})
 
 		It("should create a custom image and return its ID", func() {
@@ -120,6 +118,7 @@ var _ = Describe("Image Management", Ordered, func() {
 			err := regionClient.DeleteImage(ctx, config.OrgID, config.RegionID, customImageID)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Printf("Deleted image %s\n", customImageID)
+			customImageID = ""
 		})
 
 		It("should return not found when deleting the already-deleted image", func() {

--- a/test/api/suites/loadbalancers_test.go
+++ b/test/api/suites/loadbalancers_test.go
@@ -21,7 +21,6 @@ limitations under the License.
 package suites
 
 import (
-	"errors"
 	"net/http"
 	"time"
 
@@ -31,7 +30,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
-	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
 	regionopenapi "github.com/unikorn-cloud/region/pkg/openapi"
 	"github.com/unikorn-cloud/region/test/api"
 )
@@ -52,13 +50,9 @@ var _ = Describe("LoadBalancer", func() {
 
 				DeferCleanup(func() {
 					if lbID != "" {
-						if err := regionClient.DeleteLoadBalancer(ctx, lbID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
-							GinkgoWriter.Printf("Warning: cleanup delete load balancer %s: %v\n", lbID, err)
-						}
+						Expect(regionClient.DeleteLoadBalancer(ctx, lbID)).To(Succeed())
 					}
-					if err := regionClient.DeleteNetwork(ctx, networkID); err != nil {
-						GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
-					}
+					Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
 				})
 			})
 


### PR DESCRIPTION
Closes INST-848

Teardown failures are now test failures. Previously, cleanup errors were swallowed and logged as warnings, meaning deletion bugs (e.g. hanging deletes causing resource leaks) were invisible to the suite.

Resources deleted by a test spec nil out their ID so the `AfterAll` safety net skips the redundant delete on the happy path.