### PR TITLE
Let people use an OpenStack region for integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /sboms
+/.devstack
 /charts/region/Chart.lock
 /charts/region/charts
 *.swp
@@ -9,6 +10,9 @@ go.work.sum
 go.work
 test/.env
 test/.env.install
+test/.env.openstack
+test/.env.provider
+test/ca-bundle.pem
 junit.xml
 test-results.json
 hack/ci/ca-bundle.pem

--- a/README.md
+++ b/README.md
@@ -115,41 +115,73 @@ Regions define cloud instances to expose to clients.
 
 ### Local Testing
 
-1. **Set up your environment configuration:**
+The API test targets load `test/.env` when it exists.
 
-   Copy the example config and update with your values:
-   ```bash
-   cp test/.env.example test/.env
-   ```
+For tests against an existing deployment, copy the example config and update it
+with your service URLs, tokens, and fixture IDs:
 
-   Or create environment-specific files (not tracked in git):
-   ```bash
-   # Create .env.dev with your dev credentials
-   cp test/.env.example test/.env.dev
-   # Edit test/.env.dev with dev values
+```bash
+cp test/.env.example test/.env
+```
 
-   # Create .env.uat with your UAT credentials
-   cp test/.env.example test/.env.uat
-   # Edit test/.env.uat with UAT values
+The required values are:
 
-   # Use the appropriate environment
-   cp test/.env.dev test/.env    # For dev environment
-   cp test/.env.uat test/.env    # For UAT environment
-   ```
+- `API_BASE_URL` - Region API server URL
+- `API_AUTH_TOKEN` - service token from console
+- `TEST_ORG_ID`, `TEST_PROJECT_ID`, `TEST_REGION_ID` - test data IDs
 
-2. **Configure the required values in `test/.env`:**
-   - `API_BASE_URL` - Region API server URL
-   - `API_AUTH_TOKEN` - Service token from console
-   - `TEST_ORG_ID`, `TEST_PROJECT_ID`, `TEST_REGION_ID` - Test data IDs
+For a Helm-based local install in the current `kubectl` context, generate the
+install environment and fixtures instead of hand-editing `test/.env`:
 
-3. **Run tests:**
-   ```bash
-   make test-api                                              # Run all tests
-   make test-api-verbose                                      # Verbose output
-   make test-api-focus FOCUS="should return all available"   # Run focused tests
-   ```
+```bash
+hack/local-install-env --output test/.env.install
+make integration-fixtures
+```
 
-**Note:** The `.env`, `.env.dev`, and `.env.uat` files are gitignored and contain sensitive credentials. They should never be committed to the repository.
+`hack/local-install-env` discovers the identity and region Helm releases, their
+ingress hosts, and the local CA bundle. `make integration-fixtures` creates the
+identity fixtures and writes `test/.env`.
+
+To run API tests against an OpenStack-backed region, generate `test/.env.install`
+first, then register or reference the region. In OpenStack mode the public test
+region is the existing Region CR identified by `TEST_REGION_ID`; the simulated
+private region fixture is still created. `OPENSTACK_REGION_ID` is accepted as a
+fallback alias for the value printed by `register-region`, but `TEST_REGION_ID`
+takes precedence when both are set. `register-region` prints the environment
+entries the fixture setup needs:
+
+```bash
+provider_env="${TMPDIR:-/tmp}/gb-north-1.openstack.env" # From hack/openstack/configure.
+
+hack/openstack/register-region \
+    --provider-env "${provider_env}" \
+    --namespace unikorn-region \
+    --region-id c7e8492f-c320-4278-8201-48cd38fed38b \
+    --display-name gb-north-1 \
+    --secret-name gb-north-1-openstack-credentials \
+    --create-secret \
+    > test/.env.openstack
+
+set -a
+. test/.env.openstack
+set +a
+make integration-fixtures
+```
+
+For persistent regions, create or sync the OpenStack credential Secret from a
+password manager and omit `--create-secret`; see the OpenStack provider
+documentation for details.
+
+Run tests with:
+
+```bash
+make test-api                                             # Run all tests
+make test-api-verbose                                     # Verbose output
+make test-api-focus FOCUS="should return all available"   # Run focused tests
+```
+
+**Note:** Local env files and CA bundles under `test/` are gitignored and may
+contain sensitive credentials. They should never be committed to the repository.
 
 ### Integration Fixtures
 

--- a/README.md
+++ b/README.md
@@ -115,41 +115,73 @@ Regions define cloud instances to expose to clients.
 
 ### Local Testing
 
-1. **Set up your environment configuration:**
+The API test targets load `test/.env` when it exists.
 
-   Copy the example config and update with your values:
-   ```bash
-   cp test/.env.example test/.env
-   ```
+For tests against an existing deployment, copy the example config and update it
+with your service URLs, tokens, and fixture IDs:
 
-   Or create environment-specific files (not tracked in git):
-   ```bash
-   # Create .env.dev with your dev credentials
-   cp test/.env.example test/.env.dev
-   # Edit test/.env.dev with dev values
+```bash
+cp test/.env.example test/.env
+```
 
-   # Create .env.uat with your UAT credentials
-   cp test/.env.example test/.env.uat
-   # Edit test/.env.uat with UAT values
+The required values are:
 
-   # Use the appropriate environment
-   cp test/.env.dev test/.env    # For dev environment
-   cp test/.env.uat test/.env    # For UAT environment
-   ```
+- `API_BASE_URL` - Region API server URL
+- `API_AUTH_TOKEN` - service token from console
+- `TEST_ORG_ID`, `TEST_PROJECT_ID`, `TEST_REGION_ID` - test data IDs
 
