### PR TITLE
test(uni-region): add Security Groups CRUD integration tests

### DIFF
--- a/pkg/providers/internal/simulated/provider.go
+++ b/pkg/providers/internal/simulated/provider.go
@@ -329,11 +329,11 @@ func (p *Provider) DeleteNetwork(_ context.Context, _ *unikornv1.Identity, _ *un
 }
 
 func (p *Provider) CreateSecurityGroup(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.SecurityGroup) error {
-	return unsupported("CreateSecurityGroup")
+	return nil
 }
 
 func (p *Provider) DeleteSecurityGroup(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.SecurityGroup) error {
-	return unsupported("DeleteSecurityGroup")
+	return nil
 }
 
 func deterministicIPv4Address(prefix net.IPNet, seed string) (*unikornv1core.IPv4Address, error) {

--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -237,6 +237,114 @@ func (c *APIClient) ListExternalNetworks(ctx context.Context, orgID, regionID st
 	)
 }
 
+// ListSecurityGroups lists security groups filtered by org, project and region.
+func (c *APIClient) ListSecurityGroups(ctx context.Context, orgID, projectID, regionID string) (regionopenapi.SecurityGroupsV2Read, error) {
+	path := c.endpoints.ListSecurityGroups(orgID, projectID, regionID)
+
+	return coreclient.ListResource[regionopenapi.SecurityGroupV2Read](
+		ctx,
+		c.regionClient,
+		path,
+		coreclient.ResponseHandlerConfig{
+			ResourceType:   "securityGroups",
+			ResourceID:     projectID,
+			ResourceIDType: "project",
+		},
+	)
+}
+
+// CreateSecurityGroup creates a new security group.
+func (c *APIClient) CreateSecurityGroup(ctx context.Context, request regionopenapi.SecurityGroupV2Create) (*regionopenapi.SecurityGroupV2Read, error) {
+	path := c.endpoints.CreateSecurityGroup()
+
+	reqBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling security group request: %w", err)
+	}
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.regionClient.DoRequest(ctx, http.MethodPost, path, bytes.NewReader(reqBody), http.StatusCreated)
+	if err != nil {
+		return nil, fmt.Errorf("creating security group: %w", err)
+	}
+
+	var sg regionopenapi.SecurityGroupV2Read
+	if err := json.Unmarshal(respBody, &sg); err != nil {
+		return nil, fmt.Errorf("unmarshaling security group: %w", err)
+	}
+
+	return &sg, nil
+}
+
+// GetSecurityGroup gets a specific security group by ID.
+// Returns ErrResourceNotFound if the security group does not exist.
+func (c *APIClient) GetSecurityGroup(ctx context.Context, securityGroupID string) (*regionopenapi.SecurityGroupV2Read, error) {
+	path := c.endpoints.GetSecurityGroup(securityGroupID)
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	resp, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("getting security group: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var sg regionopenapi.SecurityGroupV2Read
+		if err := json.Unmarshal(respBody, &sg); err != nil {
+			return nil, fmt.Errorf("unmarshaling security group: %w", err)
+		}
+
+		return &sg, nil
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("security group '%s': %w", securityGroupID, coreclient.ErrResourceNotFound)
+	default:
+		return nil, fmt.Errorf("getting security group: status %d: %w", resp.StatusCode, coreclient.ErrUnexpectedStatus)
+	}
+}
+
+// UpdateSecurityGroup updates a security group's rules.
+func (c *APIClient) UpdateSecurityGroup(ctx context.Context, securityGroupID string, request regionopenapi.SecurityGroupV2Update) (*regionopenapi.SecurityGroupV2Read, error) {
+	path := c.endpoints.UpdateSecurityGroup(securityGroupID)
+
+	reqBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling security group update request: %w", err)
+	}
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	_, respBody, err := c.regionClient.DoRequest(ctx, http.MethodPut, path, bytes.NewReader(reqBody), http.StatusAccepted)
+	if err != nil {
+		return nil, fmt.Errorf("updating security group: %w", err)
+	}
+
+	var sg regionopenapi.SecurityGroupV2Read
+	if err := json.Unmarshal(respBody, &sg); err != nil {
+		return nil, fmt.Errorf("unmarshaling security group: %w", err)
+	}
+
+	return &sg, nil
+}
+
+// DeleteSecurityGroup deletes a security group.
+func (c *APIClient) DeleteSecurityGroup(ctx context.Context, securityGroupID string) error {
+	path := c.endpoints.DeleteSecurityGroup(securityGroupID)
+
+	//nolint:bodyclose // DoRequest handles response body closing internally
+	resp, _, err := c.regionClient.DoRequest(ctx, http.MethodDelete, path, nil, 0)
+	if err != nil {
+		return fmt.Errorf("deleting security group: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("security group '%s': %w", securityGroupID, coreclient.ErrResourceNotFound)
+	default:
+		return fmt.Errorf("deleting security group: status %d: %w", resp.StatusCode, coreclient.ErrUnexpectedStatus)
+	}
+}
+
 // ListFileStorage lists all file storage resources for a project in a region.
 func (c *APIClient) ListFileStorage(ctx context.Context, orgID, projectID, regionID string) (regionopenapi.StorageV2List, error) {
 	path := c.endpoints.ListFileStorage(orgID, projectID, regionID)

--- a/test/api/endpoints.go
+++ b/test/api/endpoints.go
@@ -131,6 +131,32 @@ func (e *Endpoints) DeleteNetwork(networkID string) string {
 		url.PathEscape(networkID))
 }
 
+// ListSecurityGroups returns the endpoint for listing security groups filtered by org, project and region.
+func (e *Endpoints) ListSecurityGroups(orgID, projectID, regionID string) string {
+	return fmt.Sprintf("/api/v2/securitygroups?organizationID=%s&projectID=%s&regionID=%s",
+		url.QueryEscape(orgID), url.QueryEscape(projectID), url.QueryEscape(regionID))
+}
+
+// CreateSecurityGroup returns the endpoint for creating a security group.
+func (e *Endpoints) CreateSecurityGroup() string {
+	return "/api/v2/securitygroups"
+}
+
+// GetSecurityGroup returns the endpoint for getting a specific security group.
+func (e *Endpoints) GetSecurityGroup(securityGroupID string) string {
+	return fmt.Sprintf("/api/v2/securitygroups/%s", url.PathEscape(securityGroupID))
+}
+
+// UpdateSecurityGroup returns the endpoint for updating a specific security group.
+func (e *Endpoints) UpdateSecurityGroup(securityGroupID string) string {
+	return fmt.Sprintf("/api/v2/securitygroups/%s", url.PathEscape(securityGroupID))
+}
+
+// DeleteSecurityGroup returns the endpoint for deleting a specific security group.
+func (e *Endpoints) DeleteSecurityGroup(securityGroupID string) string {
+	return fmt.Sprintf("/api/v2/securitygroups/%s", url.PathEscape(securityGroupID))
+}
+
 // ListLoadBalancers returns the endpoint for listing load balancers in a project.
 func (e *Endpoints) ListLoadBalancers(orgID, projectID, regionID string) string {
 	return fmt.Sprintf("/api/v2/loadbalancers?organizationID=%s&projectID=%s&regionID=%s",

--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -267,6 +267,51 @@ func (b *SSHCertificateAuthorityPayloadBuilder) Build() regionopenapi.SshCertifi
 	return b.ca
 }
 
+// SecurityGroupPayloadBuilder builds SecurityGroupV2Create payloads for testing.
+type SecurityGroupPayloadBuilder struct {
+	sg regionopenapi.SecurityGroupV2Create
+}
+
+// NewSecurityGroupPayload creates a builder pre-loaded with a single allow-all TCP ingress rule.
+func NewSecurityGroupPayload(networkID string) *SecurityGroupPayloadBuilder {
+	port := 22
+
+	return &SecurityGroupPayloadBuilder{
+		sg: regionopenapi.SecurityGroupV2Create{
+			Metadata: coreapi.ResourceWriteMetadata{
+				Name: uniqueName("sg"),
+			},
+			Spec: regionopenapi.SecurityGroupV2CreateSpec{
+				NetworkId: networkID,
+				Rules: regionopenapi.SecurityGroupRuleV2List{
+					{
+						Direction: regionopenapi.NetworkDirectionIngress,
+						Protocol:  regionopenapi.NetworkProtocolTcp,
+						Port:      &port,
+					},
+				},
+			},
+		},
+	}
+}
+
+// WithName overrides the security group name.
+func (b *SecurityGroupPayloadBuilder) WithName(name string) *SecurityGroupPayloadBuilder {
+	b.sg.Metadata.Name = name
+	return b
+}
+
+// WithRules overrides the rule list.
+func (b *SecurityGroupPayloadBuilder) WithRules(rules regionopenapi.SecurityGroupRuleV2List) *SecurityGroupPayloadBuilder {
+	b.sg.Spec.Rules = rules
+	return b
+}
+
+// Build returns the typed SecurityGroupV2Create struct.
+func (b *SecurityGroupPayloadBuilder) Build() regionopenapi.SecurityGroupV2Create {
+	return b.sg
+}
+
 // WaitForImageReady polls until the image appears in the region with state ready.
 // Uses a 1-hour timeout to accommodate image download and import times.
 func WaitForImageReady(c *APIClient, ctx context.Context, config *TestConfig, imageID string) {

--- a/test/api/suites/securitygroups_test.go
+++ b/test/api/suites/securitygroups_test.go
@@ -1,0 +1,165 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,testpackage,gci // dot imports and package naming standard for Ginkgo, import grouping
+package suites
+
+import (
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/utils/ptr"
+
+	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
+	regionopenapi "github.com/unikorn-cloud/region/pkg/openapi"
+	"github.com/unikorn-cloud/region/test/api"
+)
+
+var _ = Describe("SecurityGroup", func() {
+	Context("When managing security groups", Ordered, func() {
+		var networkID string
+		var sgID string
+		var createReq regionopenapi.SecurityGroupV2Create
+
+		BeforeAll(func() {
+			network, err := regionClient.CreateNetwork(ctx, api.NewNetworkPayload(config.OrgID, config.ProjectID, config.RegionID).Build())
+			Expect(err).NotTo(HaveOccurred(), "failed to create network fixture")
+			networkID = network.Metadata.Id
+			DeferCleanup(func() {
+				GinkgoWriter.Printf("Cleaning up network fixture: %s\n", networkID)
+				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
+			})
+			GinkgoWriter.Printf("Created network fixture: %s\n", networkID)
+
+			createReq = api.NewSecurityGroupPayload(networkID).Build()
+			created, err := regionClient.CreateSecurityGroup(ctx, createReq)
+			Expect(err).NotTo(HaveOccurred(), "failed to create security group fixture")
+			sgID = created.Metadata.Id
+			DeferCleanup(func() {
+				if sgID == "" {
+					return
+				}
+				GinkgoWriter.Printf("Cleaning up security group: %s\n", sgID)
+				Expect(regionClient.DeleteSecurityGroup(ctx, sgID)).To(Succeed())
+			})
+			GinkgoWriter.Printf("Created security group: %s (%s)\n", created.Metadata.Name, sgID)
+		})
+
+		Describe("Given a network fixture and valid configuration", func() {
+			It("should create a security group with correct response fields", func() {
+				Expect(sgID).NotTo(BeEmpty())
+				Expect(createReq.Metadata.Name).NotTo(BeEmpty())
+
+				got, err := regionClient.GetSecurityGroup(ctx, sgID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(got.Metadata.Id).To(Equal(sgID))
+				Expect(got.Metadata.Name).To(Equal(createReq.Metadata.Name))
+				Expect(got.Metadata.OrganizationId).To(Equal(config.OrgID))
+				Expect(got.Metadata.ProjectId).To(Equal(config.ProjectID))
+				Expect(got.Status.RegionId).To(Equal(config.RegionID))
+				Expect(got.Status.NetworkId).To(Equal(networkID))
+				Expect(got.Spec.Rules).To(HaveLen(1))
+				Expect(got.Spec.Rules[0].Direction).To(Equal(regionopenapi.NetworkDirectionIngress))
+				Expect(got.Spec.Rules[0].Protocol).To(Equal(regionopenapi.NetworkProtocolTcp))
+				Expect(got.Spec.Rules[0].Port).To(Equal(ptr.To(22)))
+			})
+
+			It("should appear in the list filtered by org, project and region", func() {
+				list, err := regionClient.ListSecurityGroups(ctx, config.OrgID, config.ProjectID, config.RegionID)
+				Expect(err).NotTo(HaveOccurred())
+
+				var found *regionopenapi.SecurityGroupV2Read
+				for i := range list {
+					if list[i].Metadata.Id == sgID {
+						found = &list[i]
+						break
+					}
+				}
+
+				Expect(found).NotTo(BeNil(), "created security group %s not found in list", sgID)
+				Expect(found.Metadata.Name).To(Equal(createReq.Metadata.Name))
+				Expect(found.Status.NetworkId).To(Equal(networkID))
+				GinkgoWriter.Printf("Found security group in list: %s\n", sgID)
+			})
+
+			It("should update rules and verify the change persists on re-GET", func() {
+				updatedPort := 443
+				updateReq := regionopenapi.SecurityGroupV2Update{
+					Metadata: coreapi.ResourceWriteMetadata{
+						Name: createReq.Metadata.Name,
+					},
+					Spec: regionopenapi.SecurityGroupV2Spec{
+						Rules: regionopenapi.SecurityGroupRuleV2List{
+							{
+								Direction: regionopenapi.NetworkDirectionIngress,
+								Protocol:  regionopenapi.NetworkProtocolTcp,
+								Port:      &updatedPort,
+							},
+							{
+								Direction: regionopenapi.NetworkDirectionEgress,
+								Protocol:  regionopenapi.NetworkProtocolAny,
+							},
+						},
+					},
+				}
+
+				updated, err := regionClient.UpdateSecurityGroup(ctx, sgID, updateReq)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated.Spec.Rules).To(HaveLen(2))
+
+				roundTrip, err := regionClient.GetSecurityGroup(ctx, sgID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(roundTrip.Spec.Rules).To(HaveLen(2))
+				Expect(roundTrip.Spec.Rules[0].Port).To(Equal(ptr.To(443)))
+				GinkgoWriter.Printf("Updated security group rules: %s\n", sgID)
+			})
+
+			It("should delete the security group and confirm it is no longer found", func() {
+				deletedID := sgID
+				Expect(regionClient.DeleteSecurityGroup(ctx, deletedID)).To(Succeed())
+				sgID = "" // suppress DeferCleanup — already deleted
+				GinkgoWriter.Printf("Deleted security group: %s\n", deletedID)
+
+				Eventually(func() error {
+					_, err := regionClient.GetSecurityGroup(ctx, deletedID)
+					return err
+				}).WithTimeout(30*time.Second).
+					WithPolling(2*time.Second).
+					Should(And(HaveOccurred(), MatchError(coreclient.ErrResourceNotFound)),
+						"deleted security group should eventually return not found")
+
+				GinkgoWriter.Printf("Confirmed security group deleted: %s\n", deletedID)
+			})
+		})
+	})
+
+	Context("When getting a non-existent security group", func() {
+		Describe("Given a non-existent security group ID", func() {
+			It("should return not found", func() {
+				_, err := regionClient.GetSecurityGroup(ctx, "00000000-0000-0000-0000-000000000000")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+})

--- a/test/api/suites/sshcertificateauthorities_test.go
+++ b/test/api/suites/sshcertificateauthorities_test.go
@@ -22,6 +22,7 @@ package suites
 
 import (
 	"errors"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -90,9 +91,10 @@ var _ = Describe("SSHCertificateAuthority", func() {
 				Expect(regionClient.DeleteSSHCertificateAuthority(ctx, caID)).To(Succeed())
 				GinkgoWriter.Printf("Deleted ssh certificate authority: %s\n", caID)
 
-				_, err := regionClient.GetSSHCertificateAuthority(ctx, caID)
-				Expect(err).To(HaveOccurred())
-				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue(),
+				Eventually(func() bool {
+					_, err := regionClient.GetSSHCertificateAuthority(ctx, caID)
+					return errors.Is(err, coreclient.ErrResourceNotFound)
+				}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(BeTrue(),
 					"deleted ssh certificate authority should return not found")
 				GinkgoWriter.Printf("Confirmed ssh certificate authority deleted: %s\n", caID)
 			})


### PR DESCRIPTION
## Summary

- Adds `test/api/suites/securitygroups_test.go` with a full CRUD lifecycle test for the Security Groups v2 API (`POST`, `LIST`, `GET`, `PUT`, `DELETE`) and a negative test for non-existent IDs
- Adds typed client methods (`CreateSecurityGroup`, `ListSecurityGroups`, `GetSecurityGroup`, `UpdateSecurityGroup`, `DeleteSecurityGroup`) to `test/api/api_client.go`
- Adds v2 security group endpoints to `test/api/endpoints.go`
- Adds `SecurityGroupPayloadBuilder` to `test/api/fixtures.go`
- Enables `CreateSecurityGroup`/`DeleteSecurityGroup` in the simulated provider (previously returned `unsupported`); security groups require no cloud-side provisioning in simulation, so both are no-ops. Without this the controller continuously retried reconciliation in the KIND/CI environment, causing optimistic-lock conflicts on the update test.
- Fixes pre-existing incorrect query parameter casing in `test/api/endpoints.go` — `organizationId`, `projectId`, `regionId` corrected to `organizationID`, `projectID`, `regionID` to match the OpenAPI spec across the `networks`, `loadbalancers`, `filestorage`, and `filestorageclasses` endpoints.
- Fixes pre-existing SSH CA delete test: polls with `Eventually` until the resource is gone rather than checking immediately after the async `202 Accepted` response.

Closes INST-870

## Test plan

- [x] `make test-api-focus FOCUS="SecurityGroup"` — 9/9 specs pass against dev environment