### PR TITLE
Add script for configuring a region in OpenStack

### DIFF
--- a/hack/openstack/configure
+++ b/hack/openstack/configure
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# Configure a generic OpenStack cloud for the Region OpenStack provider.
+set -euo pipefail
+
+OPENSTACK_CLI="${OPENSTACK_CLI:-openstack}"
+OPENRC_FILE=""
+OUTPUT_FILE=""
+MODE="${UNIKORN_OPENSTACK_CONFIGURE_MODE:-create}"
+PREFIX_OVERRIDE=""
+DOMAIN_NAME_OVERRIDE=""
+PROJECT_NAME_OVERRIDE=""
+USER_NAME_OVERRIDE=""
+PASSWORD_OVERRIDE=""
+
+log() {
+  echo "==> $*" >&2
+}
+
+fatal() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || fatal "$1 is required"
+}
+
+shell_quote() {
+  local value="$1"
+
+  printf "'"
+  printf "%s" "${value}" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+emit_env() {
+  printf "%s=%s\n" "$1" "$(shell_quote "$2")"
+}
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 [--openrc FILE] [--output FILE] [--mode create|existing]
+
+Configures an existing OpenStack cloud for the Region OpenStack provider and
+emits a shell-compatible provider env file.
+
+Inputs:
+  Standard OpenStack CLI auth environment, OS_CLOUD, or --openrc FILE.
+
+Common environment overrides:
+  UNIKORN_OPENSTACK_PREFIX
+  UNIKORN_OPENSTACK_DOMAIN_NAME
+  UNIKORN_OPENSTACK_PROJECT_NAME
+  UNIKORN_OPENSTACK_USER_NAME
+  UNIKORN_OPENSTACK_PASSWORD
+  UNIKORN_OPENSTACK_DOMAIN_ROLES
+  UNIKORN_OPENSTACK_PROJECT_ROLES
+  UNIKORN_OPENSTACK_INCLUDE_LEGACY_MEMBER_ROLE=true
+
+Modes:
+  create    Create or update the domain, project, user, and role grants.
+  existing  Re-emit an already supplied UNIKORN_OPENSTACK_* provider env.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --openrc)
+      OPENRC_FILE="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_FILE="$2"
+      shift 2
+      ;;
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --prefix)
+      PREFIX_OVERRIDE="$2"
+      shift 2
+      ;;
+    --domain-name)
+      DOMAIN_NAME_OVERRIDE="$2"
+      shift 2
+      ;;
+    --project-name)
+      PROJECT_NAME_OVERRIDE="$2"
+      shift 2
+      ;;
+    --user-name)
+      USER_NAME_OVERRIDE="$2"
+      shift 2
+      ;;
+    --password)
+      PASSWORD_OVERRIDE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fatal "unknown argument: $1"
+      ;;
+  esac
+done
+
+case "${MODE}" in
+  create|existing)
+    ;;
+  *)
+    fatal "--mode must be create or existing"
+    ;;
+esac
+
+if [[ -n "${OPENRC_FILE}" ]]; then
+  [[ -f "${OPENRC_FILE}" ]] || fatal "openrc file not found: ${OPENRC_FILE}"
+  # shellcheck disable=SC1090
+  . "${OPENRC_FILE}"
+fi
+
+PREFIX="${PREFIX_OVERRIDE:-${UNIKORN_OPENSTACK_PREFIX:-unikorn-openstack}}"
+DOMAIN_NAME="${DOMAIN_NAME_OVERRIDE:-${UNIKORN_OPENSTACK_DOMAIN_NAME:-${PREFIX}}}"
+PROJECT_NAME="${PROJECT_NAME_OVERRIDE:-${UNIKORN_OPENSTACK_PROJECT_NAME:-${PREFIX}-provider}}"
+USER_NAME="${USER_NAME_OVERRIDE:-${UNIKORN_OPENSTACK_USER_NAME:-${PREFIX}-provider}}"
+PASSWORD="${PASSWORD_OVERRIDE:-${UNIKORN_OPENSTACK_PASSWORD:-}}"
+DOMAIN_ROLES="${UNIKORN_OPENSTACK_DOMAIN_ROLES:-member load-balancer_member manager}"
+PROJECT_ROLES="${UNIKORN_OPENSTACK_PROJECT_ROLES:-member manager}"
+CREATE_MISSING_ROLES="${UNIKORN_OPENSTACK_CREATE_MISSING_ROLES:-true}"
+DISCOVER_EXTERNAL_NETWORK="${UNIKORN_OPENSTACK_DISCOVER_EXTERNAL_NETWORK:-true}"
+
+if [[ "${UNIKORN_OPENSTACK_INCLUDE_LEGACY_MEMBER_ROLE:-false}" == "true" ]]; then
+  DOMAIN_ROLES="${DOMAIN_ROLES} _member_"
+  PROJECT_ROLES="${PROJECT_ROLES} _member_"
+fi
+
+auth_url() {
+  local value="${UNIKORN_OPENSTACK_AUTH_URL:-${OS_AUTH_URL:-}}"
+
+  if [[ -z "${value}" ]] && command -v "${OPENSTACK_CLI}" >/dev/null 2>&1; then
+    value="$("${OPENSTACK_CLI}" configuration show -f value -c auth.auth_url 2>/dev/null | awk 'NF { print; exit }' || true)"
+  fi
+
+  [[ -n "${value}" ]] || fatal "UNIKORN_OPENSTACK_AUTH_URL, OS_AUTH_URL, or a resolvable OS_CLOUD is required"
+  echo "${value}"
+}
+
+generate_password() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 18
+    return
+  fi
+
+  printf "unikorn%s\n" "$(date +%s)"
+}
+
+role_exists() {
+  local role="$1"
+
+  "${OPENSTACK_CLI}" role show "${role}" >/dev/null 2>&1
+}
+
+ensure_role() {
+  local role="$1"
+
+  if role_exists "${role}"; then
+    return 0
+  fi
+
+  if [[ "${CREATE_MISSING_ROLES}" != "true" ]]; then
+    log "Skipping missing OpenStack role ${role}; UNIKORN_OPENSTACK_CREATE_MISSING_ROLES=false."
+    return 1
+  fi
+
+  log "Creating role ${role}..."
+  "${OPENSTACK_CLI}" role create "${role}" >/dev/null
+}
+
+ensure_domain() {
+  local domain="$1"
+  local id
+
+  if [[ -n "${UNIKORN_OPENSTACK_DOMAIN_ID:-}" ]]; then
+    echo "${UNIKORN_OPENSTACK_DOMAIN_ID}"
+    return
+  fi
+
+  if id="$("${OPENSTACK_CLI}" domain show "${domain}" -f value -c id 2>/dev/null)"; then
+    "${OPENSTACK_CLI}" domain set --enable "${id}" >/dev/null
+    echo "${id}"
+    return
+  fi
+
+  log "Creating domain ${domain}..."
+  "${OPENSTACK_CLI}" domain create "${domain}" --enable -f value -c id
+}
+
+ensure_project() {
+  local domain_id="$1"
+  local project="$2"
+  local id
+
+  if [[ -n "${UNIKORN_OPENSTACK_PROJECT_ID:-}" ]]; then
+    echo "${UNIKORN_OPENSTACK_PROJECT_ID}"
+    return
+  fi
+
+  if id="$("${OPENSTACK_CLI}" project show "${project}" --domain "${domain_id}" -f value -c id 2>/dev/null)"; then
+    echo "${id}"
+    return
+  fi
+
+  log "Creating project ${project}..."
+  "${OPENSTACK_CLI}" project create "${project}" --domain "${domain_id}" -f value -c id
+}
+
+ensure_user() {
+  local domain_id="$1"
+  local user="$2"
+  local password="$3"
+  local id
+
+  if [[ -n "${UNIKORN_OPENSTACK_USER_ID:-}" ]]; then
+    echo "${UNIKORN_OPENSTACK_USER_ID}"
+    return
+  fi
+
+  if id="$("${OPENSTACK_CLI}" user show "${user}" --domain "${domain_id}" -f value -c id 2>/dev/null)"; then
+    "${OPENSTACK_CLI}" user set --enable --password "${password}" "${id}" >/dev/null
+    echo "${id}"
+    return
+  fi
+
+  log "Creating user ${user}..."
+  "${OPENSTACK_CLI}" user create "${user}" --domain "${domain_id}" --password "${password}" --enable -f value -c id
+}
+
+assign_role_to_domain() {
+  local role="$1"
+  local user_id="$2"
+  local domain_id="$3"
+  local output
+
+  if output="$("${OPENSTACK_CLI}" role add --user "${user_id}" --domain "${domain_id}" "${role}" 2>&1)"; then
+    return
+  fi
+
+  if grep -qiE 'already|conflict|duplicate' <<<"${output}"; then
+    return
+  fi
+
+  echo "${output}" >&2
+  return 1
+}
+
+assign_role_to_project() {
+  local role="$1"
+  local user_id="$2"
+  local project_id="$3"
+  local output
+
+  if output="$("${OPENSTACK_CLI}" role add --user "${user_id}" --project "${project_id}" "${role}" 2>&1)"; then
+    return
+  fi
+
+  if grep -qiE 'already|conflict|duplicate' <<<"${output}"; then
+    return
+  fi
+
+  echo "${output}" >&2
+  return 1
+}
+
+first_external_network_id() {
+  "${OPENSTACK_CLI}" network list --external -f value -c ID 2>/dev/null | awk 'NR == 1 { print; exit }' || true
+}
+
+emit_provider_env() {
+  local auth_url_value="$1"
+  local domain_id="$2"
+  local project_id="$3"
+  local user_id="$4"
+  local password="$5"
+  local external_network_id="$6"
+
+  emit_env UNIKORN_OPENSTACK_AUTH_URL "${auth_url_value}"
+  emit_env UNIKORN_OPENSTACK_DOMAIN_ID "${domain_id}"
+  emit_env UNIKORN_OPENSTACK_PROJECT_ID "${project_id}"
+  emit_env UNIKORN_OPENSTACK_USER_ID "${user_id}"
+  emit_env UNIKORN_OPENSTACK_PASSWORD "${password}"
+  emit_env UNIKORN_OPENSTACK_DOMAIN_NAME "${DOMAIN_NAME}"
+  emit_env UNIKORN_OPENSTACK_PROJECT_NAME "${PROJECT_NAME}"
+  emit_env UNIKORN_OPENSTACK_USER_NAME "${USER_NAME}"
+
+  if [[ -n "${external_network_id}" ]]; then
+    emit_env UNIKORN_OPENSTACK_EXTERNAL_NETWORK_ID "${external_network_id}"
+  fi
+
+  if [[ -n "${UNIKORN_OPENSTACK_FLAVOR_ID:-}" ]]; then
+    emit_env UNIKORN_OPENSTACK_FLAVOR_ID "${UNIKORN_OPENSTACK_FLAVOR_ID}"
+  fi
+
+  if [[ -n "${UNIKORN_OPENSTACK_IMAGE_ID:-}" ]]; then
+    emit_env UNIKORN_OPENSTACK_IMAGE_ID "${UNIKORN_OPENSTACK_IMAGE_ID}"
+  fi
+}
+
+configure_existing() {
+  local external_network_id="${UNIKORN_OPENSTACK_EXTERNAL_NETWORK_ID:-}"
+
+  [[ -n "${UNIKORN_OPENSTACK_DOMAIN_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_DOMAIN_ID is required in existing mode"
+  [[ -n "${UNIKORN_OPENSTACK_PROJECT_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_PROJECT_ID is required in existing mode"
+  [[ -n "${UNIKORN_OPENSTACK_USER_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_USER_ID is required in existing mode"
+  [[ -n "${PASSWORD}" ]] || fatal "UNIKORN_OPENSTACK_PASSWORD is required in existing mode"
+
+  if [[ -z "${external_network_id}" && "${DISCOVER_EXTERNAL_NETWORK}" == "true" ]] && command -v "${OPENSTACK_CLI}" >/dev/null 2>&1; then
+    external_network_id="$(first_external_network_id)"
+  fi
+
+  emit_provider_env "$(auth_url)" "${UNIKORN_OPENSTACK_DOMAIN_ID}" "${UNIKORN_OPENSTACK_PROJECT_ID}" "${UNIKORN_OPENSTACK_USER_ID}" "${PASSWORD}" "${external_network_id}"
+}
+
+configure_created() {
+  local domain_id
+  local project_id
+  local user_id
+  local external_network_id="${UNIKORN_OPENSTACK_EXTERNAL_NETWORK_ID:-}"
+  local role
+
+  require "${OPENSTACK_CLI}"
+
+  if [[ -n "${UNIKORN_OPENSTACK_USER_ID:-}" && -z "${PASSWORD}" ]]; then
+    fatal "UNIKORN_OPENSTACK_PASSWORD is required when UNIKORN_OPENSTACK_USER_ID is supplied"
+  fi
+
+  if [[ -z "${PASSWORD}" ]]; then
+    PASSWORD="$(generate_password)"
+  fi
+
+  log "Checking OpenStack credentials..."
+  "${OPENSTACK_CLI}" token issue >/dev/null
+
+  domain_id="$(ensure_domain "${DOMAIN_NAME}")"
+  project_id="$(ensure_project "${domain_id}" "${PROJECT_NAME}")"
+  user_id="$(ensure_user "${domain_id}" "${USER_NAME}" "${PASSWORD}")"
+
+  for role in ${DOMAIN_ROLES}; do
+    if ensure_role "${role}"; then
+      assign_role_to_domain "${role}" "${user_id}" "${domain_id}"
+    fi
+  done
+
+  for role in ${PROJECT_ROLES}; do
+    if ensure_role "${role}"; then
+      assign_role_to_project "${role}" "${user_id}" "${project_id}"
+    fi
+  done
+
+  if [[ -z "${external_network_id}" && "${DISCOVER_EXTERNAL_NETWORK}" == "true" ]]; then
+    external_network_id="$(first_external_network_id)"
+  fi
+
+  emit_provider_env "$(auth_url)" "${domain_id}" "${project_id}" "${user_id}" "${PASSWORD}" "${external_network_id}"
+}
+
+emit_output() {
+  if [[ "${MODE}" == "existing" ]]; then
+    configure_existing
+    return
+  fi
+
+  configure_created
+}
+
+if [[ -n "${OUTPUT_FILE}" ]]; then
+  tmp_output=""
+
+  mkdir -p "$(dirname "${OUTPUT_FILE}")"
+
+  tmp_output="$(mktemp "${OUTPUT_FILE}.XXXXXX")"
+
+  if emit_output > "${tmp_output}" && mv "${tmp_output}" "${OUTPUT_FILE}"; then
+    log "OpenStack provider configuration written to ${OUTPUT_FILE}."
+  else
+    rm -f "${tmp_output}"
+    exit 1
+  fi
+else
+  emit_output
+fi

--- a/hack/openstack/configure
+++ b/hack/openstack/configure
@@ -11,6 +11,8 @@ DOMAIN_NAME_OVERRIDE=""
 PROJECT_NAME_OVERRIDE=""
 USER_NAME_OVERRIDE=""
 PASSWORD_OVERRIDE=""
+ROTATE_PASSWORD="${UNIKORN_OPENSTACK_ROTATE_PASSWORD:-false}"
+USER_ID=""
 
 log() {
   echo "==> $*" >&2
@@ -39,7 +41,7 @@ emit_env() {
 
 usage() {
   cat >&2 <<EOF
-Usage: $0 [--openrc FILE] [--output FILE] [--mode create|existing]
+Usage: $0 [--openrc FILE] [--output FILE] [--mode create|existing] [--rotate-password]
 
 Configures an existing OpenStack cloud for the Region OpenStack provider and
 emits a shell-compatible provider env file.
@@ -56,10 +58,14 @@ Common environment overrides:
   UNIKORN_OPENSTACK_DOMAIN_ROLES
   UNIKORN_OPENSTACK_PROJECT_ROLES
   UNIKORN_OPENSTACK_INCLUDE_LEGACY_MEMBER_ROLE=true
+  UNIKORN_OPENSTACK_ROTATE_PASSWORD=true
 
 Modes:
   create    Create or update the domain, project, user, and role grants.
   existing  Re-emit an already supplied UNIKORN_OPENSTACK_* provider env.
+
+By default, an existing provider user's password is never changed. Set
+UNIKORN_OPENSTACK_ROTATE_PASSWORD=true or pass --rotate-password to reset it.
 EOF
 }
 
@@ -96,6 +102,10 @@ while [[ $# -gt 0 ]]; do
     --password)
       PASSWORD_OVERRIDE="$2"
       shift 2
+      ;;
+    --rotate-password)
+      ROTATE_PASSWORD="true"
+      shift
       ;;
     -h|--help)
       usage
@@ -219,22 +229,52 @@ ensure_project() {
 ensure_user() {
   local domain_id="$1"
   local user="$2"
-  local password="$3"
   local id
 
   if [[ -n "${UNIKORN_OPENSTACK_USER_ID:-}" ]]; then
-    echo "${UNIKORN_OPENSTACK_USER_ID}"
+    if [[ -z "${PASSWORD}" ]]; then
+      if [[ "${ROTATE_PASSWORD}" == "true" ]]; then
+        PASSWORD="$(generate_password)"
+      else
+        fatal "--password or UNIKORN_OPENSTACK_PASSWORD is required when UNIKORN_OPENSTACK_USER_ID is supplied"
+      fi
+    fi
+
+    if [[ "${ROTATE_PASSWORD}" == "true" ]]; then
+      log "Resetting password for existing user ${UNIKORN_OPENSTACK_USER_ID}..."
+      "${OPENSTACK_CLI}" user set --enable --password "${PASSWORD}" "${UNIKORN_OPENSTACK_USER_ID}" >/dev/null
+    fi
+
+    USER_ID="${UNIKORN_OPENSTACK_USER_ID}"
     return
   fi
 
   if id="$("${OPENSTACK_CLI}" user show "${user}" --domain "${domain_id}" -f value -c id 2>/dev/null)"; then
-    "${OPENSTACK_CLI}" user set --enable --password "${password}" "${id}" >/dev/null
-    echo "${id}"
+    if [[ -z "${PASSWORD}" ]]; then
+      if [[ "${ROTATE_PASSWORD}" == "true" ]]; then
+        PASSWORD="$(generate_password)"
+      else
+        fatal "provider user ${user} already exists; supply --password or UNIKORN_OPENSTACK_PASSWORD, or pass --rotate-password to reset it"
+      fi
+    fi
+
+    if [[ "${ROTATE_PASSWORD}" == "true" ]]; then
+      log "Resetting password for existing user ${user}..."
+      "${OPENSTACK_CLI}" user set --enable --password "${PASSWORD}" "${id}" >/dev/null
+    else
+      "${OPENSTACK_CLI}" user set --enable "${id}" >/dev/null
+    fi
+
+    USER_ID="${id}"
     return
   fi
 
+  if [[ -z "${PASSWORD}" ]]; then
+    PASSWORD="$(generate_password)"
+  fi
+
   log "Creating user ${user}..."
-  "${OPENSTACK_CLI}" user create "${user}" --domain "${domain_id}" --password "${password}" --enable -f value -c id
+  USER_ID="$("${OPENSTACK_CLI}" user create "${user}" --domain "${domain_id}" --password "${PASSWORD}" --enable -f value -c id)"
 }
 
 assign_role_to_domain() {
@@ -331,20 +371,13 @@ configure_created() {
 
   require "${OPENSTACK_CLI}"
 
-  if [[ -n "${UNIKORN_OPENSTACK_USER_ID:-}" && -z "${PASSWORD}" ]]; then
-    fatal "UNIKORN_OPENSTACK_PASSWORD is required when UNIKORN_OPENSTACK_USER_ID is supplied"
-  fi
-
-  if [[ -z "${PASSWORD}" ]]; then
-    PASSWORD="$(generate_password)"
-  fi
-
   log "Checking OpenStack credentials..."
   "${OPENSTACK_CLI}" token issue >/dev/null
 
   domain_id="$(ensure_domain "${DOMAIN_NAME}")"
   project_id="$(ensure_project "${domain_id}" "${PROJECT_NAME}")"
-  user_id="$(ensure_user "${domain_id}" "${USER_NAME}" "${PASSWORD}")"
+  ensure_user "${domain_id}" "${USER_NAME}"
+  user_id="${USER_ID}"
 
   for role in ${DOMAIN_ROLES}; do
     if ensure_role "${role}"; then

--- a/hack/openstack/register-region
+++ b/hack/openstack/register-region
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Register an OpenStack-backed Region CR in the current Kubernetes cluster.
+set -euo pipefail
+
+NAMESPACE="${REGION_NAMESPACE:-}"
+REGION_ID="${REGION_ID:-}"
+DISPLAY_NAME="${REGION_DISPLAY_NAME:-}"
+SECRET_NAME="${OPENSTACK_SECRET_NAME:-}"
+ORGANIZATION_ID="${REGION_ORGANIZATION_ID:-}"
+PROVIDER_ENV_FILE=""
+
+log() {
+  echo "==> $*" >&2
+}
+
+fatal() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || fatal "$1 is required"
+}
+
+shell_quote() {
+  local value="$1"
+
+  printf "'"
+  printf "%s" "${value}" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+emit_env() {
+  printf "%s=%s\n" "$1" "$(shell_quote "$2")"
+}
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 [--provider-env FILE] --namespace NS [--region-id ID] [--display-name NAME] [--secret-name NAME] [--organization-id ID]
+
+Environment:
+  UNIKORN_OPENSTACK_AUTH_URL
+  UNIKORN_OPENSTACK_DOMAIN_ID
+  UNIKORN_OPENSTACK_PROJECT_ID
+  UNIKORN_OPENSTACK_USER_ID
+  UNIKORN_OPENSTACK_PASSWORD
+  REGION_NAMESPACE
+  REGION_ID
+  REGION_DISPLAY_NAME
+  OPENSTACK_SECRET_NAME
+  REGION_ORGANIZATION_ID
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --provider-env)
+      PROVIDER_ENV_FILE="$2"
+      shift 2
+      ;;
+    --namespace)
+      NAMESPACE="$2"
+      shift 2
+      ;;
+    --region-id)
+      REGION_ID="$2"
+      shift 2
+      ;;
+    --display-name)
+      DISPLAY_NAME="$2"
+      shift 2
+      ;;
+    --secret-name)
+      SECRET_NAME="$2"
+      shift 2
+      ;;
+    --organization-id)
+      ORGANIZATION_ID="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fatal "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [[ -n "${PROVIDER_ENV_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  . "${PROVIDER_ENV_FILE}"
+fi
+
+REGION_ID="${REGION_ID:-${OPENSTACK_REGION_ID:-devstack}}"
+DISPLAY_NAME="${DISPLAY_NAME:-${OPENSTACK_REGION_NAME:-DevStack}}"
+SECRET_NAME="${SECRET_NAME:-${REGION_ID}-openstack-credentials}"
+
+require kubectl
+
+[[ -n "${NAMESPACE}" ]] || fatal "--namespace or REGION_NAMESPACE is required"
+[[ -n "${UNIKORN_OPENSTACK_AUTH_URL:-}" ]] || fatal "UNIKORN_OPENSTACK_AUTH_URL is required"
+[[ -n "${UNIKORN_OPENSTACK_DOMAIN_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_DOMAIN_ID is required"
+[[ -n "${UNIKORN_OPENSTACK_PROJECT_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_PROJECT_ID is required"
+[[ -n "${UNIKORN_OPENSTACK_USER_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_USER_ID is required"
+[[ -n "${UNIKORN_OPENSTACK_PASSWORD:-}" ]] || fatal "UNIKORN_OPENSTACK_PASSWORD is required"
+
+log "Applying OpenStack credential Secret ${NAMESPACE}/${SECRET_NAME}..."
+kubectl create secret generic "${SECRET_NAME}" \
+  --namespace "${NAMESPACE}" \
+  --from-literal="domain-id=${UNIKORN_OPENSTACK_DOMAIN_ID}" \
+  --from-literal="project-id=${UNIKORN_OPENSTACK_PROJECT_ID}" \
+  --from-literal="user-id=${UNIKORN_OPENSTACK_USER_ID}" \
+  --from-literal="password=${UNIKORN_OPENSTACK_PASSWORD}" \
+  --dry-run=client \
+  -o yaml | kubectl apply -f - >&2
+
+security_block=""
+if [[ -n "${ORGANIZATION_ID}" ]]; then
+  security_block=$(cat <<EOF
+  security:
+    organizations:
+    - id: ${ORGANIZATION_ID}
+EOF
+)
+fi
+
+network_block=""
+if [[ -n "${UNIKORN_OPENSTACK_EXTERNAL_NETWORK_ID:-}" ]]; then
+  network_block=$(cat <<EOF
+    network:
+      externalNetworks:
+        selector:
+          ids:
+          - ${UNIKORN_OPENSTACK_EXTERNAL_NETWORK_ID}
+EOF
+)
+fi
+
+flavor_block=""
+if [[ -n "${UNIKORN_OPENSTACK_FLAVOR_ID:-}" ]]; then
+  flavor_block=$(cat <<EOF
+    compute:
+      flavors:
+        selector:
+          ids:
+          - ${UNIKORN_OPENSTACK_FLAVOR_ID}
+EOF
+)
+fi
+
+log "Applying OpenStack Region ${NAMESPACE}/${REGION_ID}..."
+cat <<EOF | kubectl apply -f - >&2
+apiVersion: region.unikorn-cloud.org/v1alpha1
+kind: Region
+metadata:
+  name: ${REGION_ID}
+  namespace: ${NAMESPACE}
+  labels:
+    unikorn-cloud.org/name: ${DISPLAY_NAME}
+spec:
+${security_block}
+  provider: openstack
+  openstack:
+    endpoint: ${UNIKORN_OPENSTACK_AUTH_URL}
+    serviceAccountSecret:
+      namespace: ${NAMESPACE}
+      name: ${SECRET_NAME}
+    identity:
+      clusterRoles:
+      - member
+      - load-balancer_member
+${flavor_block}
+${network_block}
+EOF
+
+emit_env REGION_PROVIDER openstack
+emit_env OPENSTACK_REGION_ID "${REGION_ID}"
+emit_env TEST_REGION_ID "${REGION_ID}"

--- a/hack/openstack/register-region
+++ b/hack/openstack/register-region
@@ -8,6 +8,7 @@ DISPLAY_NAME="${REGION_DISPLAY_NAME:-}"
 SECRET_NAME="${OPENSTACK_SECRET_NAME:-}"
 ORGANIZATION_ID="${REGION_ORGANIZATION_ID:-}"
 PROVIDER_ENV_FILE=""
+CREATE_SECRET="${OPENSTACK_CREATE_SECRET:-false}"
 
 log() {
   echo "==> $*" >&2
@@ -36,7 +37,7 @@ emit_env() {
 
 usage() {
   cat >&2 <<EOF
-Usage: $0 [--provider-env FILE] --namespace NS [--region-id ID] [--display-name NAME] [--secret-name NAME] [--organization-id ID]
+Usage: $0 [--provider-env FILE] --namespace NS [--region-id ID] [--display-name NAME] [--secret-name NAME] [--organization-id ID] [--create-secret]
 
 Environment:
   UNIKORN_OPENSTACK_AUTH_URL
@@ -48,7 +49,13 @@ Environment:
   REGION_ID
   REGION_DISPLAY_NAME
   OPENSTACK_SECRET_NAME
+  OPENSTACK_CREATE_SECRET=true
   REGION_ORGANIZATION_ID
+
+By default, this script references an existing Kubernetes Secret. Create or sync
+that Secret from your password manager before registering persistent regions.
+Use --create-secret only for local or test regions where direct Secret creation
+from the provider env file is acceptable.
 EOF
 }
 
@@ -78,6 +85,10 @@ while [[ $# -gt 0 ]]; do
       ORGANIZATION_ID="$2"
       shift 2
       ;;
+    --create-secret)
+      CREATE_SECRET="true"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -101,20 +112,25 @@ require kubectl
 
 [[ -n "${NAMESPACE}" ]] || fatal "--namespace or REGION_NAMESPACE is required"
 [[ -n "${UNIKORN_OPENSTACK_AUTH_URL:-}" ]] || fatal "UNIKORN_OPENSTACK_AUTH_URL is required"
-[[ -n "${UNIKORN_OPENSTACK_DOMAIN_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_DOMAIN_ID is required"
-[[ -n "${UNIKORN_OPENSTACK_PROJECT_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_PROJECT_ID is required"
-[[ -n "${UNIKORN_OPENSTACK_USER_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_USER_ID is required"
-[[ -n "${UNIKORN_OPENSTACK_PASSWORD:-}" ]] || fatal "UNIKORN_OPENSTACK_PASSWORD is required"
 
-log "Applying OpenStack credential Secret ${NAMESPACE}/${SECRET_NAME}..."
-kubectl create secret generic "${SECRET_NAME}" \
-  --namespace "${NAMESPACE}" \
-  --from-literal="domain-id=${UNIKORN_OPENSTACK_DOMAIN_ID}" \
-  --from-literal="project-id=${UNIKORN_OPENSTACK_PROJECT_ID}" \
-  --from-literal="user-id=${UNIKORN_OPENSTACK_USER_ID}" \
-  --from-literal="password=${UNIKORN_OPENSTACK_PASSWORD}" \
-  --dry-run=client \
-  -o yaml | kubectl apply -f - >&2
+if [[ "${CREATE_SECRET}" == "true" ]]; then
+  [[ -n "${UNIKORN_OPENSTACK_DOMAIN_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_DOMAIN_ID is required with --create-secret"
+  [[ -n "${UNIKORN_OPENSTACK_PROJECT_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_PROJECT_ID is required with --create-secret"
+  [[ -n "${UNIKORN_OPENSTACK_USER_ID:-}" ]] || fatal "UNIKORN_OPENSTACK_USER_ID is required with --create-secret"
+  [[ -n "${UNIKORN_OPENSTACK_PASSWORD:-}" ]] || fatal "UNIKORN_OPENSTACK_PASSWORD is required with --create-secret"
+
+  log "Applying OpenStack credential Secret ${NAMESPACE}/${SECRET_NAME}..."
+  kubectl create secret generic "${SECRET_NAME}" \
+    --namespace "${NAMESPACE}" \
+    --from-literal="domain-id=${UNIKORN_OPENSTACK_DOMAIN_ID}" \
+    --from-literal="project-id=${UNIKORN_OPENSTACK_PROJECT_ID}" \
+    --from-literal="user-id=${UNIKORN_OPENSTACK_USER_ID}" \
+    --from-literal="password=${UNIKORN_OPENSTACK_PASSWORD}" \
+    --dry-run=client \
+    -o yaml | kubectl apply -f - >&2
+else
+  log "Referencing existing OpenStack credential Secret ${NAMESPACE}/${SECRET_NAME}."
+fi
 
 security_block=""
 if [[ -n "${ORGANIZATION_ID}" ]]; then

--- a/pkg/providers/internal/openstack/ADMIN.md
+++ b/pkg/providers/internal/openstack/ADMIN.md
@@ -79,8 +79,41 @@ It may also include optional selectors such as
 
 ## Register The Region
 
-Use `hack/openstack/register-region` to create or update both the Kubernetes
-Secret containing provider credentials and the `Region` resource.
+For persistent regions, put the credentials from the provider env file in a
+password manager and sync them to Kubernetes as a Secret. The Secret referenced
+by the `Region` must contain these keys:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: unikorn-region
+  name: gb-north-1-openstack-credentials
+stringData:
+  domain-id: ...
+  project-id: ...
+  user-id: ...
+  password: ...
+```
+
+Once that Secret exists, use `hack/openstack/register-region` to create or
+update the `Region` resource and reference the Secret by name:
+
+```bash
+export UNIKORN_OPENSTACK_AUTH_URL=https://openstack.gb-north-1.unikorn-cloud.org:5000
+
+hack/openstack/register-region \
+    --namespace unikorn-region \
+    --region-id c7e8492f-c320-4278-8201-48cd38fed38b \
+    --display-name gb-north-1 \
+    --secret-name gb-north-1-openstack-credentials
+```
+
+`register-region` references the existing Kubernetes Secret. It does not write
+OpenStack credentials to the cluster by default.
+
+For local or test regions where direct Kubernetes Secret creation is acceptable,
+pass `--create-secret` with the provider env file:
 
 ```bash
 hack/openstack/register-region \
@@ -88,7 +121,8 @@ hack/openstack/register-region \
     --namespace unikorn-region \
     --region-id c7e8492f-c320-4278-8201-48cd38fed38b \
     --display-name gb-north-1 \
-    --secret-name gb-north-1-openstack-credentials
+    --secret-name gb-north-1-openstack-credentials \
+    --create-secret
 ```
 
 Pass `--organization-id` to restrict the region to a single organization. If it

--- a/pkg/providers/internal/openstack/ADMIN.md
+++ b/pkg/providers/internal/openstack/ADMIN.md
@@ -1,97 +1,116 @@
-# Unikorn OpenStack Provider
+# OpenStack Provider Administration
 
-Provides a driver for OpenStack based regions.
+`pkg/providers/internal/openstack` provides the driver for OpenStack-backed
+regions.
 
 ## Initial Setup
 
-It is envisaged that an OpenStack cluster may be used for things other than the exclusive use of Unikorn, and as such it tries to respect this as much as possible.
-We also operate under the principle of least privilege, so don't want to have a full admin credential alyng around.
+An OpenStack cloud may be shared with workloads other than UNI. The region
+provider therefore avoids requiring a long-lived full administrator credential
+at runtime and supports multiple Unikorn deployments cohabiting on the same
+cloud, for example staging and production regions.
 
-In particular we want to allow different instances of Unikorn to cohabit to support, for example, staging environments.
+Install the required OpenStack policies before registering the region. Follow
+the instructions in the
+[UNI OpenStack Policy repository][policy-repo].
 
-We need a number of policies installing to function correctly.
-Follow the instructions in the [Unikorn OpenStack Policy repository](https://github.com/unikorn-cloud/python-unikorn-openstack-policy) to install them.
+[policy-repo]: https://github.com/nscaledev/uni-python-unikorn-openstack-policy)
 
-### OpenStack Platform Configuration
+## Configure OpenStack Provider Credentials
 
-Start by selecting a unique name that will be used for the deployment's name, project, and domain:
+Use `hack/openstack/configure` to produce the provider environment consumed by
+the region registration step. It accepts the usual OpenStack CLI authentication
+inputs: a standard `openrc`, existing `OS_*` variables, or `OS_CLOUD`.
 
-```bash
-export USER=unikorn-staging
-export DOMAIN=unikorn-staging
-export PROJECT=unikorn-default
-export PASSWORD=$(apg -n 1 -m 24)
-```
-
-#### Create the domain.
-
-The use of project domains for projects deployed to provision Kubernetes cluster achieves a few aims.
-First namespace isolation.
-Second is a security consideration.
-It is dangerous, anecdotally, to have a privileged process that has the power of deletion.
-By limiting the scope of list operations to that of the project domain we limit our impact on other tenants on the system.
-A domain may also aid in simplifying operations like auditing and capacity planning.
+The default `create` mode creates or updates the Keystone domain, project, user,
+and role grants used by the region provider. Choose a stable prefix for
+persistent regions and keep the output in a secret store because it contains the
+provider user's password.
 
 ```bash
-DOMAIN_ID=$(openstack domain create ${DOMAIN} -f json | jq -r .id)
+provider_env="${TMPDIR:-/tmp}/gb-north-1.openstack.env"
+
+hack/openstack/configure \
+    --openrc /path/to/admin-openrc \
+    --prefix gb-north-1 \
+    --output "${provider_env}"
 ```
 
-#### Create the project.
+By default, `configure` grants the provider user these roles:
 
-As the OpenStack provider for the region controller also functions as a client in order to retrieve information such as available images, flavors, and so on it also needs to be associated with a project so that the default policy for various API requests is correctly satisfied:
+- domain roles: `member`, `load-balancer_member`, and `manager`
+- project roles: `member` and `manager`
+
+Set `UNIKORN_OPENSTACK_INCLUDE_LEGACY_MEMBER_ROLE=true` when targeting older
+OpenStack deployments where Neutron still requires the `_member_` role. Override
+`UNIKORN_OPENSTACK_DOMAIN_ROLES` or `UNIKORN_OPENSTACK_PROJECT_ROLES` only when
+the target cloud's policy model has intentionally diverged from the defaults.
+
+If the provider user already exists, `configure` sets it to the supplied or
+generated password. Source the existing provider env file, set
+`UNIKORN_OPENSTACK_PASSWORD`, or pass `--password` when re-running the script and
+the password must stay stable.
+
+When the OpenStack resources are managed elsewhere, use `existing` mode to
+validate and re-emit an already supplied provider env file without creating
+domains, projects, users, or role grants:
 
 ```bash
-PROJECT_ID=$(openstack project create $PROJECT --domain $DOMAIN -f json | jq -r .id)
+. "${provider_env}"
+
+hack/openstack/configure \
+    --mode existing \
+    --output "${provider_env}"
 ```
 
-#### Create the user.
+The generated file contains the values needed by region registration:
 
 ```bash
-USER_ID=$(openstack user create --domain ${DOMAIN_ID} --password ${PASSWORD} ${USER} -f json | jq -r .id)
+UNIKORN_OPENSTACK_AUTH_URL=...
+UNIKORN_OPENSTACK_DOMAIN_ID=...
+UNIKORN_OPENSTACK_PROJECT_ID=...
+UNIKORN_OPENSTACK_USER_ID=...
+UNIKORN_OPENSTACK_PASSWORD=...
 ```
 
-### Grant any roles to the user.
+It may also include optional selectors such as
+`UNIKORN_OPENSTACK_EXTERNAL_NETWORK_ID`, `UNIKORN_OPENSTACK_FLAVOR_ID`, or
+`UNIKORN_OPENSTACK_IMAGE_ID` when those values were supplied or discovered.
 
-When a Kubernetes cluster is provisioned, it will be done using application credentials, so ensure any required application credentials as configured for the region are explicitly associated with the user here.
+## Register The Region
 
-> [!NOTE]
-> It may be necessary to add the `_member_` role on older OpenStack deployments where Neutron requires it to function.
+Use `hack/openstack/register-region` to create or update both the Kubernetes
+Secret containing provider credentials and the `Region` resource.
 
 ```bash
-for role in member load-balancer_member manager; do
-	openstack role add --user ${USER_ID} --domain ${DOMAIN_ID} ${role}
-done
+hack/openstack/register-region \
+    --provider-env "${provider_env}" \
+    --namespace unikorn-region \
+    --region-id c7e8492f-c320-4278-8201-48cd38fed38b \
+    --display-name gb-north-1 \
+    --secret-name gb-north-1-openstack-credentials
 ```
 
-Grant the `member` and `manager` roles on the project we created in a previous step:
+Pass `--organization-id` to restrict the region to a single organization. If it
+is omitted, the region is visible to all organizations.
+
+`register-region` also prints `REGION_PROVIDER`, `OPENSTACK_REGION_ID`, and
+`TEST_REGION_ID` entries for local test environments. Those can be ignored for
+persistent region setup.
+
+For additional configuration options for individual OpenStack services, consult
+the CRD documentation:
 
 ```bash
-for role in member manager; do
-    openstack role add --user ${USER_ID} --project ${PROJECT_ID} ${role}
-done
+kubectl explain regions.region.unikorn-cloud.org
 ```
 
-### Unikorn Configuration
-
-When we create a `Region` of type `openstack`, it will require a secret that contains credentials.
-This can be configured as follows.
-
-```bash
-kubectl create secret generic -n unikorn-region gb-north-1-credentials \
-    --from-literal=domain-id=${DOMAIN_ID} \
-    --from-literal=project-id=${PROJECT_ID} \
-    --from-literal=user-id=${USER_ID} \
-    --from-literal=password=${PASSWORD}
-```
-
-Finally we can create the region itself, although this should be statically configured via Helm.
-For additional configuration options for individual OpenStack services, consult `kubectl explain regions.region.unikorn-cloud.org` for documentation.
+The resulting `Region` shape is equivalent to:
 
 ```yaml
 apiVersion: region.unikorn-cloud.org/v1alpha1
 kind: Region
 metadata:
-  # Use "uuidgen -r" to select a random ID, this MUST start with a character a-f.
   namespace: unikorn-region
   name: c7e8492f-c320-4278-8201-48cd38fed38b
   labels:
@@ -101,18 +120,10 @@ spec:
   openstack:
     endpoint: https://openstack.gb-north-1.unikorn-cloud.org:5000
     serviceAccountSecret:
-      namespace: unikorn
-      name: gb-north-1-credentials
-```
-
-Cleanup actions.
-
-```bash
-unset DOMAIN
-unset DOMAIN_ID
-unset USER
-unset USER_ID
-unset PASSWORD
-unset PROJECT
-unset PROJECT_ID
+      namespace: unikorn-region
+      name: gb-north-1-openstack-credentials
+    identity:
+      clusterRoles:
+      - member
+      - load-balancer_member
 ```

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -60,6 +60,18 @@ covers the local VLAN allocator used when provider networks need segmentation ID
 `ADMIN.md` keeps the human operator setup guidance for preparing an OpenStack
 region.
 
+## OpenStack Region Registration
+
+An OpenStack-backed region should be registered with `hack/openstack/configure`
+and `hack/openstack/register-region`, rather than by hand-creating the Keystone
+domain, project, user, Kubernetes Secret, and `Region` manifest. That flow keeps
+operator setup aligned with this package's scoping model: region-level provider
+credentials are used to manage provider-domain scaffolding and discover region
+inventory, while workload operations still context-switch into per-identity
+OpenStack projects.
+
+The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
+
 ## Invariants And Guard Rails
 
 - This package implements the full `types.Provider` contract for OpenStack


### PR DESCRIPTION
To date we've had prose instructions for making an OpenStack deployment usable as a region in UNI. These are not _too_ error prone, and don't have to be done too often, and by people who knew what they were doing.

But now, we want to include that in automated testing.

This commit adds a script that will create the necessary domain etc., for use as a region in UNI, and outputs all the necessary details to stdout or to a file as given with `--output`.

The README.md for the OpenStack provider is updated to refer to the script rather than manual steps.