### PR TITLE
Mention `manager` role in Openstack Setup Docs

### DIFF
--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -63,10 +63,12 @@ for role in member load-balancer_member manager; do
 done
 ```
 
-Grant the `member` role on the project we created in a previous step:
+Grant the `member` and `manager` roles on the project we created in a previous step:
 
 ```bash
-openstack role add --user ${USER_ID} --project ${PROJECT_ID} member
+for role in member manager; do
+    openstack role add --user ${USER_ID} --project ${PROJECT_ID} ${role}
+done
 ```
 
 ### Unikorn Configuration


### PR DESCRIPTION
In order fo the provider to publicize images it needs to have a token scoped to a project (how Glance works).  It also needs the necessary permissions to be granted, which currently are injected via the `manager` role.  As such we need to update the documentation so that role gets bound to the provider user and project.