### PR TITLE
Remove restrictions around OS family and distribution in image metadata

### DIFF
--- a/pkg/handler/image/conversions.go
+++ b/pkg/handler/image/conversions.go
@@ -70,28 +70,6 @@ func convertOsKernel(in types.OsKernel) openapi.OsKernel {
 	return ""
 }
 
-func convertOsFamily(in types.OsFamily) openapi.OsFamily {
-	switch in {
-	case types.Debian:
-		return openapi.OsFamilyDebian
-	case types.Redhat:
-		return openapi.OsFamilyRedhat
-	}
-
-	return ""
-}
-
-func convertOsDistro(in types.OsDistro) openapi.OsDistro {
-	switch in {
-	case types.Rocky:
-		return openapi.OsDistroRocky
-	case types.Ubuntu:
-		return openapi.OsDistroUbuntu
-	}
-
-	return ""
-}
-
 func convertPackages(in *types.ImagePackages) *openapi.SoftwareVersions {
 	if in == nil {
 		return nil
@@ -156,8 +134,8 @@ func convertImage(in *types.Image) *openapi.Image {
 			Virtualization: convertImageVirtualization(in.Virtualization),
 			Os: openapi.ImageOS{
 				Kernel:   convertOsKernel(in.OS.Kernel),
-				Family:   convertOsFamily(in.OS.Family),
-				Distro:   convertOsDistro(in.OS.Distro),
+				Family:   in.OS.Family,
+				Distro:   in.OS.Distro,
 				Codename: in.OS.Codename,
 				Variant:  in.OS.Variant,
 				Version:  in.OS.Version,
@@ -228,28 +206,6 @@ func generateOSKernel(source openapi.OsKernel) types.OsKernel {
 	}
 }
 
-func generateOSFamily(source openapi.OsFamily) types.OsFamily {
-	switch source {
-	case openapi.OsFamilyDebian:
-		return types.Debian
-	case openapi.OsFamilyRedhat:
-		return types.Redhat
-	default:
-		return ""
-	}
-}
-
-func generateOSDistro(source openapi.OsDistro) types.OsDistro {
-	switch source {
-	case openapi.OsDistroRocky:
-		return types.Rocky
-	case openapi.OsDistroUbuntu:
-		return types.Ubuntu
-	default:
-		return ""
-	}
-}
-
 func generatePackages(source openapi.SoftwareVersions) types.ImagePackages {
 	target := make(types.ImagePackages, len(source))
 
@@ -287,8 +243,8 @@ func generateImageGPU(source *openapi.ImageGpu) *types.ImageGPU {
 func generateImageOS(source *openapi.ImageOS) *types.ImageOS {
 	return &types.ImageOS{
 		Kernel:   generateOSKernel(source.Kernel),
-		Family:   generateOSFamily(source.Family),
-		Distro:   generateOSDistro(source.Distro),
+		Family:   source.Family,
+		Distro:   source.Distro,
 		Variant:  source.Variant,
 		Codename: source.Codename,
 		Version:  source.Version,

--- a/pkg/openapi/server.spec.yaml
+++ b/pkg/openapi/server.spec.yaml
@@ -2024,15 +2024,9 @@ components:
     osFamily:
       description: A family of operating systems.  This typically defines the package format.
       type: string
-      enum:
-      - redhat
-      - debian
     osDistro:
       description: A distribution name.
       type: string
-      enum:
-      - rocky
-      - ubuntu
     imageOS:
       description: An operating system description.
       type: object

--- a/pkg/openapi/types.go
+++ b/pkg/openapi/types.go
@@ -69,18 +69,6 @@ const (
 	NetworkProtocolVrrp NetworkProtocol = "vrrp"
 )
 
-// Defines values for OsDistro.
-const (
-	OsDistroRocky  OsDistro = "rocky"
-	OsDistroUbuntu OsDistro = "ubuntu"
-)
-
-// Defines values for OsFamily.
-const (
-	OsFamilyDebian OsFamily = "debian"
-	OsFamilyRedhat OsFamily = "redhat"
-)
-
 // Defines values for OsKernel.
 const (
 	OsKernelLinux OsKernel = "linux"
@@ -671,10 +659,10 @@ type NetworksRead = []NetworkRead
 type NetworksV2Read = []NetworkV2Read
 
 // OsDistro A distribution name.
-type OsDistro string
+type OsDistro = string
 
 // OsFamily A family of operating systems.  This typically defines the package format.
-type OsFamily string
+type OsFamily = string
 
 // OsKernel A kernel type.
 type OsKernel string

--- a/pkg/providers/internal/openstack/image_test.go
+++ b/pkg/providers/internal/openstack/image_test.go
@@ -179,16 +179,6 @@ func TestImageSchema(t *testing.T) {
 			mutator: replacePropertyMutator(osKernelProperty, "darwin"),
 		},
 		{
-			name:    "BasicImageInvalidFamily",
-			fixture: basicImageFixture,
-			mutator: replacePropertyMutator(osFamilyProperty, "gentoo"),
-		},
-		{
-			name:    "BasicImageInvalidDistro",
-			fixture: basicImageFixture,
-			mutator: replacePropertyMutator(osDistroProperty, "mandriver"),
-		},
-		{
 			name:    "BasicImageInvalidVirtualization",
 			fixture: basicImageFixture,
 			mutator: replacePropertyMutator(virtualizationProperty, "virtualised"),

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -425,8 +425,8 @@ func imageOS(image *images.Image) types.ImageOS {
 
 	result := types.ImageOS{
 		Kernel:  types.OsKernel(kernel),
-		Family:  types.OsFamily(family),
-		Distro:  types.OsDistro(distro),
+		Family:  family,
+		Distro:  distro,
 		Version: version,
 	}
 
@@ -708,8 +708,8 @@ func createImageMetadata(image *types.Image) (map[string]string, error) {
 	metadata := make(map[string]string)
 
 	metadata[osKernelLabel] = string(image.OS.Kernel)
-	metadata[osFamilyLabel] = string(image.OS.Family)
-	metadata[osDistroLabel] = string(image.OS.Distro)
+	metadata[osFamilyLabel] = image.OS.Family
+	metadata[osDistroLabel] = image.OS.Distro
 	metadata[osVersionLabel] = image.OS.Version
 	setIfNotNil(metadata, osVariantLabel, image.OS.Variant)
 	setIfNotNil(metadata, osCodenameLabel, image.OS.Codename)

--- a/pkg/providers/internal/openstack/provider_test.go
+++ b/pkg/providers/internal/openstack/provider_test.go
@@ -1012,8 +1012,8 @@ func TestImageTagRoundTrip(t *testing.T) {
 				},
 				OS: types.ImageOS{
 					Kernel:  types.Linux,
-					Family:  types.Debian,
-					Distro:  types.Ubuntu,
+					Family:  "debian",
+					Distro:  "ubuntu",
 					Version: "24.04",
 				},
 			},
@@ -1025,8 +1025,8 @@ func TestImageTagRoundTrip(t *testing.T) {
 				Tags: nil,
 				OS: types.ImageOS{
 					Kernel:  types.Linux,
-					Family:  types.Redhat,
-					Distro:  types.Rocky,
+					Family:  "redhat",
+					Distro:  "rocky",
 					Version: "9.3",
 				},
 			},
@@ -1042,8 +1042,8 @@ func TestImageTagRoundTrip(t *testing.T) {
 				},
 				OS: types.ImageOS{
 					Kernel:  types.Linux,
-					Family:  types.Debian,
-					Distro:  types.Ubuntu,
+					Family:  "debian",
+					Distro:  "ubuntu",
 					Version: "22.04",
 				},
 			},
@@ -1057,8 +1057,8 @@ func TestImageTagRoundTrip(t *testing.T) {
 				},
 				OS: types.ImageOS{
 					Kernel:  types.Linux,
-					Family:  types.Debian,
-					Distro:  types.Ubuntu,
+					Family:  "debian",
+					Distro:  "ubuntu",
 					Version: "24.04",
 				},
 			},

--- a/pkg/providers/internal/openstack/v2.image.schema.json
+++ b/pkg/providers/internal/openstack/v2.image.schema.json
@@ -20,18 +20,10 @@
                         ]
                 },
                 "unikorn:os:family":{
-                        "type":"string",
-                        "enum":[
-                                "debian",
-                                "redhat"
-                        ]
+                        "type":"string"
                 },
                 "unikorn:os:distro":{
-                        "type":"string",
-                        "enum":[
-                                "ubuntu",
-                                "rocky"
-                        ]
+                        "type":"string"
                 },
                 "unikorn:os:variant":{
                         "type":"string"

--- a/pkg/providers/internal/simulated/provider.go
+++ b/pkg/providers/internal/simulated/provider.go
@@ -202,8 +202,8 @@ func builtInImages() []types.Image {
 			Virtualization: types.Virtualized,
 			OS: types.ImageOS{
 				Kernel:   types.Linux,
-				Family:   types.Debian,
-				Distro:   types.Ubuntu,
+				Family:   "debian",
+				Distro:   "ubuntu",
 				Codename: &noble,
 				Version:  "24.04",
 			},
@@ -227,8 +227,8 @@ func builtInImages() []types.Image {
 			},
 			OS: types.ImageOS{
 				Kernel:   types.Linux,
-				Family:   types.Debian,
-				Distro:   types.Ubuntu,
+				Family:   "debian",
+				Distro:   "ubuntu",
 				Codename: &noble,
 				Version:  "24.04",
 			},

--- a/pkg/providers/internal/simulated/provider_test.go
+++ b/pkg/providers/internal/simulated/provider_test.go
@@ -120,8 +120,8 @@ func TestImages(t *testing.T) {
 		Virtualization: types.Virtualized,
 		OS: types.ImageOS{
 			Kernel:  types.Linux,
-			Family:  types.Debian,
-			Distro:  types.Ubuntu,
+			Family:  "debian",
+			Distro:  "ubuntu",
 			Version: "24.04",
 		},
 	}, "https://example.invalid/image.raw")

--- a/pkg/providers/types/types.go
+++ b/pkg/providers/types/types.go
@@ -190,30 +190,14 @@ const (
 	Linux OsKernel = "linux"
 )
 
-// OsFamily A family of operating systems.  This typically defines the package format.
-type OsFamily string
-
-const (
-	Debian OsFamily = "debian"
-	Redhat OsFamily = "redhat"
-)
-
-// OsDistro A distribution name.
-type OsDistro string
-
-const (
-	Rocky  OsDistro = "rocky"
-	Ubuntu OsDistro = "ubuntu"
-)
-
 // ImageOS defines the operating system of an image.
 type ImageOS struct {
 	// Kernel is the kernel type of the OS.
 	Kernel OsKernel
 	// Family is the family of the OS.
-	Family OsFamily
+	Family string
 	// Distro is the distribution of the OS.
-	Distro OsDistro
+	Distro string
 	// Variant is the variant of the OS.
 	Variant *string
 	// Codename is the codename of the OS.

--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -52,8 +52,8 @@ func NewImagePayload() *ImagePayloadBuilder {
 				Architecture: regionopenapi.ArchitectureX8664,
 				Os: regionopenapi.ImageOS{
 					Codename: ptr.To("noble"),
-					Distro:   regionopenapi.OsDistroUbuntu,
-					Family:   regionopenapi.OsFamilyDebian,
+					Distro:   "ubuntu",
+					Family:   "debian",
 					Kernel:   regionopenapi.OsKernelLinux,
 					Version:  "23.04",
 				},

--- a/test/api/suites/images_test.go
+++ b/test/api/suites/images_test.go
@@ -91,8 +91,8 @@ var _ = Describe("Image Management", Ordered, func() {
 			data, err := regionClient.CreateImage(ctx, config.OrgID, config.RegionID,
 				api.NewImagePayload().
 					WithURI(ubuntuNobleAMD64Image).
-					WithOSDistro(regionopenapi.OsDistroUbuntu).
-					WithOSFamily(regionopenapi.OsFamilyDebian).
+					WithOSDistro("ubuntu").
+					WithOSFamily("debian").
 					WithOSKernel(regionopenapi.OsKernelLinux).
 					WithOSCodename("noble").
 					WithOSVersion("24.04").


### PR DESCRIPTION
In the spirit of https://github.com/nscaledev/uni-specifications/pull/40, remove these restrictions from region machinery so that users can specify any string for the OS family and distribution in their image metadata.