-2. **Configure the required values in `test/.env`:**
-   - `API_BASE_URL` - Region API server URL
-   - `API_AUTH_TOKEN` - Service token from console
-   - `TEST_ORG_ID`, `TEST_PROJECT_ID`, `TEST_REGION_ID` - Test data IDs
+For a Helm-based local install in the current `kubectl` context, generate the
+install environment and fixtures instead of hand-editing `test/.env`:
 
-3. **Run tests:**
-   ```bash
-   make test-api                                              # Run all tests
-   make test-api-verbose                                      # Verbose output
-   make test-api-focus FOCUS="should return all available"   # Run focused tests
-   ```
+```bash
+hack/local-install-env --output test/.env.install
+make integration-fixtures
+```
 
-**Note:** The `.env`, `.env.dev`, and `.env.uat` files are gitignored and contain sensitive credentials. They should never be committed to the repository.
+`hack/local-install-env` discovers the identity and region Helm releases, their
+ingress hosts, and the local CA bundle. `make integration-fixtures` creates the
+identity fixtures and writes `test/.env`.
+
+To run API tests against an OpenStack-backed region, generate `test/.env.install`
+first, then register or reference the region. In OpenStack mode the public test
+region is the existing Region CR identified by `TEST_REGION_ID`; the simulated
+private region fixture is still created. `OPENSTACK_REGION_ID` is accepted as a
+fallback alias for the value printed by `register-region`, but `TEST_REGION_ID`
+takes precedence when both are set. `register-region` prints the environment
+entries the fixture setup needs:
+
+```bash
+provider_env="${TMPDIR:-/tmp}/gb-north-1.openstack.env" # From hack/openstack/configure.
+
+hack/openstack/register-region \
+    --provider-env "${provider_env}" \
+    --namespace unikorn-region \
+    --region-id c7e8492f-c320-4278-8201-48cd38fed38b \
+    --display-name gb-north-1 \
+    --secret-name gb-north-1-openstack-credentials \
+    --create-secret \
+    > test/.env.openstack
+
+set -a
+. test/.env.openstack
+set +a
+make integration-fixtures
+```
+
+For persistent regions, create or sync the OpenStack credential Secret from a
+password manager and omit `--create-secret`; see the OpenStack provider
+documentation for details.
+
+Run tests with:
+
+```bash
+make test-api                                             # Run all tests
+make test-api-verbose                                     # Verbose output
+make test-api-focus FOCUS="should return all available"   # Run focused tests
+```
+
+**Note:** Local env files and CA bundles under `test/` are gitignored and may
+contain sensitive credentials. They should never be committed to the repository.
 
 ### GitHub Actions
 

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -26,6 +26,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -54,6 +55,12 @@ const (
 	fixtureActor  = "ci-fixtures"
 	publicRegion  = "sim-public"
 	privateRegion = "sim-private"
+)
+
+var (
+	errOpenstackTestRegionIDRequired = errors.New("TEST_REGION_ID or --test-region-id must be set when REGION_PROVIDER=openstack")
+	errRegionProviderMismatch        = errors.New("region fixture has unexpected provider")
+	errUnsupportedRegionProvider     = errors.New("unsupported region provider fixture mode")
 )
 
 func fatalf(format string, args ...interface{}) {
@@ -387,6 +394,21 @@ func upsertRegion(ctx context.Context, k8s client.Client, regionNamespace, name 
 	}
 }
 
