### PR TITLE
test: add dedicated CRUD integration tests for networks 

### DIFF
--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -363,7 +363,7 @@ func (c *APIClient) ListNetworks(ctx context.Context, orgID, projectID, regionID
 }
 
 // CreateNetwork creates a new network resource.
-func (c *APIClient) CreateNetwork(ctx context.Context, request regionopenapi.NetworkV2CreateRequest) (*regionopenapi.NetworkV2Read, error) {
+func (c *APIClient) CreateNetwork(ctx context.Context, request regionopenapi.NetworkV2Create) (*regionopenapi.NetworkV2Read, error) {
 	path := c.endpoints.CreateNetwork()
 
 	reqBody, err := json.Marshal(request)
@@ -375,6 +375,47 @@ func (c *APIClient) CreateNetwork(ctx context.Context, request regionopenapi.Net
 	_, respBody, err := c.regionClient.DoRequest(ctx, http.MethodPost, path, bytes.NewReader(reqBody), http.StatusCreated)
 	if err != nil {
 		return nil, fmt.Errorf("creating network: %w", err)
+	}
+
+	var network regionopenapi.NetworkV2Read
+	if err := json.Unmarshal(respBody, &network); err != nil {
+		return nil, fmt.Errorf("unmarshaling network: %w", err)
+	}
+
+	return &network, nil
+}
+
+// GetNetwork gets a specific network by ID.
+func (c *APIClient) GetNetwork(ctx context.Context, networkID string) (*regionopenapi.NetworkV2Read, error) {
+	path := c.endpoints.GetNetwork(networkID)
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
+	if err != nil {
+		return nil, fmt.Errorf("getting network: %w", err)
+	}
+
+	var network regionopenapi.NetworkV2Read
+	if err := json.Unmarshal(respBody, &network); err != nil {
+		return nil, fmt.Errorf("unmarshaling network: %w", err)
+	}
+
+	return &network, nil
+}
+
+// UpdateNetwork updates a network resource.
+func (c *APIClient) UpdateNetwork(ctx context.Context, networkID string, request regionopenapi.NetworkV2Update) (*regionopenapi.NetworkV2Read, error) {
+	path := c.endpoints.UpdateNetwork(networkID)
+
+	reqBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling network update request: %w", err)
+	}
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.regionClient.DoRequest(ctx, http.MethodPut, path, bytes.NewReader(reqBody), http.StatusAccepted)
+	if err != nil {
+		return nil, fmt.Errorf("updating network: %w", err)
 	}
 
 	var network regionopenapi.NetworkV2Read

--- a/test/api/endpoints.go
+++ b/test/api/endpoints.go
@@ -113,6 +113,18 @@ func (e *Endpoints) CreateNetwork() string {
 	return "/api/v2/networks"
 }
 
+// GetNetwork returns the endpoint for getting a specific network resource.
+func (e *Endpoints) GetNetwork(networkID string) string {
+	return fmt.Sprintf("/api/v2/networks/%s",
+		url.PathEscape(networkID))
+}
+
+// UpdateNetwork returns the endpoint for updating a specific network resource.
+func (e *Endpoints) UpdateNetwork(networkID string) string {
+	return fmt.Sprintf("/api/v2/networks/%s",
+		url.PathEscape(networkID))
+}
+
 // DeleteNetwork returns the endpoint for deleting a specific network resource.
 func (e *Endpoints) DeleteNetwork(networkID string) string {
 	return fmt.Sprintf("/api/v2/networks/%s",

--- a/test/api/suites/networks_test.go
+++ b/test/api/suites/networks_test.go
@@ -1,0 +1,192 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,testpackage,gci // dot imports and package naming standard for Ginkgo, import grouping
+package suites
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/utils/ptr"
+
+	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	regionopenapi "github.com/unikorn-cloud/region/pkg/openapi"
+	"github.com/unikorn-cloud/region/test/api"
+)
+
+var _ = Describe("Network Management", func() {
+	Context("When managing the network lifecycle", Ordered, func() {
+		var networkID string
+		var networkName string
+		var networkPrefix string
+		var deletedNetworkID string
+
+		Describe("Given valid organization and project credentials", func() {
+			It("should provision a network with correct metadata and prefix", func() {
+				createReq := api.NewNetworkPayload(config.OrgID, config.ProjectID, config.RegionID).Build()
+
+				created, err := regionClient.CreateNetwork(ctx, createReq)
+				Expect(err).NotTo(HaveOccurred(), "failed to create network")
+				Expect(created).NotTo(BeNil())
+
+				Expect(created.Metadata.Id).NotTo(BeEmpty())
+				Expect(created.Metadata.Name).To(Equal(createReq.Metadata.Name))
+				Expect(created.Metadata.OrganizationId).To(Equal(config.OrgID))
+				Expect(created.Metadata.ProjectId).To(Equal(config.ProjectID))
+				Expect(created.Metadata.ProvisioningStatus).NotTo(BeEmpty())
+				Expect(created.Status.RegionId).To(Equal(config.RegionID))
+				Expect(created.Status.Prefix).To(Equal(createReq.Spec.Prefix))
+
+				networkID = created.Metadata.Id
+				networkName = created.Metadata.Name
+				networkPrefix = created.Status.Prefix
+
+				GinkgoWriter.Printf("Created network: %s (%s)\n", networkName, networkID)
+			})
+		})
+
+		Describe("Given an existing network", func() {
+			It("should appear in the project network list", func() {
+				if networkID == "" {
+					Skip("No network ID available - create step may have been skipped or failed")
+				}
+
+				list, err := regionClient.ListNetworks(ctx, config.OrgID, config.ProjectID, config.RegionID)
+				Expect(err).NotTo(HaveOccurred())
+
+				var found *regionopenapi.NetworkV2Read
+				for i := range list {
+					if list[i].Metadata.Id == networkID {
+						found = &list[i]
+						break
+					}
+				}
+
+				Expect(found).NotTo(BeNil(), "created network not found in list")
+				Expect(found.Metadata.Name).To(Equal(networkName))
+				Expect(found.Metadata.OrganizationId).To(Equal(config.OrgID))
+				Expect(found.Metadata.ProjectId).To(Equal(config.ProjectID))
+			})
+
+			It("should reach provisioned state and be retrievable by ID", func() {
+				if networkID == "" {
+					Skip("No network ID available - create step may have been skipped or failed")
+				}
+
+				var got *regionopenapi.NetworkV2Read
+
+				Eventually(func() coreapi.ResourceProvisioningStatus {
+					var err error
+					got, err = regionClient.GetNetwork(ctx, networkID)
+					if err != nil {
+						return ""
+					}
+					return got.Metadata.ProvisioningStatus
+				}).WithTimeout(2*time.Minute).
+					WithPolling(5*time.Second).
+					Should(Equal(coreapi.ResourceProvisioningStatusProvisioned),
+						"network should reach provisioned state before update")
+
+				Expect(got.Metadata.Id).To(Equal(networkID))
+				Expect(got.Metadata.Name).To(Equal(networkName))
+				Expect(got.Metadata.OrganizationId).To(Equal(config.OrgID))
+				Expect(got.Metadata.ProjectId).To(Equal(config.ProjectID))
+				Expect(got.Status.RegionId).To(Equal(config.RegionID))
+			})
+
+			It("should reflect updated name and description while preserving the prefix", func() {
+				if networkID == "" {
+					Skip("No network ID available - create step may have been skipped or failed")
+				}
+
+				got, err := regionClient.GetNetwork(ctx, networkID)
+				Expect(err).NotTo(HaveOccurred())
+
+				updatedName := networkName + "-upd"
+				updateReq := regionopenapi.NetworkV2Update{
+					Metadata: coreapi.ResourceWriteMetadata{
+						Name:        updatedName,
+						Description: ptr.To("updated description"),
+					},
+					Spec: regionopenapi.NetworkV2Spec{
+						DnsNameservers: got.Spec.DnsNameservers,
+					},
+				}
+
+				putResp, err := regionClient.UpdateNetwork(ctx, networkID, updateReq)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(putResp.Metadata.Name).To(Equal(updatedName))
+				Expect(putResp.Metadata.Description).NotTo(BeNil())
+				Expect(*putResp.Metadata.Description).To(Equal("updated description"))
+
+				roundTrip, err := regionClient.GetNetwork(ctx, networkID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(roundTrip.Metadata.Name).To(Equal(updatedName))
+				Expect(roundTrip.Metadata.Description).NotTo(BeNil())
+				Expect(*roundTrip.Metadata.Description).To(Equal("updated description"))
+				Expect(roundTrip.Status.Prefix).To(Equal(networkPrefix))
+
+				networkName = updatedName
+			})
+		})
+
+		Describe("Given the network is deleted", func() {
+			It("should succeed", func() {
+				if networkID == "" {
+					Skip("No network ID available - create step may have been skipped or failed")
+				}
+
+				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
+
+				GinkgoWriter.Printf("Deleted network: %s\n", networkID)
+				deletedNetworkID = networkID
+				networkID = "" // suppress AfterAll cleanup — already deleted
+			})
+
+			It("should return 404 on subsequent reads", func() {
+				if deletedNetworkID == "" {
+					Skip("No deleted network ID available - delete step may have been skipped or failed")
+				}
+
+				Eventually(func() bool {
+					_, err := regionClient.GetNetwork(ctx, deletedNetworkID)
+					return err != nil
+				}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(BeTrue())
+
+				path := regionClient.GetEndpoints().GetNetwork(deletedNetworkID)
+				resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+				GinkgoWriter.Printf("Confirmed network deleted: %s\n", deletedNetworkID)
+			})
+		})
+
+		AfterAll(func() {
+			if networkID != "" {
+				GinkgoWriter.Printf("Cleaning up network: %s\n", networkID)
+				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
+			}
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- Adds `test/api/suites/networks_test.go` with a full CRUD integration test: create, list, get, update (name + description round-trip), delete with `404` assertion
- Adds typed client methods (`GetNetwork`, `UpdateNetwork`) and endpoint helpers to support the new test
- Follows the builder pattern and BDD conventions established in the existing test suite

Closes INST-872

## Test plan

- [x] `make test-api-focus FOCUS="Network"` passes against dev