### PR TITLE
Version v1.16.3

### DIFF
--- a/charts/region/Chart.yaml
+++ b/charts/region/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's Region Controller
 
 type: application
 
-version: 1.16.2
-appVersion: 1.16.2
+version: 1.16.3
+appVersion: 1.16.3
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spjmurray/go-util v0.1.3
 	github.com/stretchr/testify v1.11.1
 	github.com/unikorn-cloud/core v1.14.0-rc1.0.20260422145135-733e5169a07e
-	github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260421095602-a005bcea5bed
+	github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260430090955-4839bc57a519
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/mock v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/unikorn-cloud/core v1.14.0-rc1.0.20260422145135-733e5169a07e h1:BJBiASTtWfEJ1/yn26K18JxnMeLB4ucpuJcU0bVbpBo=
 github.com/unikorn-cloud/core v1.14.0-rc1.0.20260422145135-733e5169a07e/go.mod h1:t91+Hw7YbNt5nOtp93Ij826iQfYDcz6Og0KAi2xq+B8=
-github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260421095602-a005bcea5bed h1:2DBYOqaL2jMLhMFHLvS29a6jjTra8+Mdlos4FMpQBMc=
-github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260421095602-a005bcea5bed/go.mod h1:N5F9BXYWcv5VKNgKo/NRWII+A4x+KGiDlU7o1c/rU54=
+github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260430090955-4839bc57a519 h1:ZNMADkrIRzM8BhEdRx1JEg4UnYcqcVmE+qWgh13jbyI=
+github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260430090955-4839bc57a519/go.mod h1:N5F9BXYWcv5VKNgKo/NRWII+A4x+KGiDlU7o1c/rU54=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
The shared identity middleware now populates the propagated principal account type globally at the public API boundary from the authenticated request context, and the shared identity client injector forwards that principal automatically on downstream impersonated service-to-service calls.

`region` does not need to derive account type ad hoc in `InjectUserPrincipal()`. That helper only patches request-scoped tenancy fields such as organization and project IDs when those values are known from the current route or resource context but are not already present on the propagated principal.

This change updates `github.com/unikorn-cloud/identity` to the version that applies the new impersonation routing against the propagated principal type.