+func validateExistingRegion(ctx context.Context, k8s client.Client, regionNamespace, name string, provider regionv1.Provider) error {
+	region := &regionv1.Region{}
+	key := types.NamespacedName{Namespace: regionNamespace, Name: name}
+
+	if err := k8s.Get(ctx, key, region); err != nil {
+		return fmt.Errorf("region fixture %q was not found in namespace %q: %w", name, regionNamespace, err)
+	}
+
+	if region.Spec.Provider != provider {
+		return fmt.Errorf("%w: %q in namespace %q has provider %q, want %q", errRegionProviderMismatch, name, regionNamespace, region.Spec.Provider, provider)
+	}
+
+	return nil
+}
+
 func main() {
 	opts := parseOptions()
 	run(opts)
@@ -399,6 +421,8 @@ type options struct {
 	regionBaseURL     string
 	caCertPath        string
 	regionCACertPath  string
+	regionProvider    string
+	testRegionID      string
 }
 
 func parseOptions() options {
@@ -408,10 +432,12 @@ func parseOptions() options {
 	regionBaseURL := flag.String("region-base-url", os.Getenv("REGION_BASE_URL"), "Region service base URL")
 	caCertPath := flag.String("ca-cert", os.Getenv("IDENTITY_CA_CERT"), "Path to CA certificate bundle")
 	regionCACertPath := flag.String("region-ca-cert", os.Getenv("REGION_CA_CERT"), "Path to region CA certificate bundle")
+	regionProvider := flag.String("region-provider", envDefault("REGION_PROVIDER", string(regionv1.ProviderSimulated)), "Region provider fixture mode: simulated or openstack")
+	testRegionID := flag.String("test-region-id", firstEnv("TEST_REGION_ID", "OPENSTACK_REGION_ID"), "Existing region ID to use for tests when --region-provider=openstack")
 	flag.Parse()
 
 	if *baseURL == "" || *identityNamespace == "" || *regionNamespace == "" || *regionBaseURL == "" || *caCertPath == "" {
-		fmt.Fprintln(os.Stderr, "Usage: fixtures --base-url URL --identity-namespace NS --region-namespace NS --region-base-url URL --ca-cert PATH [--region-ca-cert PATH]")
+		fmt.Fprintln(os.Stderr, "Usage: fixtures --base-url URL --identity-namespace NS --region-namespace NS --region-base-url URL --ca-cert PATH [--region-ca-cert PATH] [--region-provider simulated|openstack] [--test-region-id ID]")
 		os.Exit(1)
 	}
 
@@ -422,6 +448,45 @@ func parseOptions() options {
 		regionBaseURL:     *regionBaseURL,
 		caCertPath:        *caCertPath,
 		regionCACertPath:  *regionCACertPath,
+		regionProvider:    *regionProvider,
+		testRegionID:      *testRegionID,
+	}
+}
+
+func envDefault(name, defaultValue string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+
+	return defaultValue
+}
+
+func firstEnv(names ...string) string {
+	for _, name := range names {
+		if value := os.Getenv(name); value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func resolveTestRegionID(regionProvider, explicitRegionID string) (regionv1.Provider, string, error) {
+	provider := regionv1.Provider(regionProvider)
+
+	switch provider {
+	case regionv1.ProviderSimulated:
+		return provider, publicRegion, nil
+	case regionv1.ProviderOpenstack:
+		if explicitRegionID == "" {
+			return "", "", errOpenstackTestRegionIDRequired
+		}
+
+		return provider, explicitRegionID, nil
+	case regionv1.ProviderKubernetes:
+		return "", "", fmt.Errorf("%w %q", errUnsupportedRegionProvider, regionProvider)
+	default:
+		return "", "", fmt.Errorf("%w %q", errUnsupportedRegionProvider, regionProvider)
 	}
 }
 
@@ -471,7 +536,7 @@ func newKubernetesClient() client.Client {
 	return k8s
 }
 
-func emitEnv(opts options, primary primaryFixture, secondaryOrgID, secondaryToken string) {
+func emitEnv(opts options, primary primaryFixture, secondaryOrgID, secondaryToken, testRegionID string) {
 	fmt.Printf("API_BASE_URL=%s\n", opts.regionBaseURL)
 	fmt.Printf("REGION_BASE_URL=%s\n", opts.regionBaseURL)
 	fmt.Printf("REGION_CA_CERT=%s\n", opts.regionCACertPath)
@@ -486,7 +551,7 @@ func emitEnv(opts options, primary primaryFixture, secondaryOrgID, secondaryToke
 	fmt.Printf("TEST_USER_SA_ID=%s\n", primary.userSAID)
 	fmt.Printf("ADMIN_AUTH_TOKEN=%s\n", primary.adminToken)
 	fmt.Printf("USER_AUTH_TOKEN=%s\n", primary.userToken)
-	fmt.Printf("TEST_REGION_ID=%s\n", publicRegion)
+	fmt.Printf("TEST_REGION_ID=%s\n", testRegionID)
 	fmt.Printf("TEST_PRIVATE_REGION_ID=%s\n", privateRegion)
 	fmt.Printf("TEST_SECONDARY_ORG_ID=%s\n", secondaryOrgID)
 	fmt.Printf("TEST_SECONDARY_AUTH_TOKEN=%s\n", secondaryToken)
@@ -496,6 +561,19 @@ func run(opts options) {
 	opts = resolveCertPaths(opts)
 	ctx := context.Background()
 	k8s := newKubernetesClient()
+
+	provider, testRegionID, err := resolveTestRegionID(opts.regionProvider, opts.testRegionID)
+	if err != nil {
+		fatalf("%v", err)
+	}
+
+	if provider == regionv1.ProviderOpenstack {
+		if err := validateExistingRegion(ctx, k8s, opts.regionNamespace, testRegionID, regionv1.ProviderOpenstack); err != nil {
+			fatalf("%v", err)
+		}
+
+		logf("Using existing OpenStack region fixture %s in namespace %s...", testRegionID, opts.regionNamespace)
+	}
 
 	logf("Issuing mTLS client certificate for %s...", fixtureActor)
 	certPEM, keyPEM := issueCert(ctx, k8s, opts.identityNamespace, fixtureActor, fixtureActor)
@@ -509,8 +587,12 @@ func run(opts options) {
 
 	secondaryOrgID, secondaryToken := createSecondaryFixtures(ctx, identityClient, k8s, opts.identityNamespace)
 
-	logf("Creating simulated region fixtures in namespace %s...", opts.regionNamespace)
-	upsertRegion(ctx, k8s, opts.regionNamespace, publicRegion, nil)
+	if provider == regionv1.ProviderSimulated {
+		logf("Creating simulated public region fixture in namespace %s...", opts.regionNamespace)
+		upsertRegion(ctx, k8s, opts.regionNamespace, publicRegion, nil)
+	}
+
+	logf("Creating simulated private region fixture in namespace %s...", opts.regionNamespace)
 	upsertRegion(ctx, k8s, opts.regionNamespace, privateRegion, []string{primary.orgID})
-	emitEnv(opts, primary, secondaryOrgID, secondaryToken)
+	emitEnv(opts, primary, secondaryOrgID, secondaryToken, testRegionID)
 }

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -26,6 +26,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -59,6 +60,12 @@ const (
 
 	publicRegion  = "sim-public"
 	privateRegion = "sim-private"
+)
+
+var (
+	errOpenstackTestRegionIDRequired = errors.New("TEST_REGION_ID or --test-region-id must be set when REGION_PROVIDER=openstack")
+	errRegionProviderMismatch        = errors.New("region fixture has unexpected provider")
+	errUnsupportedRegionProvider     = errors.New("unsupported region provider fixture mode")
 )
 
 func fatalf(format string, args ...interface{}) {
@@ -558,6 +565,21 @@ func upsertRegion(ctx context.Context, k8s client.Client, regionNamespace, name 
 	}
 }
 
+func validateExistingRegion(ctx context.Context, k8s client.Client, regionNamespace, name string, provider regionv1.Provider) error {
+	region := &regionv1.Region{}
+	key := types.NamespacedName{Namespace: regionNamespace, Name: name}
+
+	if err := k8s.Get(ctx, key, region); err != nil {
+		return fmt.Errorf("region fixture %q was not found in namespace %q: %w", name, regionNamespace, err)
+	}
+
+	if region.Spec.Provider != provider {
+		return fmt.Errorf("%w: %q in namespace %q has provider %q, want %q", errRegionProviderMismatch, name, regionNamespace, region.Spec.Provider, provider)
+	}
+
+	return nil
+}
+
 func main() {
 	opts := parseOptions()
 	run(opts)
@@ -571,6 +593,8 @@ type options struct {
 	caCertPath          string
 	regionCACertPath    string
 	fixtureCertDuration time.Duration
+	regionProvider      string
+	testRegionID        string
 }
 
 func parseOptions() options {
@@ -581,10 +605,13 @@ func parseOptions() options {
 	caCertPath := flag.String("ca-cert", os.Getenv("IDENTITY_CA_CERT"), "Path to CA certificate bundle")
 	regionCACertPath := flag.String("region-ca-cert", os.Getenv("REGION_CA_CERT"), "Path to region CA certificate bundle")
 	fixtureCertDuration := flag.String("fixture-cert-duration", envOrDefault("FIXTURE_CERT_DURATION", defaultFixtureCertDuration.String()), "Duration for generated mTLS fixture certificates")
+	regionProvider := flag.String("region-provider", envDefault("REGION_PROVIDER", string(regionv1.ProviderSimulated)), "Region provider fixture mode: simulated or openstack")
+	testRegionID := flag.String("test-region-id", firstEnv("TEST_REGION_ID", "OPENSTACK_REGION_ID"), "Existing region ID to use for tests when --region-provider=openstack")
+
 	flag.Parse()
 
 	if *baseURL == "" || *identityNamespace == "" || *regionNamespace == "" || *regionBaseURL == "" || *caCertPath == "" {
-		fmt.Fprintln(os.Stderr, "Usage: fixtures --base-url URL --identity-namespace NS --region-namespace NS --region-base-url URL --ca-cert PATH [--region-ca-cert PATH] [--fixture-cert-duration DURATION]")
+		fmt.Fprintln(os.Stderr, "Usage: fixtures --base-url URL --identity-namespace NS --region-namespace NS --region-base-url URL --ca-cert PATH [--region-ca-cert PATH] [--fixture-cert-duration DURATION] [--region-provider simulated|openstack] [--test-region-id ID]")
 		os.Exit(1)
 	}
 
@@ -605,6 +632,45 @@ func parseOptions() options {
 		caCertPath:          *caCertPath,
 		regionCACertPath:    *regionCACertPath,
 		fixtureCertDuration: duration,
+		regionProvider:      *regionProvider,
+		testRegionID:        *testRegionID,
+	}
+}
+
+func envDefault(name, defaultValue string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+
+	return defaultValue
+}
+
+func firstEnv(names ...string) string {
+	for _, name := range names {
+		if value := os.Getenv(name); value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func resolveTestRegionID(regionProvider, explicitRegionID string) (regionv1.Provider, string, error) {
+	provider := regionv1.Provider(regionProvider)
+
+	switch provider {
+	case regionv1.ProviderSimulated:
+		return provider, publicRegion, nil
+	case regionv1.ProviderOpenstack:
+		if explicitRegionID == "" {
+			return "", "", errOpenstackTestRegionIDRequired
+		}
+
+		return provider, explicitRegionID, nil
+	case regionv1.ProviderKubernetes:
+		return "", "", fmt.Errorf("%w %q", errUnsupportedRegionProvider, regionProvider)
+	default:
+		return "", "", fmt.Errorf("%w %q", errUnsupportedRegionProvider, regionProvider)
 	}
 }
 
@@ -654,7 +720,7 @@ func newKubernetesClient() client.Client {
 	return k8s
 }
 
-func emitEnv(opts options, primary primaryFixture, secondaryOrgID, secondaryToken string) {
+func emitEnv(opts options, primary primaryFixture, secondaryOrgID, secondaryToken, testRegionID string) {
 	fmt.Printf("API_BASE_URL=%s\n", opts.regionBaseURL)
 	fmt.Printf("REGION_BASE_URL=%s\n", opts.regionBaseURL)
 	fmt.Printf("REGION_CA_CERT=%s\n", opts.regionCACertPath)
@@ -669,7 +735,7 @@ func emitEnv(opts options, primary primaryFixture, secondaryOrgID, secondaryToke
 	fmt.Printf("TEST_USER_SA_ID=%s\n", primary.userSAID)
 	fmt.Printf("ADMIN_AUTH_TOKEN=%s\n", primary.adminToken)
 	fmt.Printf("USER_AUTH_TOKEN=%s\n", primary.userToken)
-	fmt.Printf("TEST_REGION_ID=%s\n", publicRegion)
+	fmt.Printf("TEST_REGION_ID=%s\n", testRegionID)
 	fmt.Printf("TEST_PRIVATE_REGION_ID=%s\n", privateRegion)
 	fmt.Printf("TEST_SECONDARY_ORG_ID=%s\n", secondaryOrgID)
 	fmt.Printf("TEST_SECONDARY_AUTH_TOKEN=%s\n", secondaryToken)
@@ -679,6 +745,19 @@ func run(opts options) {
 	opts = resolveCertPaths(opts)
 	ctx := context.Background()
 	k8s := newKubernetesClient()
+
+	provider, testRegionID, err := resolveTestRegionID(opts.regionProvider, opts.testRegionID)
+	if err != nil {
+		fatalf("%v", err)
+	}
+
+	if provider == regionv1.ProviderOpenstack {
+		if err := validateExistingRegion(ctx, k8s, opts.regionNamespace, testRegionID, regionv1.ProviderOpenstack); err != nil {
+			fatalf("%v", err)
+		}
+
+		logf("Using existing OpenStack region fixture %s in namespace %s...", testRegionID, opts.regionNamespace)
+	}
 
 	logf("Issuing mTLS client certificate for %s...", fixtureActor)
 	certPEM, keyPEM := issueCert(ctx, k8s, opts.identityNamespace, fixtureActor, fixtureActor, opts.fixtureCertDuration)
@@ -692,8 +771,12 @@ func run(opts options) {
 
 	secondaryOrgID, secondaryToken := createSecondaryFixtures(ctx, identityClient, k8s, opts.identityNamespace)
 
-	logf("Creating simulated region fixtures in namespace %s...", opts.regionNamespace)
-	upsertRegion(ctx, k8s, opts.regionNamespace, publicRegion, nil)
+	if provider == regionv1.ProviderSimulated {
+		logf("Creating simulated public region fixture in namespace %s...", opts.regionNamespace)
+		upsertRegion(ctx, k8s, opts.regionNamespace, publicRegion, nil)
+	}
+
+	logf("Creating simulated private region fixture in namespace %s...", opts.regionNamespace)
 	upsertRegion(ctx, k8s, opts.regionNamespace, privateRegion, []string{primary.orgID})
-	emitEnv(opts, primary, secondaryOrgID, secondaryToken)
+	emitEnv(opts, primary, secondaryOrgID, secondaryToken, testRegionID)
 }

--- a/hack/ci/fixtures/main_test.go
+++ b/hack/ci/fixtures/main_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const testRegionNamespace = "unikorn-region"
+
+func TestEnvDefault(t *testing.T) {
+	t.Setenv("FIXTURE_TEST_ENV_DEFAULT", "")
+
+	if got := envDefault("FIXTURE_TEST_ENV_DEFAULT", "fallback"); got != "fallback" {
+		t.Fatalf("empty environment value = %q, want fallback", got)
+	}
+
+	t.Setenv("FIXTURE_TEST_ENV_DEFAULT", "configured")
+
+	if got := envDefault("FIXTURE_TEST_ENV_DEFAULT", "fallback"); got != "configured" {
+		t.Fatalf("configured environment value = %q, want configured", got)
+	}
+}
+
+func TestFirstEnv(t *testing.T) {
+	t.Setenv("FIXTURE_TEST_FIRST_EMPTY", "")
+	t.Setenv("FIXTURE_TEST_FIRST_CONFIGURED", "first")
+	t.Setenv("FIXTURE_TEST_SECOND_CONFIGURED", "second")
+
+	got := firstEnv(
+		"FIXTURE_TEST_FIRST_EMPTY",
+		"FIXTURE_TEST_FIRST_CONFIGURED",
+		"FIXTURE_TEST_SECOND_CONFIGURED",
+	)
+	if got != "first" {
+		t.Fatalf("firstEnv() = %q, want first", got)
+	}
+}
+
+func TestResolveTestRegionID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		provider     string
+		explicitID   string
+		wantProvider regionv1.Provider
+		wantRegionID string
+		wantErr      string
+	}{
+		{
+			name:         "simulated",
+			provider:     string(regionv1.ProviderSimulated),
+			wantProvider: regionv1.ProviderSimulated,
+			wantRegionID: publicRegion,
+		},
+		{
+			name:         "openstack",
+			provider:     string(regionv1.ProviderOpenstack),
+			explicitID:   "gb-north-1",
+			wantProvider: regionv1.ProviderOpenstack,
+			wantRegionID: "gb-north-1",
+		},
+		{
+			name:     "openstack missing ID",
+			provider: string(regionv1.ProviderOpenstack),
+			wantErr:  "TEST_REGION_ID",
+		},
+		{
+			name:     "kubernetes",
+			provider: string(regionv1.ProviderKubernetes),
+			wantErr:  "unsupported region provider",
+		},
+		{
+			name:     "unknown",
+			provider: "unknown",
+			wantErr:  "unsupported region provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider, regionID, err := resolveTestRegionID(tt.provider, tt.explicitID)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("resolveTestRegionID() error = %v, want containing %q", err, tt.wantErr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("resolveTestRegionID() error = %v", err)
+			}
+
+			if provider != tt.wantProvider {
+				t.Fatalf("resolveTestRegionID() provider = %q, want %q", provider, tt.wantProvider)
+			}
+
+			if regionID != tt.wantRegionID {
+				t.Fatalf("resolveTestRegionID() region ID = %q, want %q", regionID, tt.wantRegionID)
+			}
+		})
+	}
+}
+
+func TestValidateExistingRegion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		objects  []client.Object
+		provider regionv1.Provider
+		wantErr  string
+	}{
+		{
+			name: "openstack region exists",
+			objects: []client.Object{
+				regionFixture("gb-north-1", regionv1.ProviderOpenstack),
+			},
+			provider: regionv1.ProviderOpenstack,
+		},
+		{
+			name:     "region missing",
+			provider: regionv1.ProviderOpenstack,
+			wantErr:  "was not found",
+		},
+		{
+			name: "provider mismatch",
+			objects: []client.Object{
+				regionFixture("gb-north-1", regionv1.ProviderSimulated),
+			},
+			provider: regionv1.ProviderOpenstack,
+			wantErr:  "has provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateExistingRegion(
+				t.Context(),
+				fixtureClient(t, tt.objects...),
+				testRegionNamespace,
+				"gb-north-1",
+				tt.provider,
+			)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("validateExistingRegion() error = %v, want containing %q", err, tt.wantErr)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("validateExistingRegion() error = %v", err)
+			}
+		})
+	}
+}
+
+func regionFixture(name string, provider regionv1.Provider) *regionv1.Region {
+	return &regionv1.Region{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testRegionNamespace,
+			Name:      name,
+		},
+		Spec: regionv1.RegionSpec{
+			Provider: provider,
+		},
+	}
+}
+
+func fixtureClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := regionv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("adding region scheme: %v", err)
+	}
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}

--- a/hack/local-install-env
+++ b/hack/local-install-env
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+# Generate test/.env.install from an existing Helm-based local installation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+IDENTITY_NAMESPACE="${IDENTITY_NAMESPACE:-}"
+IDENTITY_RELEASE="${IDENTITY_RELEASE:-}"
+IDENTITY_BASE_URL="${IDENTITY_BASE_URL:-}"
+REGION_NAMESPACE="${REGION_NAMESPACE:-}"
+REGION_RELEASE="${REGION_RELEASE:-}"
+REGION_BASE_URL="${REGION_BASE_URL:-}"
+OUTPUT_FILE="${REPO_ROOT}/test/.env.install"
+CA_CERT="${REPO_ROOT}/test/ca-bundle.pem"
+CA_SECRET_NAMESPACE="${CA_SECRET_NAMESPACE:-cert-manager}"
+CA_SECRET_NAME="${CA_SECRET_NAME:-unikorn-ca}"
+SYNC_CA=true
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 [options]
+
+Discovers an existing identity and region Helm installation in the current
+kubectl context and writes a shell-compatible test/.env.install file.
+
+Options:
+  --identity-namespace NS       Identity release namespace
+  --identity-release NAME       Identity Helm release name
+  --identity-release-name NAME  Alias for --identity-release
+  --identity-base-url URL       Override discovered identity URL
+  --region-namespace NS         Region release namespace
+  --namespace NS                Alias for --region-namespace
+  --region-release NAME         Region Helm release name
+  --release-name NAME           Alias for --region-release
+  --region-base-url URL         Override discovered region URL
+  --ca-cert FILE                CA bundle output path (default: test/ca-bundle.pem)
+  --ca-secret-namespace NS      CA secret namespace (default: cert-manager)
+  --ca-secret-name NAME         CA secret name (default: unikorn-ca)
+  --no-sync-ca                  Use --ca-cert as-is instead of extracting it
+  --output FILE                 Env file path (default: test/.env.install)
+  --stdout                      Write env content to stdout
+  -h, --help                    Show this help
+
+Environment defaults:
+  IDENTITY_NAMESPACE, IDENTITY_RELEASE, IDENTITY_BASE_URL
+  REGION_NAMESPACE, REGION_RELEASE, REGION_BASE_URL
+  CA_SECRET_NAMESPACE, CA_SECRET_NAME
+EOF
+}
+
+log() {
+  echo "==> $*" >&2
+}
+
+fatal() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || fatal "$1 is required"
+}
+
+abs_path() {
+  local path="$1"
+
+  if [[ "${path}" == /* ]]; then
+    printf "%s\n" "${path}"
+    return
+  fi
+
+  printf "%s\n" "${PWD}/${path#./}"
+}
+
+decode_base64() {
+  local input="$1"
+  local output="$2"
+
+  if base64 --decode < "${input}" > "${output}" 2>/dev/null; then
+    return
+  fi
+
+  if base64 -d < "${input}" > "${output}" 2>/dev/null; then
+    return
+  fi
+
+  if base64 -D < "${input}" > "${output}" 2>/dev/null; then
+    return
+  fi
+
+  fatal "failed to decode CA data from ${CA_SECRET_NAMESPACE}/${CA_SECRET_NAME}"
+}
+
+discover_release() {
+  local component="$1"
+  local release="$2"
+  local namespace="$3"
+  local matches
+  local count
+
+  matches=$(helm list -A -o json | jq -r \
+    --arg component "${component}" \
+    --arg release "${release}" \
+    --arg namespace "${namespace}" \
+    '
+      .[]
+      | select($release == "" or .name == $release)
+      | select($namespace == "" or .namespace == $namespace)
+      | select(
+          $release != ""
+          or .name == $component
+          or (.name | startswith($component + "-"))
+          or .name == ("unikorn-" + $component)
+          or (.name | startswith("unikorn-" + $component + "-"))
+          or (.chart | startswith($component + "-"))
+          or (.chart | startswith("unikorn-" + $component + "-"))
+        )
+      | [.name, .namespace]
+      | @tsv
+    ')
+  count=$(printf "%s\n" "${matches}" | awk 'NF { c++ } END { print c + 0 }')
+
+  if [[ "${count}" -eq 0 ]]; then
+    fatal "could not find a ${component} Helm release; pass --${component}-release and --${component}-namespace"
+  fi
+
+  if [[ "${count}" -gt 1 ]]; then
+    echo "Multiple ${component} Helm releases matched:" >&2
+    printf "%s\n" "${matches}" | awk 'NF { printf "  release=%s namespace=%s\n", $1, $2 }' >&2
+    fatal "pass --${component}-release and --${component}-namespace"
+  fi
+
+  printf "%s\n" "${matches}" | awk 'NF { print; exit }'
+}
+
+base_url() {
+  local value="$1"
+
+  if [[ "${value}" =~ ^https?:// ]]; then
+    printf "%s\n" "${value}"
+    return
+  fi
+
+  printf "https://%s\n" "${value}"
+}
+
+unique_non_empty_lines() {
+  awk 'NF && !seen[$0]++'
+}
+
+discover_base_url() {
+  local component="$1"
+  local release="$2"
+  local namespace="$3"
+  local override="$4"
+  local hosts
+  local count
+
+  if [[ -n "${override}" ]]; then
+    base_url "${override}"
+    return
+  fi
+
+  hosts=$(kubectl get ingress "${release}-server" \
+    -n "${namespace}" \
+    -o jsonpath='{range .spec.rules[*]}{.host}{"\n"}{end}' 2>/dev/null \
+    | unique_non_empty_lines || true)
+
+  if [[ -z "${hosts}" ]]; then
+    hosts=$(kubectl get ingress \
+      -n "${namespace}" \
+      -l "app.kubernetes.io/instance=${release}" \
+      -o json 2>/dev/null \
+      | jq -r '.items[].spec.rules[]?.host' \
+      | unique_non_empty_lines || true)
+  fi
+
+  count=$(printf "%s\n" "${hosts}" | awk 'NF { c++ } END { print c + 0 }')
+
+  if [[ "${count}" -eq 0 ]]; then
+    fatal "could not find ${component} ingress host; pass --${component}-base-url"
+  fi
+
+  if [[ "${count}" -gt 1 ]]; then
+    echo "Multiple ${component} ingress hosts matched:" >&2
+    printf "%s\n" "${hosts}" | awk 'NF { printf "  %s\n", $0 }' >&2
+    fatal "pass --${component}-base-url"
+  fi
+
+  base_url "${hosts}"
+}
+
+discover_ingress_ip() {
+  kubectl get service ingress-nginx-controller \
+    -n ingress-nginx \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true
+}
+
+sync_ca_bundle() {
+  local encoded
+  local encoded_file
+  local decoded_file
+  local cert_dir
+
+  cert_dir="$(dirname "${CA_CERT}")"
+  mkdir -p "${cert_dir}"
+
+  log "Extracting CA bundle from ${CA_SECRET_NAMESPACE}/${CA_SECRET_NAME}..."
+  encoded=$(kubectl get secret "${CA_SECRET_NAME}" \
+    -n "${CA_SECRET_NAMESPACE}" \
+    -o jsonpath='{.data.ca\.crt}' 2>/dev/null || true)
+
+  if [[ -z "${encoded}" ]]; then
+    encoded=$(kubectl get secret "${CA_SECRET_NAME}" \
+      -n "${CA_SECRET_NAMESPACE}" \
+      -o jsonpath='{.data.tls\.crt}' 2>/dev/null || true)
+  fi
+
+  [[ -n "${encoded}" ]] || fatal "secret ${CA_SECRET_NAMESPACE}/${CA_SECRET_NAME} has no ca.crt or tls.crt data"
+
+  encoded_file="$(mktemp)"
+  decoded_file="$(mktemp)"
+
+  printf "%s" "${encoded}" > "${encoded_file}"
+  decode_base64 "${encoded_file}" "${decoded_file}"
+  rm -f "${encoded_file}"
+  mv "${decoded_file}" "${CA_CERT}"
+}
+
+emit_env() {
+  cat <<EOF
+IDENTITY_BASE_URL=${IDENTITY_BASE_URL}
+IDENTITY_INGRESS_IP=${IDENTITY_INGRESS_IP}
+IDENTITY_NAMESPACE=${IDENTITY_NAMESPACE}
+IDENTITY_RELEASE=${IDENTITY_RELEASE}
+IDENTITY_CA_CERT=${CA_CERT}
+REGION_BASE_URL=${REGION_BASE_URL}
+API_BASE_URL=${REGION_BASE_URL}
+REGION_NAMESPACE=${REGION_NAMESPACE}
+REGION_RELEASE=${REGION_RELEASE}
+REGION_CA_CERT=${CA_CERT}
+EOF
+}
+
+write_env_file() {
+  local output="$1"
+  local dir
+  local base
+  local tmp
+
+  if [[ "${output}" == "-" ]]; then
+    emit_env
+    return
+  fi
+
+  dir="$(dirname "${output}")"
+  base="$(basename "${output}")"
+  mkdir -p "${dir}"
+  tmp="$(mktemp "${dir}/.${base}.XXXXXX")"
+  emit_env > "${tmp}"
+  mv "${tmp}" "${output}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --identity-namespace)
+      IDENTITY_NAMESPACE="$2"
+      shift 2
+      ;;
+    --identity-release|--identity-release-name)
+      IDENTITY_RELEASE="$2"
+      shift 2
+      ;;
+    --identity-base-url)
+      IDENTITY_BASE_URL="$2"
+      shift 2
+      ;;
+    --region-namespace|--namespace)
+      REGION_NAMESPACE="$2"
+      shift 2
+      ;;
+    --region-release|--release-name)
+      REGION_RELEASE="$2"
+      shift 2
+      ;;
+    --region-base-url)
+      REGION_BASE_URL="$2"
+      shift 2
+      ;;
+    --ca-cert)
+      CA_CERT="$2"
+      shift 2
+      ;;
+    --ca-secret-namespace)
+      CA_SECRET_NAMESPACE="$2"
+      shift 2
+      ;;
+    --ca-secret-name)
+      CA_SECRET_NAME="$2"
+      shift 2
+      ;;
+    --no-sync-ca)
+      SYNC_CA=false
+      shift
+      ;;
+    --output)
+      OUTPUT_FILE="$2"
+      shift 2
+      ;;
+    --stdout)
+      OUTPUT_FILE="-"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fatal "unknown argument: $1"
+      ;;
+  esac
+done
+
+require kubectl
+require helm
+require jq
+require awk
+require base64
+
+CA_CERT="$(abs_path "${CA_CERT}")"
+if [[ "${OUTPUT_FILE}" != "-" ]]; then
+  OUTPUT_FILE="$(abs_path "${OUTPUT_FILE}")"
+fi
+
+CONTEXT=$(kubectl config current-context)
+log "Cluster context: ${CONTEXT}"
+
+read -r IDENTITY_RELEASE IDENTITY_NAMESPACE < <(discover_release identity "${IDENTITY_RELEASE}" "${IDENTITY_NAMESPACE}")
+read -r REGION_RELEASE REGION_NAMESPACE < <(discover_release region "${REGION_RELEASE}" "${REGION_NAMESPACE}")
+
+IDENTITY_BASE_URL="$(discover_base_url identity "${IDENTITY_RELEASE}" "${IDENTITY_NAMESPACE}" "${IDENTITY_BASE_URL}")"
+REGION_BASE_URL="$(discover_base_url region "${REGION_RELEASE}" "${REGION_NAMESPACE}" "${REGION_BASE_URL}")"
+IDENTITY_INGRESS_IP="$(discover_ingress_ip)"
+
+if [[ "${SYNC_CA}" == true ]]; then
+  sync_ca_bundle
+elif [[ ! -f "${CA_CERT}" ]]; then
+  fatal "CA bundle does not exist: ${CA_CERT}"
+fi
+
+log "Identity: release=${IDENTITY_RELEASE}, namespace=${IDENTITY_NAMESPACE}, url=${IDENTITY_BASE_URL}"
+log "Region: release=${REGION_RELEASE}, namespace=${REGION_NAMESPACE}, url=${REGION_BASE_URL}"
+write_env_file "${OUTPUT_FILE}"
+
+if [[ "${OUTPUT_FILE}" != "-" ]]; then
+  log "Wrote ${OUTPUT_FILE}"
+fi


### PR DESCRIPTION
This PR makes it possible to use something like [devstack](https://docs.openstack.org/devstack/latest/) for developing and testing against. The integration test fixture needs some information about how UNI is run in the Kubernetes cluster, and a region to run against (actually more than one, but one _main_ region).

The various bits of integration tests rendezvous via env files. The relevant ones here are `test/.env.install` about the UNI installation, output by the KinD-based install used in GHActions; and, `test/.env`, which is generated when the fixture is created, and used by the tests themselves.

 - add a little script that looks at the local UNI installation and outputs a `test/.env.install`, to be used for creating fixtures
 - adapt the fixture generation so it can be pointed at an OpenStack region.
