### PR TITLE
docs: add package architecture readmes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,24 @@ All new tests must follow the patterns established in `test/api/`:
 
 - **Build tags**: Integration tests use `//go:build integration`.
   E2e tests use `//go:build e2e`. Never omit the build tag.
+
+## Documentation Maintenance
+
+The package documentation under `pkg/**/README.md` is part of the implementation contract for this
+repository, not optional commentary.
+
+- Before making changes, consult the relevant package documentation so code changes stay aligned
+  with the documented architecture, invariants, caveats, API conventions, and lifecycle model.
+- Use `pkg/README.md` as the ordered knowledge-graph entry point for service internals, then drill
+  into the specific package docs it links to.
+- When implementation changes alter behaviour, architecture, lifecycle semantics, error handling,
+  trust boundaries, or provider/linkage assumptions, update the affected package documentation in
+  the same change.
+- Keep the documentation link graph coherent:
+  - avoid dead links
+  - add links for any new meaningful package documentation
+  - update higher-level rollups when lower-level package responsibilities move
+- If a code change invalidates an existing caveat or TODO in the docs, correct it rather than
+  leaving stale guidance behind.
+- Treat the top-level `README.md` and `pkg/README.md` as landing pages that should remain
+  technically accurate for new starters, external observers, and AI coding assistants.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Region
 
-Centralized region discovery and routing service.
+Region is the platform's cloud and region abstraction service. It exposes
+provider-backed regions, networks, images, servers, load balancers, storage,
+and related project-scoped infrastructure through one API and lifecycle model.
+
+## Developers
+
+[Developer Hub](https://github.com/nscaledev/uni/blob/main/DEVELOPER.md)
+
+## Package Documentation
+
+Implementation-level package documentation lives in [pkg/README.md](./pkg/README.md).
+Use that as the drill-down entry point for the service internals, especially
+for the API model, provider bindings, handlers, controller lifecycle, and
+monitoring behaviour.
 
 ## Architecture
 
@@ -9,13 +22,33 @@ We provide a composable suite of different micro-services that provide different
 Hardware provisioning can come in a number of different flavors, namely bare-metal, managed Kubernetes etc.
 These services have a common requirement on a compute cloud/region to provision projects, users, roles, networking etc. in order to function.
 
+The current region service is therefore more than simple discovery. It is the
+shared layer that:
+
+- maps platform resources onto real cloud/provider resources
+- maintains project-scoped service-principal and resource lifecycle
+- exposes a common API shape across different provider substrates
+- coordinates both desired-state reconciliation and observed-state monitoring
+
+The preferred API direction is `v2`. Older `v1` shapes remain as deprecated
+compatibility surface and should be migrated away from as quickly as practical.
+
 ### A Note on Security
 
-At present this region controller is monolithic, offering region discovery and routing to allow scoped provisioning and deprovisioning or the aforementioned hardware prerequisites.
+At present this service is still monolithic. It combines region discovery and
+routing with the provider-facing lifecycle work needed to provision and
+deprovision the aforementioned hardware prerequisites.
 
-Given this service holds elevated privilege credentials to all of those clouds, it make it somewhat of a honey pot.
-Eventually, the goal is to have this act as a purely discovery and routing service, and platform specific region controllers live in those platforms, including their credentials.
-The end goal being the compromise of one, doesn't affect the others, limiting blast radius, and not having to disseminate credentials across the internet, they would reside locally in the cloud platform's AS to improve security guarantees.
+Given this service holds elevated-privilege credentials to those clouds, it is
+somewhat of a honey pot.
+
+Longer term, the goal is to move toward a model where this service is primarily
+discovery and routing, and platform-specific region controllers live within the
+target platforms alongside their credentials.
+
+That would reduce blast radius, because compromise of one provider-local
+controller would not automatically affect the others, and it would avoid having
+to disseminate provider credentials across the internet.
 
 ## Supported Providers
 
@@ -25,20 +58,28 @@ OpenStack is an open source cloud provider that allows on premise provisioning o
 It allows a vertically integrated stack from server to application, so you have full control over the platform.
 This obviously entails a support crew to keep it up and running!
 
-For further info see the [OpenStack provider documentation](pkg/providers/internal/openstack/README.md).
+For further info see the [OpenStack provider documentation](pkg/providers/internal/openstack/ADMIN.md).
 
 ### Kubernetes
 
-Kubernetes regions allow Kubernetes clusters from any cloud provider to be consumed and increase capacity without the hassle of physical infrastructure.
-Kubernetes regions are exposed to end users with virtual Kubernetes clusters.
+Kubernetes regions allow existing Kubernetes clusters from any cloud provider
+to be consumed as region substrates without the hassle of physical
+infrastructure.
 
-For further info see the [Kubernetes provider documentation](pkg/providers/internal/kubernetes/README.md).
+They are not limited to one workload model. A Kubernetes-backed region can be
+used for Kubernetes-on-Kubernetes patterns such as virtual clusters, but the
+important contract is broader than that: the backing cluster must expose a
+region shape that higher-level services can consume in roughly the same way as
+other clouds. That could include virtual clusters, VM-style provisioning, or
+other region-shaped services.
+
+For further info see the [Kubernetes provider documentation](pkg/providers/internal/kubernetes/ADMIN.md).
 
 ## Installation
 
 ### Prerequisites
 
-The use the Kubernetes service you first need to install:
+To use the region service you first need to install:
 
 * [The identity service](https://github.com/nscaledev/uni-identity) to provide API authentication and authorization.
 

--- a/cmd/unikorn-region-project-consumer/README.md
+++ b/cmd/unikorn-region-project-consumer/README.md
@@ -1,0 +1,80 @@
+# `cmd/unikorn-region-project-consumer`
+
+## Purpose
+
+This command is a cross-service lifecycle-edge bridge.
+
+It watches `Project` lifecycle events from identity and propagates project
+deletion into region root resources that are scoped to that project by label.
+
+Right now it registers cascading-delete consumers for:
+
+- `Identity`
+- `FileStorage`
+- `SSHCertificateAuthority`
+
+So this command does not implement a new deletion model by itself. It adds one
+specific edge type to the platform lifecycle DAG by stitching together two
+existing local models:
+
+- identity's project lifecycle and deletion semantics
+- region's own root-resource cascade semantics
+
+Without this bridge, those two systems would be locally correct but globally
+disconnected.
+
+## What It Adds
+
+Identity already knows when a project is being deleted.
+
+Region handlers and controllers already know how to cascade deletion once a
+region root resource is told to die.
+
+This command adds the missing cross-repo propagation edge:
+
+1. observe project deletion in identity
+2. discover region root resources labeled with that project
+3. delete those roots in the shared region namespace
+4. let region's owner refs, finalizers, and controllers take over from there
+
+That preserves the platform-level invariant that deleting a project should
+retire its region-owned project roots too, even though they live in a different
+service and are not isolated by per-project namespaces.
+
+## Invariants And Guard Rails
+
+- Identity remains the source of truth for project lifecycle.
+- This command is label-driven: it only finds region roots that are correctly
+  labeled with `coreconstants.ProjectLabel`.
+- It should only target true region root resources. Descendant cleanup is
+  expected to happen through region's own ownership and reconciliation logic
+  after the root is deleted.
+- The command operates in the shared region namespace, which is why label-based
+  discovery is necessary in the first place.
+
+## Caveats
+
+- Correctness depends on the root set being complete. If a project-scoped root
+  resource is not registered here, project deletion in identity will not
+  automatically trigger its teardown in region.
+- Correctness also depends on downstream region root deletion working properly.
+  This command initiates teardown; it does not replace region's own cascading
+  semantics.
+- Because it is simple, it would be easy to undersell. Architecturally it is
+  one of the explicit pieces that makes cross-service tenancy deletion behave
+  like one platform rather than adjacent services.
+
+## TODO
+
+- Keep the list of consumed region project-root resource kinds in sync with the
+  real set of project-scoped roots in region.
+- Revisit whether any additional region root resources should participate in the
+  project-deletion bridge as the API evolves.
+
+## Cross-Package Context
+
+- [../../pkg/handler/README.md](../../pkg/handler/README.md) documents the
+  region-side deletion and ownership semantics this command relies on after it
+  deletes a root
+- [`../../../identity/pkg/handler/README.md`](../../../identity/pkg/handler/README.md)
+  documents the identity-side project lifecycle this command listens to

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,0 +1,180 @@
+# Packages
+
+## Purpose
+
+This tree contains the region service implementation.
+
+At a high level it splits into six layers:
+
+- API and storage model definition
+- cloud-provider abstraction and concrete provider bindings
+- request handling and server composition
+- controller/provisioner lifecycle management
+- polling-based status and telemetry projection
+- a small amount of shared client and wiring glue
+
+The useful way to read it is not as a directory tree, but as one system:
+
+- handlers shape and validate the lifecycle graph
+- provisioners and managers realize provider-side effects
+- monitors project observed provider truth back into status and metrics
+- providers bind the region model to real or simulated clouds
+
+## Recommended Reading Order
+
+### API And Contract Model
+
+- [constants](./constants/README.md)
+- [apis/unikorn/v1alpha1](./apis/unikorn/v1alpha1/README.md)
+- [openapi](./openapi/README.md)
+
+These packages define the shared control vocabulary, the stored Kubernetes
+resource model, and the HTTP wire contract.
+
+The most important direction here is that `v2` is the intended API shape.
+`v1` remains as deprecated compatibility surface and should be migrated away
+from as quickly as practical.
+
+### Provider Model
+
+- [providers](./providers/README.md)
+- [providers/types](./providers/types/README.md)
+- [providers/internal/openstack](./providers/internal/openstack/README.md)
+- [providers/internal/kubernetes](./providers/internal/kubernetes/README.md)
+- [providers/internal/simulated](./providers/internal/simulated/README.md)
+
+These packages define the mixed provider boundary:
+
+- CRD-backed service resources are still passed through in native region shapes
+- non-CRD provider concepts use intermediate provider-neutral types
+- concrete providers preserve the linkage between region resources and real
+  cloud resources
+
+OpenStack is the real heavyweight implementation. Kubernetes and simulated are
+alternative substrates shaped to fit the same broad service model.
+
+### Handler And Server Layer
+
+- [client](./client/README.md)
+- [handler](./handler/README.md)
+- [server](./server/README.md)
+
+These packages define the application layer:
+
+- direct lookup in a shared namespace rather than namespace indirection
+- label- and relationship-derived scope
+- `v2` selector-prefiltered listing and principal-context completion
+- request-to-storage/provider translation
+- platform-defined middleware and server composition
+
+### Controller Lifecycle Layer
+
+- [provisioners](./provisioners/README.md)
+- [managers](./managers/README.md)
+
+These packages define how desired state becomes provider-side effects.
+
+Managers are thin controller factories. Provisioners hold the resource-specific
+lifecycle logic: waiting for prerequisite identity readiness, maintaining
+reference edges, calling providers, and cleaning up allocation/accounting
+relationships.
+
+### Monitor Layer
+
+- [monitor](./monitor/README.md)
+- [monitor/health/server](./monitor/health/server/README.md)
+
+These packages cover the part of the system that is intentionally observational
+rather than declarative.
+
+They poll provider-backed reality and project it back into Kubernetes status,
+logs, and telemetry. That is an important architectural admission: not all
+lifecycle truth in this platform arrives through controller watches alone.
+
+## Important Cross-Cutting Themes
+
+### `v2` First
+
+The service is converging on flat `v2` APIs.
+
+Compared with the older nested `v1` model, that means:
+
+- direct resource addressing instead of deep path hierarchy
+- org/project context recovered from request fields or dependent resources
+- list working sets constrained before RBAC walks
+- more handler responsibility for inferred scope and graph validation
+
+`v1` is not an equal architectural citizen. It is deprecated compatibility
+surface.
+
+### Shared Namespace, Recovered Scope
+
+Unlike identity, region does not primarily model user-visible scope by mapping
+it onto separate Kubernetes namespaces.
+
+Most resources live in one shared namespace. Scope is reconstructed through:
+
+- labels
+- owner relationships
+- dependent-resource lookup
+- RBAC checks over recovered organization/project bindings
+
+That difference is one of the most important things to understand before
+reading the handlers.
+
+### Lifecycle DAG
+
+The service behaves like a lifecycle DAG whose edges carry different blocking
+and propagation semantics.
+
+Common edge types include:
+
+- owner references
+- explicit blocking references
+- quota/allocation consistency edges
+- hidden service-principal roots
+- cross-service propagation bridges
+
+This is the abstraction that ties together handlers, provisioners, monitors,
+and even command-level consumers outside `pkg`.
+
+### OpenStack Project Scoping
+
+OpenStack is not just a provider backend here. It strongly shapes the service
+model.
+
+The important pattern is:
+
+- managed-domain authority provisions user/project scaffolding
+- most real cloud resources are then created in the per-identity project
+- the OpenStack project becomes the main lookup, isolation, and intended
+  accounting boundary
+
+That is why service principals, hidden identity roots, deterministic lookup,
+and image/resource visibility rules matter so much throughout this tree.
+
+### Best-Effort Consistency
+
+Much of the service operates over Kubernetes objects plus external provider and
+service APIs rather than a single transaction system.
+
+The main consistency tools are:
+
+- optimistic read/modify/write
+- ownership and deletion blocking
+- saga-based compensation for true multi-operation workflows
+- polling where observed truth cannot be trusted to arrive through watches
+
+This is especially visible in:
+
+- [handler](./handler/README.md)
+- [provisioners](./provisioners/README.md)
+- [monitor](./monitor/README.md)
+
+## Caveats
+
+- The package graph still contains transitional compatibility debt, especially
+  around `v1`, provider-specific historical state, and version-label handling.
+- Some of the most important lifecycle edges are not contained entirely within
+  `pkg`; for example, cross-service project deletion propagation is implemented
+  by [`cmd/unikorn-region-project-consumer`](../cmd/unikorn-region-project-consumer/README.md).

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -1,0 +1,103 @@
+# pkg/apis/unikorn/v1alpha1
+
+## Intention
+
+`pkg/apis/unikorn/v1alpha1` defines the region service's Kubernetes storage
+model and controller contract. It is not just a set of CRD structs for
+generation. It is the persisted object model that handlers, provisioners,
+providers, monitors, and controller-runtime integrations share.
+
+The package contains three broad kinds of object:
+
+- user-meaningful region resources such as `Region`, `Identity`, `Network`,
+  `SecurityGroup`, `LoadBalancer`, `SSHCertificateAuthority`, `Server`, and
+  `FileStorage`
+- service-internal provider state, primarily `OpenstackIdentity`
+- operational support objects such as `VLANAllocation`, `FileStorageClass`, and
+  `FileStorageProvisioner`
+
+That split matters. Not every type in this package is part of the public
+service model in the same way. Some types exist mainly so controllers and
+providers have durable state to coordinate around, while others are historical
+carryovers from older designs.
+
+## Links
+
+- [../../constants](../../constants/README.md)
+
+`pkg/constants` defines much of the label and annotation vocabulary that these
+stored objects rely on for linkage, migration, and operational coordination.
+
+## Invariants And Guard Rails
+
+- This package defines Kubernetes storage objects, not the full public service
+  contract. Higher-level API semantics are layered on top elsewhere.
+- A new external API generation does not necessarily imply a new CRD or storage
+  model. This repository performs some API evolution in place over broadly
+  stable stored shapes.
+- `Region` is the configuration and capability root for a provider-backed
+  region. It carries provider type, provider-specific configuration, stored
+  visibility inputs, flavor/image/network selection rules, and helper methods
+  that downstream code actively depends on.
+- Namespaced Kubernetes storage scope and platform tenancy scope are separate
+  concerns. These objects are namespaced, but their logical visibility and
+  authorization are often organization-, project-, identity-, or region-scoped
+  at higher layers.
+- `OpenstackIdentity` is the remaining necessary provider-state record. It
+  persists the information needed to find and use the ephemeral OpenStack user,
+  project, and credentials that back a region `Identity`, because those values
+  cannot be recovered later by deterministic lookup in the same way as many
+  other cloud-side objects.
+- `VLANAllocation` is a coordination object, not a user-facing resource. It is
+  designed around there being only one allocation record per region and relies
+  on Kubernetes optimistic locking for safe concurrent updates.
+- Several resources implement helper methods such as `Paused()`,
+  `StatusConditionRead()`, and `StatusConditionWrite()` because this package
+  also satisfies generic controller contracts. It should not be described as
+  schema-only.
+- `FileStorage` carries a more explicit observed-state model than the older
+  resource types. Attachment-level provisioning state, observed size, and usage
+  reporting are part of the stored reconciliation contract.
+
+## Caveats
+
+- This package mixes durable public resource storage, internal provider state,
+  and transitional compatibility fields in one API group. Readers must not
+  assume that every type here is equally service-facing or equally stable.
+- Some fields are explicitly transitional rather than ideal long-term schema.
+  `Network.Spec.Provider` and `NetworkStatus.Openstack` are called out in code
+  as temporary compatibility baggage.
+- `OpenstackNetwork`, `OpenstackSecurityGroup`, and `OpenstackServer` are
+  historical state-record types from an older design that attempted to mirror
+  OpenStack state locally. That approach created drift and race conditions, and
+  these types are now better understood as deletion candidates rather than
+  durable architectural primitives.
+- Where possible, OpenStack itself is now the intended source of truth for
+  cloud-side state, with local code preferring deterministic lookup over
+  mirrored persistence.
+- `ResourceLabels()` exists on several resources to satisfy shared controller
+  interfaces, but currently returns `nil, nil`. That is an implementation
+  contract for generic integration, not proof that these resources already have
+  a meaningful label-tuple identity model defined here.
+- `SSHCertificateAuthority` is structurally much lighter than the other major
+  resource types. It has no status and behaves more like a stored project-scoped
+  OpenSSH user CA record than a long-running provisioned object.
+
+## TODO
+
+- Delete `OpenstackNetwork`, `OpenstackSecurityGroup`, and `OpenstackServer`.
+  They are leftover mirror-state CRDs from an older design that drifted from
+  OpenStack and introduced race conditions.
+- Remove the remaining transitional `Network` compatibility baggage, especially
+  `Network.Spec.Provider` and `NetworkStatus.Openstack`, once the old paths no
+  longer need to be preserved.
+
+## Cross-Package Context
+
+- handler packages define the user-visible API behaviour, authorization checks,
+  and migration semantics layered on top of these stored shapes
+- provider and provisioner packages turn these stored specs and status records
+  into concrete cloud-side resources and, where still necessary, internal
+  provider state
+- monitor code consumes the same stored model and status helpers, especially for
+  server lifecycle and health transitions

--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -1,0 +1,110 @@
+# Client
+
+## Purpose
+
+This package is the region-specific realization of the generic client machinery
+in [`core/pkg/client`](../../../core/pkg/client/README.md), built on top of
+the outbound identity-aware transport model already established in
+[`identity/pkg/client`](../../../identity/pkg/client/README.md).
+
+Its main job is to construct outbound region API clients that obey the same
+internal service-to-service trust model used elsewhere in the platform.
+
+In practice that means:
+
+- building generated [OpenAPI](../openapi/README.md) clients for the region API
+- reusing the shared TLS and HTTP client construction from
+  [`core/pkg/client`](../../../core/pkg/client/README.md)
+- reusing the delegated-principal and trace-propagation model from
+  [`identity/pkg/client`](../../../identity/pkg/client/README.md)
+- exposing a small region-specific helper for network reference lifecycle
+
+This is not a general client-abstraction package. Most of the interesting trust
+and transport behaviour lives below it in `core` and `identity`. This package
+mainly binds those shared client foundations to the region OpenAPI surface.
+
+## Main Components
+
+### Client
+
+`Client` is a thin wrapper around `identity/pkg/client.BaseClient`.
+
+It carries:
+
+- a Kubernetes client
+- region HTTP endpoint options
+- optional HTTP client certificate configuration
+
+It does not reimplement transport behaviour itself. It reuses the base client
+so region callers inherit the same internal trust and delegation machinery as
+other service-to-service clients.
+
+### APIClient
+
+`APIClient(...)` is the normal service-to-service path.
+
+It constructs a generated region API client from [`pkg/openapi`](../openapi)
+and delegates request construction to `identity/pkg/client` so outbound calls
+carry the same trace and principal propagation model expected by the wider
+platform.
+
+### ControllerClient
+
+`ControllerClient(...)` is the controller/provisioner path.
+
+Instead of assuming an active request principal already exists in context, it
+reconstructs delegated principal information from a persisted Kubernetes
+resource and applies that to the outbound region API request.
+
+This is what allows controller-style workflows in other services to call the
+region API while still participating in the same delegated identity model as
+request-originated flows.
+
+### References
+
+`References` is the only region-specific helper currently living in this
+package.
+
+It wraps the region API's network-reference endpoints so remote services can add
+or remove dependency references on a `Network` using the shared resource
+reference model from [`core/pkg/manager`](../../../core/pkg/manager/README.md).
+
+That matters because deletion protection is not purely local to region-owned
+descendants. Other services may hold logical dependencies on a network, and the
+reference API is how they register or release those dependencies over the
+normal service boundary.
+
+## Invariants And Guard Rails
+
+- This package is an outbound region-API client binding, not a standalone trust
+  or transport implementation.
+- The authoritative transport and delegation behaviour comes from
+  `core/pkg/client` and `identity/pkg/client`; this package should stay thin and
+  avoid forking those rules locally.
+- `APIClient` is for request-context service-to-service calls.
+- `ControllerClient` is for controller/provisioner-style calls that must derive
+  delegated principal context from durable resource metadata.
+- `References` uses the shared resource-reference model from
+  [`core/pkg/manager`](../../../core/pkg/manager/README.md) rather than inventing
+  a region-specific dependency identity format.
+- Reference add/remove operations are thin API wrappers intended for normal
+  convergent lifecycle use, with success determined by the region API response
+  rather than by local client-side assumptions.
+
+## Caveats
+
+- The package name is broader than the current responsibility. This is mostly a
+  region OpenAPI client wrapper plus one network-reference helper.
+- Most of the interesting behaviour is inherited rather than implemented here.
+  If the trust model or principal propagation changes, the real source of truth
+  is in `core` and `identity`, not this package.
+- `References` currently covers only network references. That is a real current
+  contract surface, not a generic reusable dependency helper for every region
+  resource type.
+- `References` still carries dead constructor shape inherited from the matching
+  identity helper: `serviceDescriptor` is accepted but not currently used here.
+  If outbound wire identity is ever added, it should be implemented in the
+  shared client-construction path rather than hidden in this helper.
+- Because this package is intentionally thin, it is easy to overestimate how
+  much “region client logic” actually lives here. Most failures in outbound
+  trust semantics would originate below this package, even if they surface here.

--- a/pkg/constants/README.md
+++ b/pkg/constants/README.md
@@ -1,0 +1,84 @@
+# pkg/constants
+
+## Intention
+
+`pkg/constants` is the region service's shared control vocabulary. It is the
+single place that defines the service's canonical runtime identity and the
+metadata keys that other packages rely on for resource linkage, in-place API
+migration, image-origin discrimination, and a small amount of operational state
+tracking.
+
+Most of the package is not "just constants" in the casual sense. It contains a
+small number of contract clusters:
+
+- runtime identity for the service binary
+- linkage labels that tie stored resources back to their region, identity, or
+  network context
+- an API-generation label used to distinguish old and new external API
+  semantics while keeping storage broadly in place
+- specialized image and server-state metadata that drives snapshot/import
+  provenance and monitor-owned pending-state timing
+
+The same package also defines the process-level build metadata for the running
+binary: application name, version, revision, and the derived service
+descriptor/version string used by shared runtime layers.
+
+## Invariants And Guard Rails
+
+- This package is a shared contract package, not a miscellaneous bucket for
+  arbitrary constants.
+- Code that reads or writes the region service's standard labels, annotations,
+  and tags should use these constants rather than open-coded strings.
+- `RegionLabel`, `IdentityLabel`, and `NetworkLabel` are part of the service's
+  resource-linkage model. They are not optional decorative metadata.
+- `ResourceAPIVersionLabel` is the canonical stored discriminator used to
+  distinguish old and new external API generations when the underlying CRD
+  shape remains broadly stable and objects are migrated in place rather than
+  split into separate storage models.
+- `MarshalAPIVersion()` and `UnmarshalAPIVersion()` define the current storage
+  encoding for that API version discriminator as a decimal string.
+- `ServerPendingEntryTimeAnnotation` has a single-writer operational contract:
+  the region monitor stamps it when a server enters `Pending` and removes it
+  when the server leaves that state.
+- `ImageSourceTag`, `ImageSourceImport`, `ImageSourceSnapshot`, and
+  `ImageOrganizationIDTag` are part of the current image-origin contract used to
+  distinguish imported images pushed into OpenStack via the back channel from
+  snapshot-derived images, and to preserve organization ownership where display
+  and deletion semantics differ.
+- `Application`, `Version`, and `Revision` are the canonical runtime identity
+  for the binary in this repository.
+- `ServiceDescriptor()` must remain aligned with the shared `core`
+  `ServiceDescriptor` shape so manager and runtime code can consume it
+  generically.
+- `VersionString()` must remain suitable for wire-visible client identity such
+  as HTTP `User-Agent` style reporting.
+
+## Caveats
+
+- Changing active metadata keys here is a compatibility change across multiple
+  packages and, in some cases, across repositories. It is not a local refactor.
+- `Application` is derived from `os.Args[0]`, so reported process identity
+  depends partly on how the binary is packaged or invoked.
+- If the build does not inject `Version` or `Revision`, the package still
+  compiles, but much of its deployment-debugging value is lost.
+- `ServerPendingEntryTimeAnnotation` records an entry timestamp, but its value
+  is not corrected while the server stays pending. Manual edits therefore remain
+  visible until the next state transition out of and back into `Pending`.
+- The image-origin contract is currently encoded in generic user-visible tags,
+  which is a weak abstraction for service-owned semantics. A typed API field
+  would be a safer long-term design than relying on mutable key/value metadata.
+- `SecurityGroupLabel` and `ServerLabel` are currently better treated as
+  transitional vocabulary than as strong active contracts. If their remaining
+  consumers disappear, they are plausible deletion candidates rather than keys
+  that should be preserved indefinitely.
+- The package mixes two related but distinct concerns: runtime service identity
+  and resource metadata contract. That is coherent today, but it means readers
+  should not undersell the package because of its small size.
+
+## Cross-Repo Context
+
+This package follows the same cross-repository pattern used elsewhere for
+runtime identity and service descriptors, but most of its metadata vocabulary is
+best understood first as a region-repository contract for resource linkage,
+in-place API migration, image-origin handling, and monitor-managed server
+timing.

--- a/pkg/handler/README.md
+++ b/pkg/handler/README.md
@@ -1,0 +1,253 @@
+# `pkg/handler`
+
+This package is the API application layer for region.
+
+## Intent
+
+The handler layer sits below middleware and above persisted Kubernetes
+resources, provider abstractions, and a small amount of cross-service API
+coordination with identity.
+
+It is where the region API turns:
+
+- authenticated and authorized request context
+- OpenAPI request/response models
+- CRD-backed storage
+- provider-backed non-CRD capabilities
+
+into resource-specific behaviour.
+
+At the top level, [`handler.go`](./handler.go), [`handler_v2.go`](./handler_v2.go),
+[`handler_v2_server.go`](./handler_v2_server.go), and the image-specific glue are
+mostly transport wiring: they perform final handler-level RBAC checks where needed,
+read request bodies, delegate to resource-specific clients, and normalize response
+and error handling. The real package behaviour lives in the per-resource clients
+beneath them.
+
+The most important architectural fact in this package is that `v2` is the intended
+handler model. `v1` is deprecated compatibility surface and should be migrated
+away from as quickly as practical.
+
+So this package should be understood primarily in `v2` terms:
+
+- flatter API shapes
+- direct resource lookup in a shared namespace
+- label- and relationship-derived scope
+- selector-prefiltered list operations
+- saga-backed multi-object workflows where needed
+
+`v1` remains important only because migration is not complete yet.
+
+## Shared Handler Model
+
+Most handler clients follow the same broad pattern:
+
+1. resolve logical scope and visibility
+2. load current state where mutation is involved
+3. convert API request shape into required stored or provider-facing shape
+4. merge system-owned metadata and derived context
+5. write back with conflict detection where applicable
+6. convert stored or provider-derived state back into API read models
+
+This is not a blind REST-to-CRD translation layer. The handler layer is allowed
+to enforce cross-resource invariants, repair missing operational context, manage
+best-effort consistency across multiple objects, and reject requests that would
+create obviously broken relationships.
+
+## `v2` First
+
+`v2` is not just a flatter URL scheme. It changes how the handler layer works.
+
+Compared with the older nested `v1` model:
+
+- org/project context is no longer always present in the request path
+- handlers often infer context from the request body or a dependent resource
+- direct resource IDs are favored over path nesting
+- list handlers use query parameters to constrain the working set before RBAC
+  walks it
+- resources created by the newer API are often gated with
+  `ResourceAPIVersionLabel=2`
+
+This is why the `v2` support helpers in [`util`](./util/README.md) exist at all.
+
+### Principal Context Completion
+
+In `v1`, tenancy context was often explicit in the path.
+
+In `v2`, write paths such as `POST /api/v2/...` may not carry organization and
+project in the URL, but the handler still needs that context for:
+
+- audit attribution
+- quota charging
+- billing/accounting
+- ownership enforcement
+
+So `v2` handlers often recover org/project context from:
+
+- required request fields
+- or a dependent resource that already carries the binding, such as
+  `server -> network`
+
+### Selector-Prefiltered Lists
+
+`v2` list handlers typically:
+
+1. start from a label selector
+2. add org/project constraints using RBAC query helpers
+3. add region/network constraints where applicable
+4. list from the shared namespace
+5. apply tag filtering
+6. apply per-item RBAC filtering
+
+This is a real scalability and consistency pattern, not incidental code style.
+
+## Shared Scoping Model
+
+Unlike identity, region does not primarily resolve user-visible scope into a
+separate Kubernetes namespace. Most region resources live in one shared
+namespace.
+
+That means handler scope is reconstructed through:
+
+- labels
+- owner relationships
+- dependent-resource lookups
+- RBAC checks against recovered organization/project bindings
+
+This is one of the biggest architectural differences from
+[`identity/pkg/handler`](../../../identity/pkg/handler/README.md).
+
+## Shared Lifecycle Graph
+
+The other major difference from identity is that region makes the platform's
+lifecycle graph very visible.
+
+In practice, the system behaves like a DAG of resources connected by edges with
+different semantics. Those edges can encode:
+
+- propagation: should lifecycle intent flow across this edge?
+- blocking: should deletion or teardown be prevented while this edge exists?
+
+In region, the common edge mechanisms are:
+
+- Kubernetes owner references for strong propagation and parent blocking
+- foreground deletion for some older `v1` roots
+- explicit resource references or finalizers for blocking edges without
+  ownership
+- cross-service consumers for propagation bridges across repositories
+- quota/allocation relationships for accounting consistency edges
+
+Examples:
+
+- `v1` `Identity` acts as the root of the older ownership tree for dependent
+  resources
+- `v2` `Network` is special and creates its own service-principal identity
+- `v2` `SecurityGroup`, `LoadBalancer`, and `Server` are generally owned by a
+  `Network`
+- `SSHCertificateAuthority v2` blocks deletion through explicit reference checks
+- `Network v2` supports external references that block deletion
+
+So the lifecycle invariant is:
+
+- users should delete the visible parent resource
+- handler, controller, and cross-service consumer logic should make downstream
+  propagation or blocking happen appropriately for each edge type
+- clients should not need to hunt for every child manually
+
+## Shared Consistency Model
+
+Many handler workflows touch more than one object or subsystem.
+
+Examples include:
+
+- quota/allocation changes alongside resource creation or update
+- service-principal creation plus network creation
+- resource validation against other resources before mutation
+- provider-backed checks such as image lookup or network suitability
+
+Because the backing store is Kubernetes objects and some workflows also cross
+service or provider boundaries, there is no transaction layer.
+
+The main consistency tools are:
+
+- explicit read/modify/write
+- optimistic-locking patch semantics
+- owner refs and deletion blocking
+- saga-based compensating workflows where a handler must coordinate multiple API
+  operations rather than simply write Kubernetes state and rely on watch-driven
+  propagation
+
+### Saga Use
+
+This package is the first place in region where the saga pattern becomes a real
+architectural tool rather than an abstract library concept.
+
+Sagas are used where handlers need ordered multi-step workflows with explicit
+rollback/compensation, for example:
+
+- `network v2` create
+- `loadbalancer v2` create/update
+- `storage v2` create/update
+
+That is the handler-layer answer to “we need consistency across multiple steps,
+but we do not have transactions.”
+
+## Resource Patterns
+
+- [`identity`](./identity/README.md): deprecated `v1` compatibility surface for
+  the still-important service-principal/project-scoping concept
+- [`region`](./region/README.md): read-side visibility and capability exposure
+- [`image`](./image/README.md): provider-backed image import/query/delete and
+  provenance handling
+- [`network`](./network/README.md): core connectivity resource; `v2` network is
+  the visible coordination point for a hidden service-principal-backed ownership
+  root
+- [`securitygroup`](./securitygroup/README.md): network-linked policy resource
+- [`server`](./server/README.md): compute lifecycle plus operational verbs and
+  snapshot bridge into image semantics
+- [`loadbalancer`](./loadbalancer/README.md): network-linked service with
+  stronger validation and quota coupling
+- [`sshcertificateauthority`](./sshcertificateauthority/README.md): project-scoped
+  SSH CA records with explicit reference-blocked deletion
+- [`storage`](./storage/README.md): quota-heavy stateful resource with saga-backed
+  create/update and attachment validation
+
+## Caveats
+
+- `v1` and `v2` are not equal architectural citizens. `v1` is deprecated and
+  should not be treated as the model for future work.
+- The flatter `v2` API is better for clients, but it pushes more hidden
+  complexity into handlers:
+  - context inference
+  - principal repair
+  - direct relationship lookup
+  - API-version gating
+- Because most resources live in one namespace, label discipline is critical.
+  Scope, visibility, ancestry, and migration state all depend on it.
+- Cross-object invariants are only best-effort. Owner references, finalizers,
+  allocation records, and saga compensation improve consistency, but they do not
+  turn the system into an ACID store.
+
+## TODO
+
+- Continue migrating all remaining `v1` handler surfaces to `v2` equivalents and
+  then delete the deprecated `v1` compatibility paths.
+- Remove handler behaviours that still depend on transitional provider-specific
+  status or older API/storage shapes as those compatibility bridges disappear.
+- Revisit places where the current `v2` model still hides an implicit resource
+  or service-principal concept that would be cleaner as an explicit API object.
+- Audit `v2` mutation RBAC verbs for copy/paste drift. Some update paths appear
+  to check `Delete` where `Update` is more likely to be the intended action.
+
+## Related Documentation
+
+- [`../openapi`](../openapi/README.md), which documents the public contract these
+  handlers implement
+- [`../../../identity/pkg/middleware/openapi`](../../../identity/pkg/middleware/openapi/README.md),
+  which establishes the trusted request context handlers consume
+- [`../apis/unikorn/v1alpha1`](../apis/unikorn/v1alpha1/README.md), which defines
+  the persisted storage contract the handlers read and write
+- [`../providers`](../providers/README.md), which documents the provider layer
+  many handlers depend on for real cloud-side behaviour
+- [`../../../core/pkg/server/conversion`](../../../core/pkg/server/conversion/README.md),
+  which provides shared metadata and conversion helpers used heavily here

--- a/pkg/handler/common/README.md
+++ b/pkg/handler/common/README.md
@@ -1,0 +1,79 @@
+# Common
+
+## Purpose
+
+`pkg/handler/common` defines the shared constructor dependency bundle for the
+region handler layer.
+
+Its entire job is `ClientArgs`: a pragmatic package-level contract for the
+ambient capabilities most handlers need in order to do useful work.
+
+Those capabilities are:
+
+- cached Kubernetes access
+- process namespace
+- provider lookup
+- outbound identity API access
+
+This is not an especially pure abstraction. It is a practical way to keep
+handler construction uniform without hiding runtime dependencies in
+`context.Context` or forcing a much larger refactor around a dedicated handler
+runtime object.
+
+## Main Component
+
+### ClientArgs
+
+`ClientArgs` is the shared constructor shape used by most region handlers and
+their helper clients.
+
+It carries:
+
+- `client.Client` for cached Kubernetes access
+- `Namespace` for process-local namespace scoping
+- `providers.Providers` for provider lookup
+- `identityapi.ClientWithResponsesInterface` for identity-side RBAC and tenancy
+  interactions
+
+The struct is intentionally made of interfaces and scalars so handlers remain
+easy to unit test and do not need to construct their own ambient clients
+ad hoc.
+
+## Invariants And Guard Rails
+
+- This package owns wiring shape, not business logic.
+- `ClientArgs` is a shared handler-layer constructor contract with wide fan-out
+  across concrete handler packages and top-level server wiring.
+- The dependency bundle is intentionally coarse-grained for practicality, but it
+  should still stay limited to ambient capabilities that are genuinely shared
+  across the handler layer.
+- Provider access is injected as the lookup façade in
+  [`pkg/providers`](../../providers/README.md), not as concrete provider
+  implementations.
+- Identity access is treated as a normal ambient dependency of region handlers,
+  not something each handler should construct independently.
+
+## Caveats
+
+- The package name `common` is broader than the actual responsibility. This is
+  really a handler wiring/dependency contract package.
+- `ClientArgs` is a pragmatic compromise, not an ideal architectural endpoint.
+  It exists because:
+  - hiding these dependencies in `context.Context` would be worse
+  - pushing a dedicated runtime object through every constructor would have been
+    more disruptive than the codebase needed at the time
+- Not every consumer uses every field. The bundle is broader than any one
+  handler because it is optimized for uniform construction rather than perfect
+  per-handler minimalism.
+- Because the struct has wide fan-out, casual field churn here would fragment
+  constructor conventions across the handler layer quickly.
+
+## Cross-Package Context
+
+- [../README.md](../README.md) aggregates the concrete handlers built on this
+  dependency bundle
+- [../../providers](../../providers/README.md) provides the provider lookup
+  façade injected through `ClientArgs`
+- [`identity/pkg/handler/common`](../../../identity/pkg/handler/common/README.md)
+  provides identity-specific handler helpers that many concrete region handlers
+  also depend on alongside this package

--- a/pkg/handler/conversion/README.md
+++ b/pkg/handler/conversion/README.md
@@ -1,0 +1,66 @@
+# Conversion
+
+## Purpose
+
+`pkg/handler/conversion` is the handler-layer analogue of
+[`pkg/providers/types`](../../providers/types/README.md).
+
+Where `pkg/providers/types` defines provider-neutral intermediate shapes for
+concepts that do not have a first-class CRD or durable Kubernetes storage
+model, this package owns the shared conversion of those intermediate shapes into
+the region OpenAPI model when they need to cross the handler boundary.
+
+So this is not “all handler conversion logic”. It is the small shared adapter
+layer for non-CRD concepts that multiple handlers may need to expose through the
+API in a consistent form.
+
+## Current Scope
+
+Today the package is deliberately narrow.
+
+It currently provides shared conversion for provider-neutral flavor data:
+
+- `types.Architecture` -> `openapi.Architecture`
+- `types.GPUVendor` -> `openapi.GpuVendor`
+- `types.Flavor` -> `openapi.Flavor`
+- `[]types.Flavor` -> `openapi.Flavors`
+
+That is why the package may look under-populated at first glance: the
+abstraction line is broader than the current amount of code, but the shape is
+coherent.
+
+## Invariants And Guard Rails
+
+- This package is for shared conversion of provider-neutral, non-CRD concepts
+  into region API shapes.
+- Resource-specific conversion should stay close to the owning handler or
+  resource package rather than accumulating here.
+- The package should remain aligned with
+  [`pkg/providers/types`](../../providers/types/README.md): if a concept lives
+  there because it has no first-class CRD, and multiple handlers need to expose
+  it through the API, this package is the right place for the shared mapping.
+- Enum and shape translation here is part of the wire contract. Careless changes
+  can break API stability even if the underlying provider-neutral type remains
+  unchanged.
+
+## Caveats
+
+- The package name is broader than the current implementation. Right now this is
+  mostly a shared flavor-conversion package plus a small amount of supporting
+  enum translation.
+- That broad name is still defensible because the intended boundary is
+  meaningful: shared non-CRD type conversion belongs here, while resource-local
+  conversion belongs elsewhere.
+- Because the package is small, it would be easy to dissolve it back into
+  individual handlers. That would make short-term editing simpler, but would
+  reintroduce duplicated translation logic for the same provider-neutral types.
+
+## Cross-Package Context
+
+- [../../providers/types](../../providers/types/README.md) defines the
+  intermediate provider-neutral shapes converted here
+- [../../openapi](../../openapi/README.md) defines the wire-visible API types
+  this package produces
+- [../region](../region/README.md) and other handler packages consume these
+  conversions when exposing provider-derived shared concepts through the region
+  API

--- a/pkg/handler/identity/README.md
+++ b/pkg/handler/identity/README.md
@@ -1,0 +1,82 @@
+# Identity
+
+## Purpose
+
+`pkg/handler/identity` is the legacy `v1` handler for region identities.
+
+As a handler surface, it is deprecated along with the older nested `v1`
+Kubernetes-service-oriented model. It should not be treated as the future shape
+of region APIs.
+
+The underlying concept is still important, though. An `Identity` is the
+project-scoped service-principal anchor that allows region to wire real cloud
+resources into a provider such as OpenStack. In that sense it is somewhat
+analogous to an Azure service principal, even though the surrounding topology is
+different.
+
+Today, `v2` often hides that concept implicitly, most notably by creating a
+service principal as part of `Network v2` creation. So the handler is legacy,
+but the architectural idea is not.
+
+## Current Responsibilities
+
+- create and list legacy `v1` region identities
+- get legacy `v1` identities
+- expose provider-specific convenience state on read, especially for OpenStack
+- provide cloud credentials and related provider state to deprecated `v1`
+  Kubernetes/CAPO-oriented flows
+- delete identity roots and rely on cascading deletion of dependants
+
+There is no meaningful update lifecycle here in the modern sense. This handler
+is mainly retained as create/read/delete compatibility surface for the
+deprecated `v1` model.
+
+The OpenStack read path is the most distinctive behaviour:
+
+- cloud and cloud-config convenience fields
+- user/project IDs
+- server-group ID
+- SSH key name
+- persisted private key material where still present
+
+That is one of the places where provider scaffolding becomes directly user-visible.
+
+## Invariants And Guard Rails
+
+- This package is `v1` compatibility surface, not the preferred handler model.
+- `Identity` is the visible root of the older `v1` ownership graph.
+- Deleting an identity uses foreground deletion so dependent resources remain
+  coordinated beneath the visible parent.
+- Provider selection and wiring are derived from the selected region during
+  generation rather than trusted blindly from the caller.
+
+## Caveats
+
+- The handler is deprecated, but the resource concept may become relevant again
+  in a cleaner future model.
+- The handler still matters operationally for remaining deprecated `v1`
+  Kubernetes flows because it is how those paths obtain cloud credentials and
+  later trigger cleanup.
+- The current `v2` network-to-service-principal mapping is effectively `1:1`.
+  If project mapping became more explicit again, identity-like resources could
+  simplify handling of project-scoped cloud artefacts such as uploaded images
+  and snapshots.
+- Exposing OpenStack convenience state here is operationally useful, but it also
+  reflects transitional provider-state ownership that the wider system should
+  continue shrinking over time.
+
+## TODO
+
+- Remove this handler surface when the remaining deprecated `v1` flows are gone.
+- Revisit whether the underlying service-principal/project-scoping concept
+  should later return as a cleaner explicit `v2` API object rather than staying
+  implicit inside other resources.
+
+## Cross-Package Context
+
+- [../README.md](../README.md) documents why this handler is legacy rather than
+  central to the future API model
+- [../network](../network/README.md) documents the `v2` network flow that now
+  creates service principals implicitly
+- [../../apis/unikorn/v1alpha1](../../apis/unikorn/v1alpha1/README.md) documents
+  the `Identity` and `OpenstackIdentity` storage contracts

--- a/pkg/handler/image/README.md
+++ b/pkg/handler/image/README.md
@@ -1,0 +1,52 @@
+# Image
+
+## Purpose
+
+`pkg/handler/image` is the image-specific handler client.
+
+It is one of the biggest outliers in the handler graph because it is mostly
+provider-backed rather than CRD-backed. The package does not primarily manage a
+stored Kubernetes image resource. Instead it coordinates image import, query,
+deletion, visibility, and snapshot-adjacent metadata through the provider layer.
+
+It therefore sits closer to the provider image-policy surface than to the
+normal CRUD-over-CRD pattern used by many other handlers.
+
+## Distinctive Behaviour
+
+- `v1` image list/create/delete flows are organization- and region-scoped
+- `v2` image query is flatter and provider-query-driven
+- import validates the remote image by peeking the MBR and currently requires a
+  raw-format style bootable image
+- image provenance and ownership semantics are carried through tags and
+  organization scoping
+- delete enforces ownership visibility and surfaces “still in use” conflicts
+
+## Invariants And Guard Rails
+
+- Image visibility is provider-mediated, not inferred from CRD ancestry.
+- Imported images are tagged to distinguish provenance and organization
+  ownership.
+- Delete only succeeds for images effectively owned by the caller's
+  organization.
+- `v2` query semantics are intentionally driven through provider query
+  interfaces rather than reimplementing image indexing locally.
+
+## Caveats
+
+- This package inherits the image-origin/tag design smell already documented in
+  [`../../constants`](../../constants/README.md): tags are carrying semantics
+  that would be cleaner as typed API fields.
+- Import validation is intentionally narrow and conservative at present.
+- Because images are mostly provider-backed, this package is not a good example
+  of the normal CRD-centric handler pattern.
+
+## Cross-Package Context
+
+- [../README.md](../README.md) explains why image is an outlier in the handler
+  graph
+- [../../providers/types](../../providers/types/README.md) and
+  [../../providers/internal/openstack](../../providers/internal/openstack/README.md)
+  describe the provider-side image model this package consumes
+- [../../constants](../../constants/README.md) documents the image provenance
+  tag contract

--- a/pkg/handler/loadbalancer/README.md
+++ b/pkg/handler/loadbalancer/README.md
@@ -1,0 +1,50 @@
+# Load Balancer
+
+## Purpose
+
+`pkg/handler/loadbalancer` handles `v2` load balancers.
+
+This package is mostly about three things:
+
+- linkage to a parent network
+- quota/allocation coordination
+- stronger semantic validation than many other handlers
+
+So although it follows the common `v2` model, it is one of the more
+domain-specific resource handlers.
+
+## Distinctive Behaviour
+
+- load balancers are network-linked and inherit region/project context from the
+  selected network
+- create and update both use sagas so allocation changes and resource mutation
+  can be compensated on failure
+- listener, pool, and member shapes are validated aggressively:
+  - DNS-label listener names
+  - protocol restrictions
+  - port ranges
+  - member uniqueness
+  - health-check constraints
+- requested VIP validation is tied to the selected network's prefix
+
+## Invariants And Guard Rails
+
+- `LoadBalancer v2` resources are labeled with `ResourceAPIVersionLabel=2`, and
+  direct object access is gated accordingly.
+- A load balancer must belong to an authorized network in the same project.
+- Quota allocation and resource mutation should move together as far as the saga
+  model can make them move together.
+- Deletion is straightforward ownership/lifecycle teardown and does not use the
+  extra reference model that some other resources do.
+
+## Caveats
+
+- This package carries more domain validation than many sibling handlers.
+- The saga pattern improves consistency, but create/update still remain
+  best-effort multi-step workflows rather than true transactions.
+
+## Cross-Package Context
+
+- [../network](../network/README.md) documents the parent linkage model
+- [../../../core/pkg/server/saga](../../../core/pkg/server/saga/README.md)
+  documents the compensating-workflow machinery used here

--- a/pkg/handler/network/README.md
+++ b/pkg/handler/network/README.md
@@ -1,0 +1,68 @@
+# Network
+
+## Purpose
+
+`pkg/handler/network` handles the region network resource in both the deprecated
+`v1` model and the preferred `v2` model.
+
+The `v1` path is the older nested identity-scoped resource surface.
+
+The `v2` path is much more important architecturally. `Network v2` is special:
+it provisions a service-principal identity, becomes an ownership root for later
+resources, carries quota allocation, and supports external references that can
+block deletion.
+
+So this package is not just “CRUD for networks.” It is the point where the
+preferred flat API model starts building a new resource tree under a hidden
+service-principal root.
+
+## Distinctive Behaviour
+
+- `v1` networks are direct children of an explicit `Identity`
+- `v2` network creation provisions a service-principal identity implicitly
+- `v2` network creation uses a saga because creation spans multiple dependent
+  steps:
+  - validate request
+  - create service principal
+  - generate network
+  - create quota allocation
+  - create network
+- `v2` delete does not delete the visible network object directly; it deletes
+  the hidden service-principal root and relies on cascading deletion
+- external references are represented as finalizers on the network and block
+  delete until removed
+
+## Invariants And Guard Rails
+
+- `v2` is the intended model; `v1` is compatibility surface only.
+- `Network v2` resources are labeled with `ResourceAPIVersionLabel=2`, and
+  direct object access paths are gated accordingly.
+- `v2` lists prefilter by organization/project/region before per-item RBAC.
+- A `Network v2` is the visible coordination point for a resource subtree whose
+  real ownership root is the hidden service principal created for it.
+- Delete must respect both ownership cascade and explicit external references.
+
+## Caveats
+
+- The service principal created for `Network v2` is implicit in the API even
+  though it is central to the real ownership model.
+- `v2` network deletion is intentionally indirect, which is correct
+  architecturally but easy to miss from the API surface alone.
+- Some network behaviour still depends on transitional provider-specific status
+  details downstream, especially for consumers like storage.
+
+## TODO
+
+- Revisit whether the hidden `v2` service-principal concept should become an
+  explicit API object in a future cleaner model.
+- Delete the deprecated `v1` nested network surface once migration is complete.
+
+## Cross-Package Context
+
+- [../identity](../identity/README.md) explains the hidden service-principal
+  concept this package still relies on
+- [../storage](../storage/README.md), [../securitygroup](../securitygroup/README.md),
+  [../loadbalancer](../loadbalancer/README.md), and [../server](../server/README.md)
+  all depend on `Network v2` as a parent/linkage root
+- [../../../core/pkg/server/saga](../../../core/pkg/server/saga/README.md)
+  documents the saga machinery used heavily here

--- a/pkg/handler/region/README.md
+++ b/pkg/handler/region/README.md
@@ -1,0 +1,52 @@
+# Region
+
+## Purpose
+
+`pkg/handler/region` is the read-side handler for region capabilities and
+visibility.
+
+Unlike most other handlers in this tree, it is not primarily about creating or
+mutating user-owned lifecycle resources. Its job is to expose:
+
+- visible regions
+- region detail
+- provider-derived flavor inventory
+- provider-derived external network inventory
+
+So this package is where the service turns stored region configuration and
+provider capability discovery into user-visible region catalogue data.
+
+## Distinctive Behaviour
+
+- region visibility is filtered against region security constraints and the
+  caller's organization scope
+- flavor and external-network reads cross the provider boundary rather than
+  reading from CRD-backed child resources
+- flavor conversion passes through the shared
+  [`conversion`](../conversion/README.md) package because flavor is a provider
+  concept rather than a first-class CRD
+
+## Invariants And Guard Rails
+
+- Regions are looked up directly from shared storage and then filtered for
+  visibility.
+- Provider-derived capability reads must resolve the correct provider for the
+  selected region rather than trusting client-supplied assumptions.
+- Flavor ordering is intentionally stable and user-facing.
+
+## Caveats
+
+- This package is mostly read-side and therefore much simpler than the resource
+  lifecycle handlers. Do not use it as the model for the rest of the handler
+  layer.
+- Visibility filtering for regions is a service policy concern, not a storage
+  property of the `Region` CRD by itself.
+
+## Cross-Package Context
+
+- [../README.md](../README.md) explains why provider-backed capability reads sit
+  alongside CRD-backed handler logic in this layer
+- [../conversion](../conversion/README.md) covers the shared flavor conversion
+  boundary
+- [../../providers](../../providers/README.md) documents the provider capability
+  contracts consumed here

--- a/pkg/handler/securitygroup/README.md
+++ b/pkg/handler/securitygroup/README.md
@@ -1,0 +1,50 @@
+# Security Group
+
+## Purpose
+
+`pkg/handler/securitygroup` handles security groups in both the older `v1`
+identity-scoped model and the preferred `v2` network-linked model.
+
+In `v2`, a security group is no longer addressed through an identity path. It
+is attached directly to a network and inherits most of its real context from
+that network.
+
+So the distinctive concerns here are linkage, cascade, and a small amount of
+rule-shape validation rather than deep multi-object orchestration.
+
+## Distinctive Behaviour
+
+- `v1` security groups are owned by an `Identity`
+- `v2` security groups are owned by a `Network`
+- `v2` create derives organization/project/region/identity context from the
+  selected network
+- `v2` rules are converted into a flatter wire shape with protocol/port/prefix
+  validation rules
+
+## Invariants And Guard Rails
+
+- `v2` is the intended model; `v1` is compatibility surface only.
+- direct `v2` object access is gated to resources labeled with
+  `ResourceAPIVersionLabel=2`.
+- A `SecurityGroup v2` must belong to a visible and authorized network in the
+  same project context.
+- Deletion is primarily handled through the ownership graph rooted at the
+  network rather than bespoke orchestration here.
+
+## Caveats
+
+- Most of the interesting behaviour here is inherited from the handler roll-up:
+  inferred scope, direct shared-namespace lookup, and ownership graph semantics.
+- This package is intentionally not doing very much beyond linkage and rule
+  translation; that is a sign of decent scoping rather than missing behaviour.
+
+## TODO
+
+- Delete the deprecated `v1` handler surface once migration is complete.
+
+## Cross-Package Context
+
+- [../network](../network/README.md) is the real parent context for `v2`
+  security groups
+- [../README.md](../README.md) documents the shared `v2` list/filter and
+  direct-lookup model this package follows

--- a/pkg/handler/server/README.md
+++ b/pkg/handler/server/README.md
@@ -1,0 +1,70 @@
+# Server
+
+## Purpose
+
+`pkg/handler/server` handles compute-server lifecycle.
+
+It contains both deprecated `v1` paths and the preferred `v2` model, but the
+package is worth documenting separately because server handling is richer than
+basic CRUD:
+
+- create/update/delete
+- power operations
+- console access
+- snapshot creation
+- stronger validation of referenced resources
+
+In `v2`, server context is primarily inferred from the selected network and
+related dependencies rather than from nested path scope.
+
+## Distinctive Behaviour
+
+- `v1` servers are nested more explicitly under identity paths
+- `v2` servers are network-linked resources with direct ID-based access
+- create/update validate referenced image existence through the provider layer
+- create/update can validate and bind an SSH certificate authority
+- snapshot creation bridges server lifecycle into image provenance semantics
+- snapshot creation is also a cross-resource permission bridge: the caller must
+  already be able to see the server and also be allowed to create images in the
+  owning organization
+- the package exposes operational verbs:
+  - start
+  - stop
+  - soft reboot
+  - hard reboot
+  - console output/session
+- server-name uniqueness is enforced per network to avoid aliasing cloud-side
+  host identity
+
+## Invariants And Guard Rails
+
+- `v2` is the intended model; `v1` is compatibility surface only.
+- direct `v2` object access is gated to resources labeled with
+  `ResourceAPIVersionLabel=2`.
+- A `Server v2` is owned by its network for cascading deletion.
+- User data and SSH certificate authority combinations are validated together to
+  avoid unsupported managed-userdata states.
+- Power-operation errors are translated carefully from provider conflict/not-found
+  states into user-facing API semantics.
+
+## Caveats
+
+- This package is partly CRUD handler and partly operational façade over the
+  provider compute API.
+- Snapshot behaviour is coupled to image provenance and ownership semantics, so
+  server is not fully self-contained as a lifecycle concept.
+- Some semantics, such as managed user-data validation for SSH CA use, are
+  important but narrow enough that they should stay local to this package.
+
+## TODO
+
+- Delete the deprecated `v1` handler surface once migration is complete.
+
+## Cross-Package Context
+
+- [../network](../network/README.md) documents the parent linkage model for
+  `v2` servers
+- [../sshcertificateauthority](../sshcertificateauthority/README.md) documents
+  the referenced SSH CA resource model
+- [../image](../image/README.md) documents the image-side semantics that
+  snapshot creation feeds into

--- a/pkg/handler/sshcertificateauthority/README.md
+++ b/pkg/handler/sshcertificateauthority/README.md
@@ -1,0 +1,55 @@
+# SSH Certificate Authority
+
+## Purpose
+
+`pkg/handler/sshcertificateauthority` handles the `v2` SSH certificate
+authority resource.
+
+Compared with most other region handlers, this package is intentionally small.
+Its distinctive concerns are:
+
+- public-key validation and normalization
+- project-scoped visibility
+- explicit deletion blocking when references still exist
+
+## Distinctive Behaviour
+
+- public keys are normalized and validated as OpenSSH authorized keys
+- unsupported key options and unsupported key types are rejected
+- deletion is blocked if explicit resource references still exist
+- a `ResourceAPIVersionLabel` is still written even though there is no active
+  `v1 -> v2` migration concern for this resource; it is there as future-proofing
+  rather than because the handler is carrying old API baggage
+- unlike network-linked resources, deletion safety here is based on explicit
+  reference checking rather than owner-ref cascade
+
+## Invariants And Guard Rails
+
+- This is a `v2` resource, but unlike several sibling handlers it does not have
+  meaningful `v1` migration baggage. The version label here is primarily a
+  forward-compatibility affordance rather than evidence of an active old/new
+  split for this resource.
+- Create requires explicit organization/project input because there is no
+  parent resource to infer scope from.
+- The stored public key should be normalized enough that later consumers do not
+  have to re-interpret malformed input.
+
+## Caveats
+
+- The package is intentionally narrow; most of the interesting architectural
+  context sits in the handler roll-up and in the server package that references
+  SSH certificate authorities.
+- Deletion safety depends on callers correctly maintaining references.
+
+## TODO
+
+- Decide whether direct-read enforcement should remain coupled to
+  `ResourceAPIVersionLabel` for future-proofing, given that this resource did
+  not need the label for a `v1 -> v2` migration in the first place.
+
+## Cross-Package Context
+
+- [../server](../server/README.md) documents the main consumer of SSH
+  certificate authorities
+- [../README.md](../README.md) documents the explicit-reference deletion model
+  used here instead of pure ownership cascade

--- a/pkg/handler/storage/README.md
+++ b/pkg/handler/storage/README.md
@@ -1,0 +1,65 @@
+# Storage
+
+## Purpose
+
+`pkg/handler/storage` handles `v2` file storage.
+
+It is one of the strongest examples of why the saga pattern exists in this
+repository. Storage create and update are not just “write one CRD” operations.
+They coordinate:
+
+- request validation
+- storage-class lookup
+- attachment/network validation
+- quota allocation changes
+- storage-object mutation
+
+So this package is where stateful lifecycle, attachment semantics, and quota
+accounting meet.
+
+## Distinctive Behaviour
+
+- create and update both use sagas with explicit compensation for quota
+  allocation changes
+- attachments are validated against `Network v2` resources in the caller's
+  project
+- storage-class and region compatibility are validated before mutation
+- attachment IP ranges are derived from transitional provider-specific network
+  storage-range information
+- attachment status reporting is currently based partly on desired state rather
+  than fully observed actual state
+
+## Invariants And Guard Rails
+
+- Storage is a `v2` resource and follows the flatter direct-lookup model.
+- Quota allocation changes are part of the storage lifecycle contract, not an
+  optional side effect.
+- Attachments must reference visible, provisioned networks in the same project.
+- Update preserves the existing allocation annotation while mutating the storage
+  resource.
+
+## Caveats
+
+- This package still depends on transitional provider-specific network status
+  (`Status.Openstack.StorageRange`) because a cleaner generic source of that
+  information does not yet exist.
+- Attachment status is intentionally conservative and not fully actual-state
+  derived yet.
+- The package relies heavily on saga compensation because there is no transaction
+  boundary for storage-plus-allocation changes.
+
+## TODO
+
+- Remove the dependency on transitional provider-specific network status once a
+  generic storage-range source exists.
+- Tighten attachment status so it reflects observed state rather than mostly
+  desired state where practical.
+
+## Cross-Package Context
+
+- [../network](../network/README.md) documents the network dependency used for
+  attachments
+- [../../../core/pkg/server/saga](../../../core/pkg/server/saga/README.md)
+  documents the compensating-workflow machinery used heavily here
+- [`../../../identity/pkg/client`](../../../identity/pkg/client/README.md)
+  documents the allocation client helpers this package coordinates with

--- a/pkg/handler/util/README.md
+++ b/pkg/handler/util/README.md
@@ -1,0 +1,91 @@
+# Util
+
+## Purpose
+
+`pkg/handler/util` is a small support package for the region `v2` handler
+model.
+
+Its current role is to preserve two things after the API moved away from the
+older org/project path-nested shape:
+
+- efficient pre-RBAC working-set reduction for list operations
+- correct principal context for write operations where org/project can no
+  longer be derived from the request path
+
+So this is not a generic utility package in the usual sense. It is a narrow
+collection of shared handler helpers that make the flatter `v2` API shape
+workable.
+
+## Main Responsibilities
+
+### Query Constraint Helpers
+
+`OrganizationIDQuery(...)`, `ProjectIDQuery(...)`, `AddRegionIDQuery(...)`, and
+`AddNetworkIDQuery(...)` support `v2` list handlers.
+
+`v2` list APIs allow callers to query visible resources through API query
+parameters rather than relying only on path-scoped tenancy. These helpers
+translate optional OpenAPI query parameters into the selector/RBAC query model
+used by handlers so the candidate working set can be constrained before the
+handler walks it for authorization and visibility checks.
+
+That is an efficiency and scalability concern, not just a cosmetic helper.
+
+### Principal Context Repair
+
+`InjectUserPrincipal(...)` supports `v2` write handlers.
+
+In the older nested API shape, org/project context could often be derived from
+the request path itself. In `v2`, write operations such as `POST /api/v2/...`
+do not necessarily carry that tenancy context in the URL, but the handler still
+needs it for:
+
+- audit attribution
+- quota charging
+- billing/accounting
+- ownership enforcement
+
+This helper updates the current principal when those fields were absent from the
+inbound request-derived principal but are available from the request body or can
+be inferred from a dependent resource that already carries the binding.
+
+### Delete Propagation
+
+`ForegroundDeleteOptions()` standardizes foreground deletion for handlers that
+need Kubernetes owner/child cleanup to complete before delete processing is
+considered finished.
+
+## Invariants And Guard Rails
+
+- This package exists to support shared `v2` handler behaviour, not to become a
+  grab-bag of unrelated helpers.
+- Query helpers should stay aligned with the label-selector and RBAC filtering
+  model used by list handlers.
+- Principal repair is only justified because the flatter `v2` API shape no
+  longer always carries tenancy context in the path. It should remain tightly
+  scoped to restoring audit/ownership/quota context, not mutating principals
+  arbitrarily.
+- Foreground deletion is a behavioural choice with lifecycle implications, not a
+  random Kubernetes convenience default.
+
+## Caveats
+
+- The package name `util` is weak. The real scope is “shared `v2` handler
+  support”.
+- The current helpers are semantically coherent, but the package would become a
+  junk drawer quickly if resource-specific logic were allowed to accumulate
+  here.
+- `InjectUserPrincipal(...)` reflects a real consequence of the `v2` API design:
+  flatter resource URLs improve ergonomics, but they push more responsibility
+  into handler logic to recover the operational context that older nested paths
+  carried implicitly.
+
+## Cross-Package Context
+
+- [../README.md](../README.md) and concrete `v2` handler packages consume these
+  helpers when implementing flat region API endpoints
+- [../../openapi](../../openapi/README.md) defines the query-parameter shapes
+  these helpers normalize
+- [`identity/pkg/middleware/openapi`](../../../identity/pkg/middleware/openapi/README.md)
+  defines the inbound principal derivation path that this package sometimes has
+  to complete with additional org/project context

--- a/pkg/managers/README.md
+++ b/pkg/managers/README.md
@@ -1,0 +1,26 @@
+# `pkg/managers`
+
+This tree contains the controller factories that wrap region provisioners in the
+shared `core/pkg/manager` controller framework.
+
+The common pattern is:
+
+- initialize a shared provider registry once per controller process
+- expose service metadata and any controller-specific CLI options
+- create a reconciler from a typed provisioner constructor
+- register a watch on one CRD with a generation-changed predicate
+
+So the managers layer is thin by design. Its job is controller composition, not
+resource policy.
+
+The main shared piece is [providers.go](./providers.go), which performs the
+provider registry bootstrap with a direct client for warm-up and a cached client
+for normal operation.
+
+## Packages
+
+- [identity](./identity/README.md)
+- [network](./network/README.md)
+- [security-group](./security-group/README.md)
+- [load-balancer](./load-balancer/README.md)
+- [server](./server/README.md)

--- a/pkg/managers/identity/README.md
+++ b/pkg/managers/identity/README.md
@@ -1,0 +1,13 @@
+# Identity
+
+This package is the controller factory for `Identity` reconciliation.
+
+It is structurally standard:
+
+- embeds shared provider initialization
+- exposes controller options for the identity provisioner
+- watches `Identity` generation changes
+- builds the reconciler around
+  [`pkg/provisioners/managers/identity`](../../provisioners/managers/identity/README.md)
+
+The resource-specific behaviour lives in the provisioner, not here.

--- a/pkg/managers/load-balancer/README.md
+++ b/pkg/managers/load-balancer/README.md
@@ -1,0 +1,7 @@
+# Load Balancer
+
+This package is the controller factory for `LoadBalancer` reconciliation.
+
+It is structurally standard, but it points at a provisioner whose current
+behaviour is asymmetric: mostly teardown/allocation cleanup rather than a full
+provider create path.

--- a/pkg/managers/network/README.md
+++ b/pkg/managers/network/README.md
@@ -1,0 +1,6 @@
+# Network
+
+This package is the controller factory for `Network` reconciliation.
+
+It is structurally standard and delegates the interesting work to
+[`pkg/provisioners/managers/network`](../../provisioners/managers/network/README.md).

--- a/pkg/managers/security-group/README.md
+++ b/pkg/managers/security-group/README.md
@@ -1,0 +1,6 @@
+# Security Group
+
+This package is the controller factory for `SecurityGroup` reconciliation.
+
+It is a thin wrapper over the shared manager framework plus
+[`pkg/provisioners/managers/security-group`](../../provisioners/managers/security-group/README.md).

--- a/pkg/managers/server/README.md
+++ b/pkg/managers/server/README.md
@@ -1,0 +1,8 @@
+# Server
+
+This package is the controller factory for `Server` reconciliation.
+
+It is structurally standard, but it fronts the richest provisioner in the tree:
+[`pkg/provisioners/managers/server`](../../provisioners/managers/server/README.md),
+which maintains explicit resource-reference edges and SSH CA cloud-init
+augmentation.

--- a/pkg/monitor/README.md
+++ b/pkg/monitor/README.md
@@ -1,0 +1,33 @@
+# `pkg/monitor`
+
+`pkg/monitor` is the polling monitor framework for region.
+
+Unlike handlers and managers, this layer is not driving desired-state
+reconciliation directly. It periodically inspects live provider-backed resource
+state and projects that back into:
+
+- Kubernetes status updates
+- structured transition logs
+- OpenTelemetry metrics
+
+Architecturally, this is important because it is a cross-resource, potentially
+cross-repo pattern rather than a one-off local helper. It is where the platform
+admits that some lifecycle truth must be polled and observed, not only pushed by
+controller watches.
+
+## Current Shape
+
+- builds a shared provider registry
+- creates OTel instruments
+- runs one or more `Checker`s on a poll interval
+- logs and continues on non-fatal per-check failures
+
+Right now the only checker is
+[health/server](./health/server/README.md), but the abstraction is clearly
+intended to allow additional monitor classes later.
+
+## Caveats
+
+- This is polling by design. That makes it simpler and more decoupled, but also
+  means timeliness and overhead are governed by poll period rather than watches.
+- Provider/cache readiness is part of monitor startup.

--- a/pkg/monitor/health/server/README.md
+++ b/pkg/monitor/health/server/README.md
@@ -1,0 +1,38 @@
+# Server Health
+
+`pkg/monitor/health/server` is the current concrete monitor checker.
+
+It polls region servers, asks the backing provider for their effective state,
+patches Kubernetes status, logs lifecycle transitions, and exports OTel metrics
+for:
+
+- current server counts by state/region/flavor
+- pending-to-running provision duration
+
+This makes it a bridge between provider-observed reality and the platform's
+status/telemetry model.
+
+## Distinctive Behaviour
+
+- resolves provider and flavor context per region and caches it for a poll cycle
+- updates server status through provider `UpdateServerState(...)`
+- logs phase and health-condition transitions
+- stamps and clears the pending-entry-time annotation used for provision-duration
+  measurement
+- rebuilds gauge counts from the effective server set each cycle
+
+## Invariants And Guard Rails
+
+- Fatal context cancellation/deadline errors abort the poll cycle; most
+  per-server/provider failures are logged and skipped.
+- Annotation patch failures for pending-entry time are non-fatal and retried on
+  later polls.
+- Servers skipped because region/provider resolution fails are absent from the
+  gauge for that cycle rather than misreported as a fake state.
+
+## Caveats
+
+- This package is intentionally eventual and observational; it does not make
+  provider state changes happen, it notices and projects them.
+- Metric correctness depends on poll cadence and on the pending-entry annotation
+  surviving long enough to observe the transition.

--- a/pkg/openapi/README.md
+++ b/pkg/openapi/README.md
@@ -1,0 +1,147 @@
+# OpenAPI
+
+## Purpose
+
+This package is the canonical wire-contract package for the region service.
+
+Its job is to define the HTTP/API surface in one place and materialize that
+contract into the generated client, server, router, and type bindings used by
+the rest of the service.
+
+The service is used both directly and indirectly. Some parts of the contract
+are intended for direct consumption, while higher-level services such as
+compute- or Kubernetes-facing APIs may also expose curated subsets of the same
+underlying capabilities.
+
+The important point is that this package is not "just generated stubs". The
+generated files are derivative. The authoritative source is
+[`server.spec.yaml`](./server.spec.yaml), and the running service depends on
+that contract both at build time and at runtime.
+
+## What Lives Here
+
+- `server.spec.yaml`: the authoritative API specification
+- `types.go`: generated request/response/domain types
+- `client.go`: generated typed client bindings
+- `router.go`: generated server interface and router bindings
+- `schema.go`: embedded schema used at runtime
+- `builder.go`: a small local adapter used by
+  [pkg/client](../client/README.md) to construct generated clients in the shape
+  expected by the region service
+
+## Why This Package Matters
+
+This package sits at the meeting point of several layers:
+
+- [pkg/server](../server/README.md) uses it to bind the concrete handler
+  implementation to the generated HTTP router
+- service middleware and routing layers depend on the runtime schema for route
+  resolution and request/response validation
+- [pkg/client](../client/README.md) wraps the generated client with the region
+  service-to-service trust model
+- [pkg/handler](../handler/README.md) implements the user-facing request and
+  response semantics expressed by these types
+
+So this package is the canonical wire contract, while those other packages
+explain how the service enforces, consumes, or implements that contract.
+
+## Visibility And Publication
+
+The specification intentionally contains more than one surface in one schema:
+
+- a deprecated `v1` surface, much of which remains hidden
+- a newer `v2` resource surface that is the intended direction for public use,
+  even though some operations still remain hidden
+- protocol-supporting endpoints such as
+  `/.well-known/openid-protected-resource`
+
+Annotations such as `x-hidden` control whether an endpoint appears in
+public-facing generated documentation. They do **not** mean the endpoint is
+outside the canonical API contract.
+
+Keeping the schema unified matters because it allows:
+
+- one generated client/server contract
+- one runtime validation and route-resolution source
+- one place to track coexistence between deprecated and preferred API
+  generations
+
+The core design shift in `v2` is that resource relationships carry more of the
+context that `v1` encoded directly into deeply nested paths. In the newer
+surface, an identity already implies its organization/project placement, and a
+network linked to that identity can derive that surrounding scope rather than
+requiring every operation to restate the full hierarchy explicitly.
+
+The newer shape also tries to preserve a read/modify/write-style duck-typed
+contract where practical. When some parameters are only valid during creation
+and become immutable afterwards, the readable model can still surface the
+effective value through status/read-only fields so clients can round-trip the
+resource shape without translating between unrelated models.
+
+For public-facing API documentation, the specification should also be treated as
+the primary authoring surface:
+
+- every published endpoint should have a `summary`
+- every published endpoint should have `tags` so related operations group
+  together coherently in generated docs
+- every endpoint should have a meaningful `description` explaining what the user
+  is doing, how the operation works, and any important caveats
+
+## Invariants And Guard Rails
+
+- `server.spec.yaml` is the source of truth; generated code is derivative
+- the service runtime depends on the embedded schema, not only on generated Go
+  interfaces
+- schema changes can affect documentation, client generation, server binding,
+  route resolution, and request/response validation simultaneously
+- shared platform API primitives are imported from
+  [`core/pkg/openapi`](../../core/pkg/openapi), rather than being redefined here
+- this package carries both deprecated `v1` and preferred `v2` generations in
+  one contract, so compatibility changes, migration steps, and publication
+  decisions must be made deliberately
+- `builder.go` is intentionally small; it exists to adapt the generated client
+  construction API to the expectations of higher-level region client code, not
+  to invent a second client abstraction
+
+## Semantics That Live Elsewhere
+
+The schema defines the transport contract, but a number of important service
+semantics are intentionally documented in higher-level packages rather than
+fully encoded here:
+
+- [pkg/handler](../handler/README.md): read/modify/write semantics, API/storage
+  conversion rules, authorization-visible behaviour, lifecycle caveats, and the
+  inference rules that let `v2` recover surrounding scope from linked resources
+- [pkg/server](../server/README.md): runtime composition of the generated router
+  into the actual middleware and handler stack
+- [pkg/apis/unikorn/v1alpha1](../apis/unikorn/v1alpha1/README.md): persisted
+  storage model and the split between service-facing resources and internal
+  state
+- [pkg/client](../client/README.md): outbound trust model and generated-client
+  consumption
+
+## Caveats
+
+- the specification still carries a deprecated `v1` surface alongside the newer
+  `v2` surface, so "canonical contract" does not mean "single-shape public API"
+- some `v2` resources are clearly documented for publication, while others such
+  as many server operations remain hidden; readers should not assume version
+  number alone determines visibility
+- the main value of `v2` is not just shorter paths. It is the shift toward a
+  relationship-driven API shape where surrounding tenancy and placement context
+  can often be inferred from the addressed resource graph
+- preserving read/modify/write ergonomics in `v2` does not mean every field is
+  always mutable. Some create-time choices are intentionally immutable later and
+  are reflected back through read-only/status fields instead
+- because generated code dominates the package by line count, it is easy to
+  under-document the package even though it is architecturally central
+- if higher-level documentation drifts from the schema, this package is where
+  those mismatches become concrete first
+
+## TODO
+
+- Remove the deprecated `v1` surface over time so the unified schema does not
+  permanently carry old and new API generations longer than necessary.
+- Promote or remove ambiguous partially hidden `v2` endpoints deliberately,
+  especially where resource families are split between published and hidden
+  operations.

--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -1,0 +1,136 @@
+# pkg/providers
+
+## Intention
+
+`pkg/providers` is the provider layer for region.
+
+It sits between handler-level service semantics and concrete cloud backends. Its
+job is to turn region-native resources and provider-neutral intermediate types
+into real infrastructure operations against a substrate such as OpenStack or a
+Kubernetes-backed region.
+
+This is not a pure abstraction boundary in the academic sense. When the service
+already has a strong persisted resource model, providers operate directly on
+repo-native CRDs. When the thing being exchanged is provider-derived,
+transient, or not modeled as a first-class Kubernetes resource, providers use
+the neutral contract in [./types](./types/README.md).
+
+The important design goal is shape preservation: higher layers should be able to
+reason about regions, identities, networks, images, servers, and related
+operations without having to absorb every provider's native object model.
+
+## Links
+
+- [./types](./types/README.md)
+- [./util](./util/README.md)
+- [./allocation/vlan](./allocation/vlan/README.md)
+- [./internal/openstack](./internal/openstack/README.md)
+- [./internal/kubernetes](./internal/kubernetes/README.md)
+- [./internal/simulated](./internal/simulated/README.md)
+
+`pkg/providers/types` defines the neutral intermediate contract. `pkg/providers/util`
+covers narrow provider-support helpers. `pkg/providers/allocation/vlan` covers a
+local compensating allocator for provider-network VLAN IDs. The `internal/*`
+packages are the concrete provider implementations.
+
+## Invariants And Guard Rails
+
+- The package exposes two lookup surfaces:
+  - `LookupCommon` returns a `types.CommonProvider` for region-level capability
+    discovery that every provider must support
+  - `LookupCloud` returns a full `types.Provider` for regions that implement the
+    full cloud lifecycle surface
+- `types.CommonProvider` is the minimum substrate contract:
+  - return the effective `Region`
+  - return allocatable `Flavor` inventory
+- `types.Provider` extends that common base with the broader image, identity,
+  network, security-group, load-balancer, server, console, and snapshot
+  lifecycle surfaces.
+- The provider abstraction is intentionally mixed:
+  - CRD-backed lifecycle operations still speak in repo-native
+    `pkg/apis/unikorn/v1alpha1` resource types
+  - provider-derived or non-CRD concepts use neutral types from
+    [./types](./types/README.md)
+- Concrete providers must preserve stable linkage between Unikorn resources and
+  cloud-side resources. The mechanism may differ by backend, but the contract is
+  the same:
+  - higher layers need a reliable way to create, re-find, inspect, and delete
+    the real backing resources
+  - mirrored provider-state records are not the preferred answer unless the
+    state cannot be reconstructed safely enough by other means
+- Providers must tolerate changing backing credentials and region state rather
+  than assuming client material is static for process lifetime.
+  Credential rotation, secret refresh, and region configuration refresh are part
+  of the provider contract, not incidental operational concerns.
+- The provider layer is allowed to carry compensating local mechanisms where the
+  underlying substrate is insufficient on its own:
+  - OpenStack image caching exists because raw image API behaviour is too slow
+    and awkward to expose directly
+  - VLAN allocation exists because provider-network segmentation IDs are not
+    allocated for us
+- The provider layer is also where substrate quirks are normalized or fenced
+  off. Providers may need to compensate for fuzzy list filters, missing
+  allocation primitives, incomplete metadata, or other cloud-specific
+  behaviour so higher layers can operate against a more stable contract.
+
+## Backend Patterns
+
+- [./internal/openstack](./internal/openstack/README.md) is the real full cloud
+  provider:
+  - it implements the full `types.Provider` contract
+  - it prefers deterministic lookup against OpenStack over broad mirrored CRD
+    state
+  - it still carries a shrinking amount of persisted provider state via
+    `OpenstackIdentity`
+- [./internal/kubernetes](./internal/kubernetes/README.md) currently implements
+  only `types.CommonProvider`:
+  - it exposes a Kubernetes-backed region as a cloud-like substrate
+  - it exports curated node-class-backed flavor inventory for higher layers that
+    can consume the normal region shape
+- [./internal/simulated](./internal/simulated/README.md) implements the full
+  interface in contract-shaped but deliberately incomplete form:
+  - it exists to push broad integration coverage left
+  - it is useful for deterministic load, race, and bottleneck testing at higher
+    layers without requiring a real cloud deployment
+
+## Caveats
+
+- This is not a “write once, run everywhere” cloud abstraction. Provider
+  differences still matter, and some of them are important enough that they
+  appear directly in provider-specific code and docs.
+- The mixed abstraction style is deliberate, but it does mean the provider
+  boundary is not perfectly uniform. Some operations feel cloud-neutral, while
+  others necessarily carry repo-native lifecycle and tenancy semantics.
+- Stable linkage is a hard requirement, but the implementation strategy can be
+  fragile:
+  - deterministic lookup depends on stable naming, metadata, and scoping
+    conventions
+  - persisted provider-state records risk drift and race conditions if they
+    duplicate cloud reality instead of anchoring genuinely unreconstructable
+    state
+- Credential handling remains one of the sharpest edges in this layer. Some
+  current flows still rely on service-managed secret material and delegated
+  application credentials that the wider platform would ideally stop exposing.
+- Some provider-specific compensating mechanisms are valuable but architectural
+  debt at the same time. Caches, local allocators, and compatibility bridges are
+  signs that the substrate contract is imperfect, not proof that those patterns
+  should expand unchecked.
+
+## TODO
+
+- Keep reducing persisted provider-state patterns in favour of deterministic or
+  otherwise reconstructable linkage where that can be done safely.
+- Continue shrinking flows that require the service to own or expose private
+  credential material.
+- Revisit mixed abstraction areas where provider-neutral logic has drifted into
+  concrete provider packages because of historical coupling.
+
+## Cross-Package Context
+
+- [../handler](../handler/README.md) and specific handler packages depend on
+  this layer to turn service API operations into real substrate behaviour
+- [./types](./types/README.md) defines the contract surface concrete providers
+  satisfy
+- [../apis/unikorn/v1alpha1](../apis/unikorn/v1alpha1/README.md) defines the
+  repo-native resources providers consume directly where a strong stored model
+  already exists

--- a/pkg/providers/allocation/vlan/README.md
+++ b/pkg/providers/allocation/vlan/README.md
@@ -1,0 +1,71 @@
+# pkg/providers/allocation/vlan
+
+## Intention
+
+`pkg/providers/allocation/vlan` is a region-local coordination package for
+allocating VLAN IDs for OpenStack provider networks.
+
+It exists because OpenStack does not allocate those provider-network VLAN IDs
+for us, while some provisioning paths, especially provider-network and
+baremetal-oriented flows, still need a concrete VLAN assignment. This package
+therefore keeps the platform's own allocation table in Kubernetes and hands out
+VLAN IDs on behalf of the provider integration.
+
+This is not a generic network allocator or a full IPAM system. It is a narrow
+bookkeeping layer for one specific gap in the underlying provider model.
+
+## Links
+
+- [../../../apis/unikorn/v1alpha1](../../../apis/unikorn/v1alpha1/README.md)
+
+`pkg/apis/unikorn/v1alpha1` defines the `VLANAllocation` coordination object
+and the `Region` VLAN/provider-network configuration that this allocator uses.
+
+## Invariants And Guard Rails
+
+- Allocation scope is per region. Each allocator instance uses the region
+  namespace and `region.StaticName()` to locate a single `VLANAllocation`
+  record for that region.
+- The allocatable set comes from `region.VLANSpec()`. If no explicit VLAN
+  segment configuration is present, the allocator falls back to the full valid
+  VLAN range `1..4094`.
+- Invalid or partially invalid configured ranges are clamped defensively rather
+  than trusted blindly.
+- Allocation is first-fit over the allocatable set, not preference-aware or
+  topology-aware.
+- Persistence and concurrency coordination rely on the backing Kubernetes
+  `VLANAllocation` object rather than in-memory state.
+- `Free()` is idempotent.
+- If the allocation table contains the same VLAN ID more than once, the package
+  treats that as corruption and returns an allocation error rather than trying
+  to guess how to repair it.
+
+## Caveats
+
+- This package compensates for a provider limitation. It should not be mistaken
+  for a general platform-wide network allocation abstraction.
+- Allocation is currently an exhaustive search with an admitted `O(n^2)`
+  worst-case shape, though the problem space is bounded.
+- Ownership is only recorded as `networkID` in the allocation table, but
+  deallocation is keyed by VLAN ID alone. Correctness therefore depends on
+  higher layers calling `Free()` with the right VLAN ID.
+- If an operator manually corrupts the `VLANAllocation` object, this package can
+  detect some bad states but does not provide a repair or reconciliation model.
+- Falling back to the full VLAN range when no explicit segments are configured
+  is convenient, but it can be too broad for environments that expect strict
+  administrative partitioning.
+
+## TODO
+
+- Replace the current exhaustive search if allocation scale or churn ever makes
+  the bounded `O(n^2)` behaviour operationally painful.
+- Re-evaluate whether this allocator should continue to exist if a future
+  provider path can source-of-truth VLAN allocation elsewhere.
+
+## Cross-Package Context
+
+- [../../internal/openstack](../../internal/openstack/README.md) invokes this
+  allocator when provider-network provisioning needs a VLAN
+- [../../../apis/unikorn/v1alpha1](../../../apis/unikorn/v1alpha1/README.md)
+  defines the persisted `VLANAllocation` state and region-side VLAN
+  configuration

--- a/pkg/providers/internal/kubernetes/ADMIN.md
+++ b/pkg/providers/internal/kubernetes/ADMIN.md
@@ -1,0 +1,91 @@
+# Unikorn Kubernetes Provider
+
+The Kubernetes provider allows entire Kubernetes clusters to be used as regions.
+While these regions do not provide the isolation inherent with virtual and physical machines, they can be provisioned into light-weight and highly performant virtual clusters.
+
+The Unikorn Kubernetes service can consume Kubernetes regions for cluster provisioning.
+
+## Kubernetes Cluster Prerequisites
+
+Before importing a Kubernetes cluster as a region, some steps need to be carried out in order to make it consumable.
+
+### Kubernetes Configuration Secret
+
+The region will need access to the Kubernetes configuration with cluster admin permissions (for now).
+This is stored in a secret as follows:
+
+```shell
+kubectl create secret generic -n unikorn-region de-central-0-kubeconfig --from-file kubeconfig=/path/to/my/kubeconfig
+```
+
+It will be consumed in the example in the next section.
+
+### Flavor Mapping
+
+Kubernetes clusters are composed of pools of machines.
+Each machine type has a set of characteristics:
+
+* CPU count and type
+* Memory capacity
+* Ephemeral disk capacity
+* GPU count and type
+
+These characteristics are directly exposed by the region controller a flavors, thus allowing virtual clusters to be composed of pools of entire nodes.
+This facilitates node level isolation, simplified quota management based on nodes and GPUs, and finally simplified billing based on node flavors (as opposed to pod resource limits).
+
+Node characteristic data can also bu used to find a suitable region to run a workload on given the requirement for a certain GPU type, for example.
+
+Each node of a certain machine type must have a `kubernetes.region.unikorn-cloud.org/node-class` node label applied.
+The value of the label should be a globally unique v4 UUID.
+
+Only nodes with a node class label can be considered and consumed by higher order services such as the Kubernetes service's virtual clusters.
+
+Node class metadata is defined by the region resource, e.g.:
+
+```yaml
+apiVersion: region.unikorn-cloud.org/v1alpha1
+kind: Region
+metadata:
+  namespace: unikorn-region
+  name: fe4ecbe4-421d-4f25-8b11-69593adfef5d
+  labels:
+    unikorn-cloud.org/name: de-central-0
+spec:
+  provider: kubernetes
+  kubernetes:
+    kubeConfigSecret:
+      namespace: unikorn-region
+      name: de-central-0-kubeconfig
+    nodes:
+    - id: 4be04a2e-87e6-4ff2-b34b-2994ee1600ba
+      name: bratwurst
+      cpu:
+        count: 2
+      disk: 40Gi
+      memory: 4Gi
+```
+
+### Kubernetes Service Prerequisites
+
+The Kubernetes service uses Loft vCluster to provide light-weight virtual clusters for end users.
+By default, the vCluster Helm chart assumes the `ingress-nginx` controller is installed, and also able to operate in TLS pass-through mode in order to propagate the Kubernetes configuration client certificate to the virtual API endpoint for authentication and authorization.
+
+This can be installed in a similar manner to the following:
+
+```shell
+helm upgrade --install nginx-ingress nginx/ingress-nginx -n ingress-nginx --create-namespace --set controller.ingressClassResource.default=true --set 'controller.extraArgs.enable-ssl-passthrough='
+```
+
+As the ingress needs to be able to route the correct clients to the correct virtual cluster API endpoint via the shared ingress, we need to be able to use SNI in order to extract the HTTP hostname from the TLS handshake to perform the routing.
+For hostname based routing, we need to have DDNS available to manage DNS records.
+This is typically achieved with the `external-dns` controller:
+
+```shell
+helm upgrade --install external-dns external-dns/external-dns -n external-dns --create-namespace --set provider.name=cloudflare --set env[0].name=CF_API_TOKEN --set env[0].value=foo --set domainFilters[0]=my-region.domain.com
+```
+
+Finally when we install virtual clusters, they need to be monitored, and therefore require Prometheus:
+
+```shell
+helm upgrade --install kube-prometheus prometheus-community/kube-prometheus-stack --create-namespace -n kube-prometheus
+```

--- a/pkg/providers/internal/kubernetes/README.md
+++ b/pkg/providers/internal/kubernetes/README.md
@@ -1,91 +1,84 @@
-# Unikorn Kubernetes Provider
+# pkg/providers/internal/kubernetes
 
-The Kubernetes provider allows entire Kubernetes clusters to be used as regions.
-While these regions do not provide the isolation inherent with virtual and physical machines, they can be provisioned into light-weight and highly performant virtual clusters.
+## Intention
 
-The Unikorn Kubernetes service can consume Kubernetes regions for cluster provisioning.
+`pkg/providers/internal/kubernetes` exposes a Kubernetes-backed region as a
+cloud-like substrate for higher-order services.
 
-## Kubernetes Cluster Prerequisites
+It does not try to make Kubernetes look identical to OpenStack. Instead, it
+adapts a Kubernetes cluster into the subset of the region provider contract
+that higher layers need when the backing platform can still satisfy the normal
+region-shaped flow in a more abstract way.
 
-Before importing a Kubernetes cluster as a region, some steps need to be carried out in order to make it consumable.
+That means the consumer is not fixed:
 
-### Kubernetes Configuration Secret
+- one consumer might provision Kubernetes-on-Kubernetes clusters, for example
+  using `vcluster` with node selectors for placement and segregation
+- another could provision VM-style workloads via something like KubeVirt
 
-The region will need access to the Kubernetes configuration with cluster admin permissions (for now).
-This is stored in a secret as follows:
+What matters is that the region exposes a usable flavor/scheduling surface in a
+shape higher-order services can consume consistently.
 
-```shell
-kubectl create secret generic -n unikorn-region de-central-0-kubeconfig --from-file kubeconfig=/path/to/my/kubeconfig
-```
+Today this package implements the common read-side provider surface for
+Kubernetes regions:
 
-It will be consumed in the example in the next section.
+- return the configured `Region`
+- connect to the remote cluster using the referenced kubeconfig secret
+- discover schedulable node classes
+- convert declared node-class metadata into provider-neutral `Flavor` values
 
-### Flavor Mapping
+## Links
 
-Kubernetes clusters are composed of pools of machines.
-Each machine type has a set of characteristics:
+- [../../../apis/unikorn/v1alpha1](../../../apis/unikorn/v1alpha1/README.md)
+- [./ADMIN.md](./ADMIN.md)
 
-* CPU count and type
-* Memory capacity
-* Ephemeral disk capacity
-* GPU count and type
+The API package defines the `Region.Spec.Kubernetes` shape consumed here.
+`ADMIN.md` keeps the cluster-preparation and operator setup guidance that
+belongs to human administrators rather than this package contract summary.
 
-These characteristics are directly exposed by the region controller a flavors, thus allowing virtual clusters to be composed of pools of entire nodes.
-This facilitates node level isolation, simplified quota management based on nodes and GPUs, and finally simplified billing based on node flavors (as opposed to pod resource limits).
+## Invariants And Guard Rails
 
-Node characteristic data can also bu used to find a suitable region to run a workload on given the requirement for a certain GPU type, for example.
+- This package currently implements `types.CommonProvider`, not the full cloud
+  provider contract.
+- The remote cluster connection is derived from
+  `region.Spec.Kubernetes.KubeconfigSecret`.
+- Only nodes carrying
+  `kubernetes.region.unikorn-cloud.org/node-class` are considered schedulable
+  exportable capacity.
+- A flavor is exposed only when its node class is both:
+  - declared in `region.Spec.Kubernetes.Nodes`
+  - observed on at least one node in the remote cluster
+- Flavor metadata is primarily taken from `Region.Spec.Kubernetes.Nodes`, not
+  auto-derived from raw node objects.
+- The package therefore treats the region spec as the authoritative flavor
+  description and the cluster as the availability check.
+- Architecture is currently hard-coded to `x86_64`.
 
-Each node of a certain machine type must have a `kubernetes.region.unikorn-cloud.org/node-class` node label applied.
-The value of the label should be a globally unique v4 UUID.
+## Caveats
 
-Only nodes with a node class label can be considered and consumed by higher order services such as the Kubernetes service's virtual clusters.
+- This is a partial provider implementation, not a full Kubernetes analogue of
+  the OpenStack provider.
+- The trust boundary is large: the referenced kubeconfig currently needs enough
+  access to inspect the remote cluster and is described in the admin guidance as
+  cluster-admin style access.
+- Flavor metadata is manually curated because node status is not treated as a
+  sufficient source of truth for all user-facing shape data.
+- `Region()` returns the stored region pointer directly and still carries a
+  `TODO` about atomic refresh.
+- `ListExternalNetworks` and the wider cloud lifecycle operations are not part
+  of this package's current implementation surface.
 
-Node class metadata is defined by the region resource, e.g.:
+## TODO
 
-```yaml
-apiVersion: region.unikorn-cloud.org/v1alpha1
-kind: Region
-metadata:
-  namespace: unikorn-region
-  name: fe4ecbe4-421d-4f25-8b11-69593adfef5d
-  labels:
-    unikorn-cloud.org/name: de-central-0
-spec:
-  provider: kubernetes
-  kubernetes:
-    kubeConfigSecret:
-      namespace: unikorn-region
-      name: de-central-0-kubeconfig
-    nodes:
-    - id: 4be04a2e-87e6-4ff2-b34b-2994ee1600ba
-      name: bratwurst
-      cpu:
-        count: 2
-      disk: 40Gi
-      memory: 4Gi
-```
+- Revisit the hard-coded `x86_64` architecture assumption.
+- Tighten the remote cluster trust model if the current kubeconfig access level
+  is broader than necessary.
 
-### Kubernetes Service Prerequisites
+## Cross-Package Context
 
-The Kubernetes service uses Loft vCluster to provide light-weight virtual clusters for end users.
-By default, the vCluster Helm chart assumes the `ingress-nginx` controller is installed, and also able to operate in TLS pass-through mode in order to propagate the Kubernetes configuration client certificate to the virtual API endpoint for authentication and authorization.
-
-This can be installed in a similar manner to the following:
-
-```shell
-helm upgrade --install nginx-ingress nginx/ingress-nginx -n ingress-nginx --create-namespace --set controller.ingressClassResource.default=true --set 'controller.extraArgs.enable-ssl-passthrough='
-```
-
-As the ingress needs to be able to route the correct clients to the correct virtual cluster API endpoint via the shared ingress, we need to be able to use SNI in order to extract the HTTP hostname from the TLS handshake to perform the routing.
-For hostname based routing, we need to have DDNS available to manage DNS records.
-This is typically achieved with the `external-dns` controller:
-
-```shell
-helm upgrade --install external-dns external-dns/external-dns -n external-dns --create-namespace --set provider.name=cloudflare --set env[0].name=CF_API_TOKEN --set env[0].value=foo --set domainFilters[0]=my-region.domain.com
-```
-
-Finally when we install virtual clusters, they need to be monitored, and therefore require Prometheus:
-
-```shell
-helm upgrade --install kube-prometheus prometheus-community/kube-prometheus-stack --create-namespace -n kube-prometheus
-```
+- [../types](../types/README.md) defines the `CommonProvider` and `Flavor`
+  contract this package satisfies
+- [../../../handler/region](../../../handler/region/README.md) consumes the
+  exported flavor view
+- higher-order services use this substrate region shape to implement concrete
+  Kubernetes-on-Kubernetes, VM, or similar region-backed provisioning flows

--- a/pkg/providers/internal/openstack/ADMIN.md
+++ b/pkg/providers/internal/openstack/ADMIN.md
@@ -1,0 +1,118 @@
+# Unikorn OpenStack Provider
+
+Provides a driver for OpenStack based regions.
+
+## Initial Setup
+
+It is envisaged that an OpenStack cluster may be used for things other than the exclusive use of Unikorn, and as such it tries to respect this as much as possible.
+We also operate under the principle of least privilege, so don't want to have a full admin credential alyng around.
+
+In particular we want to allow different instances of Unikorn to cohabit to support, for example, staging environments.
+
+We need a number of policies installing to function correctly.
+Follow the instructions in the [Unikorn OpenStack Policy repository](https://github.com/unikorn-cloud/python-unikorn-openstack-policy) to install them.
+
+### OpenStack Platform Configuration
+
+Start by selecting a unique name that will be used for the deployment's name, project, and domain:
+
+```bash
+export USER=unikorn-staging
+export DOMAIN=unikorn-staging
+export PROJECT=unikorn-default
+export PASSWORD=$(apg -n 1 -m 24)
+```
+
+#### Create the domain.
+
+The use of project domains for projects deployed to provision Kubernetes cluster achieves a few aims.
+First namespace isolation.
+Second is a security consideration.
+It is dangerous, anecdotally, to have a privileged process that has the power of deletion.
+By limiting the scope of list operations to that of the project domain we limit our impact on other tenants on the system.
+A domain may also aid in simplifying operations like auditing and capacity planning.
+
+```bash
+DOMAIN_ID=$(openstack domain create ${DOMAIN} -f json | jq -r .id)
+```
+
+#### Create the project.
+
+As the OpenStack provider for the region controller also functions as a client in order to retrieve information such as available images, flavors, and so on it also needs to be associated with a project so that the default policy for various API requests is correctly satisfied:
+
+```bash
+PROJECT_ID=$(openstack project create $PROJECT --domain $DOMAIN -f json | jq -r .id)
+```
+
+#### Create the user.
+
+```bash
+USER_ID=$(openstack user create --domain ${DOMAIN_ID} --password ${PASSWORD} ${USER} -f json | jq -r .id)
+```
+
+### Grant any roles to the user.
+
+When a Kubernetes cluster is provisioned, it will be done using application credentials, so ensure any required application credentials as configured for the region are explicitly associated with the user here.
+
+> [!NOTE]
+> It may be necessary to add the `_member_` role on older OpenStack deployments where Neutron requires it to function.
+
+```bash
+for role in member load-balancer_member manager; do
+	openstack role add --user ${USER_ID} --domain ${DOMAIN_ID} ${role}
+done
+```
+
+Grant the `member` and `manager` roles on the project we created in a previous step:
+
+```bash
+for role in member manager; do
+    openstack role add --user ${USER_ID} --project ${PROJECT_ID} ${role}
+done
+```
+
+### Unikorn Configuration
+
+When we create a `Region` of type `openstack`, it will require a secret that contains credentials.
+This can be configured as follows.
+
+```bash
+kubectl create secret generic -n unikorn-region gb-north-1-credentials \
+    --from-literal=domain-id=${DOMAIN_ID} \
+    --from-literal=project-id=${PROJECT_ID} \
+    --from-literal=user-id=${USER_ID} \
+    --from-literal=password=${PASSWORD}
+```
+
+Finally we can create the region itself, although this should be statically configured via Helm.
+For additional configuration options for individual OpenStack services, consult `kubectl explain regions.region.unikorn-cloud.org` for documentation.
+
+```yaml
+apiVersion: region.unikorn-cloud.org/v1alpha1
+kind: Region
+metadata:
+  # Use "uuidgen -r" to select a random ID, this MUST start with a character a-f.
+  namespace: unikorn-region
+  name: c7e8492f-c320-4278-8201-48cd38fed38b
+  labels:
+    unikorn-cloud.org/name: gb-north-1
+spec:
+  provider: openstack
+  openstack:
+    endpoint: https://openstack.gb-north-1.unikorn-cloud.org:5000
+    serviceAccountSecret:
+      namespace: unikorn
+      name: gb-north-1-credentials
+```
+
+Cleanup actions.
+
+```bash
+unset DOMAIN
+unset DOMAIN_ID
+unset USER
+unset USER_ID
+unset PASSWORD
+unset PROJECT
+unset PROJECT_ID
+```

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -1,118 +1,184 @@
-# Unikorn OpenStack Provider
+# pkg/providers/internal/openstack
 
-Provides a driver for OpenStack based regions.
+## Intention
 
-## Initial Setup
+`pkg/providers/internal/openstack` is the real cloud provider implementation
+for OpenStack-backed regions.
 
-It is envisaged that an OpenStack cluster may be used for things other than the exclusive use of Unikorn, and as such it tries to respect this as much as possible.
-We also operate under the principle of least privilege, so don't want to have a full admin credential alyng around.
+It does not merely wrap the OpenStack SDK. It is the package that translates
+the region service's storage model, tenancy model, metadata conventions, and
+lifecycle rules into concrete OpenStack operations across identity, compute,
+image, network, security group, load balancer, quota, and block storage
+surfaces.
 
-In particular we want to allow different instances of Unikorn to cohabit to support, for example, staging environments.
+The most important philosophy in this package is the trust and scoping model:
 
-We need a number of policies installing to function correctly.
-Follow the instructions in the [Unikorn OpenStack Policy repository](https://github.com/unikorn-cloud/python-unikorn-openstack-policy) to install them.
+- region-level `manager` authority is used only to provision and manage users
+  and projects inside a managed Keystone domain
+- once that scaffolding exists, most OpenStack operations deliberately context
+  switch into the specific project provisioned for one Unikorn identity
+- that OpenStack project then becomes the practical mapping, isolation, and
+  accounting boundary between Unikorn resources and real cloud resources
 
-### OpenStack Platform Configuration
+That model is what makes it realistic for multiple regions or deployments to
+share one underlying cloud while still limiting blast radius. It is also what
+makes backchannel accounting and billing integration plausible, because the
+project scope becomes the place where cloud resource usage can be tied back to a
+specific Unikorn identity and its descendants.
 
-Start by selecting a unique name that will be used for the deployment's name, project, and domain:
+The most important architectural rule is that this package prefers deterministic
+lookup against OpenStack over maintaining broad mirrored OpenStack state in
+Kubernetes. In older designs, dedicated `Openstack*` CRDs were used to persist
+more provider-side state locally. That drifted from reality and introduced race
+conditions. The current direction is:
 
-```bash
-export USER=unikorn-staging
-export DOMAIN=unikorn-staging
-export PROJECT=unikorn-default
-export PASSWORD=$(apg -n 1 -m 24)
-```
+- service-native CRDs remain the primary control objects
+- OpenStack remains the source of truth for cloud-side resources where they can
+  be re-found deterministically
+- only the provider state that still cannot be reconstructed safely or
+  sufficiently remains persisted locally, most notably `OpenstackIdentity`
 
-#### Create the domain.
+This package therefore owns the mapping between:
 
-The use of project domains for projects deployed to provision Kubernetes cluster achieves a few aims.
-First namespace isolation.
-Second is a security consideration.
-It is dangerous, anecdotally, to have a privileged process that has the power of deletion.
-By limiting the scope of list operations to that of the project domain we limit our impact on other tenants on the system.
-A domain may also aid in simplifying operations like auditing and capacity planning.
+- region-native CRDs and OpenStack resources
+- service labels, tags, and metadata conventions
+- per-identity delegated cloud credentials
+- compensating local mechanisms where OpenStack is not sufficient on its own,
+  such as image caching and provider-network VLAN allocation
 
-```bash
-DOMAIN_ID=$(openstack domain create ${DOMAIN} -f json | jq -r .id)
-```
+## Links
 
-#### Create the project.
+- [../../../apis/unikorn/v1alpha1](../../../apis/unikorn/v1alpha1/README.md)
+- [../../types](../../types/README.md)
+- [../allocation/vlan](../allocation/vlan/README.md)
+- [./ADMIN.md](./ADMIN.md)
 
-As the OpenStack provider for the region controller also functions as a client in order to retrieve information such as available images, flavors, and so on it also needs to be associated with a project so that the default policy for various API requests is correctly satisfied:
+`pkg/apis/unikorn/v1alpha1` defines the service-native resources and the
+remaining persisted provider-state records this package consumes. `pkg/providers/types`
+defines the provider-neutral contract this package implements. `pkg/providers/allocation/vlan`
+covers the local VLAN allocator used when provider networks need segmentation IDs.
+`ADMIN.md` keeps the human operator setup guidance for preparing an OpenStack
+region.
 
-```bash
-PROJECT_ID=$(openstack project create $PROJECT --domain $DOMAIN -f json | jq -r .id)
-```
+## Invariants And Guard Rails
 
-#### Create the user.
+- This package implements the full `types.Provider` contract for OpenStack
+  regions.
+- Provider construction has an explicit bootstrap/runtime split:
+  - bootstrap uses uncached Kubernetes reads to assemble OpenStack service
+    clients before controller-manager caches exist
+  - runtime operation switches back to the normal Kubernetes client and refreshes
+    derived OpenStack client state when region configuration or credentials
+    change
+- OpenStack access is intentionally scoped through different credential modes:
+  - region-level service credentials bootstrap privileged service clients and
+    managed-domain scaffolding
+  - per-identity credentials are used for most project-scoped operations
+  - some operations deliberately bind privileged credentials to a service
+    principal's project when manager-level powers are required
+- `OpenstackIdentity` is the remaining persisted provider-state anchor. It
+  currently stores the secret-bearing user/project/application-credential and
+  bootstrap state needed to operate on behalf of a region `Identity`.
+- The package relies heavily on deterministic naming and metadata conventions to
+  re-find cloud-side resources. This is a convention-heavy contract, not magic:
+  - identity-scoped resources use fixed generated names
+  - network lookups rely on deterministic names
+  - server metadata is written deliberately as both a control-plane lookup aid
+    and an in-guest linkage surface exposed through the metadata service
+  - legacy camelCase server metadata keys remain frozen for backwards
+    compatibility while newer namespaced keys provide the upgrade path
+- Flavor export is a hybrid model: OpenStack discovers the flavor inventory, but
+  region configuration can enrich or override user-facing flavor metadata such
+  as architecture, baremetal status, and GPU semantics.
+- Image handling is a first-class contract surface here:
+  - OpenStack image properties are validated against a schema
+  - public images can additionally be signature-verified
+  - image properties are translated into provider-neutral OS, package, GPU,
+    ownership, virtualization, and tag metadata
+  - an optional refresh-ahead cache exists because raw image API latency is too
+    expensive to expose directly to every caller
+- Quota and role behaviour are not purely discovered from OpenStack defaults.
+  The package assumes and applies a managed-role model, including default role
+  names such as `manager`, `member`, and `load-balancer_member`, unless region
+  configuration overrides parts of that behaviour.
+- Network, security group, and server resources are re-found in OpenStack by
+  deterministic lookup rather than relying on mirrored `OpenstackNetwork`,
+  `OpenstackSecurityGroup`, or `OpenstackServer` CRDs as authoritative state.
+- Some OpenStack list APIs are not safe to treat as exact lookup, notably
+  server and network `name` filters:
+  - `name` filters behave like prefix or regular-expression matches rather than
+    strict equality
+  - this package therefore re-checks exact names after listing to avoid aliasing
+    and false matches
+- Provider networks that require VLAN segmentation use the local VLAN allocator
+  because OpenStack does not allocate those IDs for us.
 
-```bash
-USER_ID=$(openstack user create --domain ${DOMAIN_ID} --password ${PASSWORD} ${USER} -f json | jq -r .id)
-```
+## Caveats
 
-### Grant any roles to the user.
+- This package is the convergence point of a large amount of platform policy,
+  provider behaviour, and historical baggage. Its size reflects real behaviour,
+  not just poor code hygiene.
+- Deterministic lookup is the preferred direction, but the package still lives
+  in a mixed world:
+  - some cloud-side state is derived live from OpenStack
+  - some transitional compatibility fields still exist in repo-native CRDs
+  - `OpenstackIdentity` still persists state that the service would ideally stop
+    owning over time
+- Deterministic lookup is cleaner than mirrored CRDs, but it is still sensitive
+  to convention drift. Renaming generated resources, changing metadata keys, or
+  casually altering project-scoping assumptions can break the linkage between
+  Unikorn resources, what OpenStack stores, and what users can see from inside
+  provisioned servers.
+- `OpenstackIdentity` should not be treated as permanently special. Its current
+  survival is largely driven by implicit side effects and secret-bearing
+  service-owned state that the architecture should work to remove:
+  - ephemeral SSH key generation and download
+  - implicit server-group creation
+  - persisted service-principal/user/project/application-credential data
+- Exposing application credentials to higher layers is current operational
+  reality, not the desired end state. The package's scoping model helps contain
+  blast radius today, while the wider platform works toward removing that
+  exposure entirely.
+- If the wider API moves toward explicit SSH certificate authority use, explicit
+  server-group resources, and less implicit provider-side identity scaffolding,
+  deleting `OpenstackIdentity` becomes more realistic.
+- Image metadata translation is powerful but fragile. This package currently
+  depends on OpenStack image properties carrying a large amount of semantic
+  information correctly.
+- Image query, get, create, delete, and snapshot flows are tightly coupled to
+  the image cache path. When caching is disabled, large parts of the higher
+  image contract are effectively unavailable rather than merely slower.
+- The image query layer still contains its own comment admitting that some logic
+  now operates on generic types and probably should not live here long term.
+- Some older assumptions still leak through in status fields and helper paths,
+  especially where compatibility with older API or storage shapes is still being
+  carried.
 
-When a Kubernetes cluster is provisioned, it will be done using application credentials, so ensure any required application credentials as configured for the region are explicitly associated with the user here.
+## TODO
 
-> [!NOTE]
-> It may be necessary to add the `_member_` role on older OpenStack deployments where Neutron requires it to function.
+- Delete the remaining mirror-state OpenStack CRD usage paths entirely:
+  `OpenstackNetwork`, `OpenstackSecurityGroup`, and `OpenstackServer` should not
+  survive as authoritative provider-state patterns.
+- Continue shrinking the reasons `OpenstackIdentity` must exist:
+  - remove service-handled private SSH key material in favour of explicit SSH
+    certificate trust
+  - stop relying on implicit server-group provisioning
+  - move toward explicit API shapes where reconstructable state does not need to
+    be persisted here
+- Revisit image-query and image-metadata logic that now operates on
+  provider-neutral types but still lives in this package because of historical
+  coupling.
+- Remove remaining compatibility writes and reads that depend on transitional
+  CRD status shapes as those fields disappear from the wider system.
 
-```bash
-for role in member load-balancer_member manager; do
-	openstack role add --user ${USER_ID} --domain ${DOMAIN_ID} ${role}
-done
-```
+## Cross-Package Context
 
-Grant the `member` and `manager` roles on the project we created in a previous step:
-
-```bash
-for role in member manager; do
-    openstack role add --user ${USER_ID} --project ${PROJECT_ID} ${role}
-done
-```
-
-### Unikorn Configuration
-
-When we create a `Region` of type `openstack`, it will require a secret that contains credentials.
-This can be configured as follows.
-
-```bash
-kubectl create secret generic -n unikorn-region gb-north-1-credentials \
-    --from-literal=domain-id=${DOMAIN_ID} \
-    --from-literal=project-id=${PROJECT_ID} \
-    --from-literal=user-id=${USER_ID} \
-    --from-literal=password=${PASSWORD}
-```
-
-Finally we can create the region itself, although this should be statically configured via Helm.
-For additional configuration options for individual OpenStack services, consult `kubectl explain regions.region.unikorn-cloud.org` for documentation.
-
-```yaml
-apiVersion: region.unikorn-cloud.org/v1alpha1
-kind: Region
-metadata:
-  # Use "uuidgen -r" to select a random ID, this MUST start with a character a-f.
-  namespace: unikorn-region
-  name: c7e8492f-c320-4278-8201-48cd38fed38b
-  labels:
-    unikorn-cloud.org/name: gb-north-1
-spec:
-  provider: openstack
-  openstack:
-    endpoint: https://openstack.gb-north-1.unikorn-cloud.org:5000
-    serviceAccountSecret:
-      namespace: unikorn
-      name: gb-north-1-credentials
-```
-
-Cleanup actions.
-
-```bash
-unset DOMAIN
-unset DOMAIN_ID
-unset USER
-unset USER_ID
-unset PASSWORD
-unset PROJECT
-unset PROJECT_ID
-```
+- [../../types](../../types/README.md) defines the neutral provider contract and
+  intermediate types this package must satisfy
+- [../../../apis/unikorn/v1alpha1](../../../apis/unikorn/v1alpha1/README.md)
+  defines the service-native control objects and the remaining persisted
+  provider-state records this package consumes
+- [../../../handler](../../../handler/README.md) and specific handler packages
+  depend on this package to make region API operations real against OpenStack
+- [../allocation/vlan](../allocation/vlan/README.md) exists because this
+  package needs a compensating local allocator for provider-network VLAN IDs

--- a/pkg/providers/internal/simulated/README.md
+++ b/pkg/providers/internal/simulated/README.md
@@ -1,0 +1,72 @@
+# pkg/providers/internal/simulated
+
+## Intention
+
+`pkg/providers/internal/simulated` is a deterministic contract-shaped provider
+used to push broad region integration testing left.
+
+It exists primarily so higher-order region flows can be exercised in pull
+request and development environments without requiring a real cloud backing
+environment. That makes it valuable for:
+
+- broad integration coverage of provider-shaped flows
+- race and bottleneck detection in higher layers
+- high-scale and performance-oriented testing where a real cloud deployment
+  would be impractical
+
+It is not intended to be a faithful emulator of OpenStack. It deliberately
+implements only enough of the provider contract to support useful testing and
+development, while keeping behaviour deterministic and cheap to run.
+
+## Invariants And Guard Rails
+
+- The package implements the full `types.Provider` interface, but only some
+  operations have meaningful simulated behaviour.
+- The current implementation is deliberately incomplete. It represents the
+  smallest useful amount of work needed to unlock broad push-left integration
+  coverage, not a mature simulation of the full provider surface.
+- Determinism matters more than provider fidelity. Built-in flavors, images,
+  external networks, and synthetic addresses are stable by design.
+- Custom images are stored in-memory behind a lock and merged with built-in
+  images through the same query/filter contract used by real providers.
+- Unsupported operations fail explicitly with `ErrUnsupportedOperation` rather
+  than pretending to succeed.
+- Some mutable operations intentionally act by mutating service-side resource
+  status deterministically, for example network status and load balancer VIP or
+  public IP assignment.
+- The simulated provider is particularly useful for stressing strongly
+  consistent higher-layer workflows such as quota, reference, and coordination
+  paths, because those higher layers can be exercised against a cheap
+  deterministic backend without a real cloud dominating the test environment.
+
+## Caveats
+
+- This is a contract stub, not a high-fidelity cloud emulator.
+- Large parts of the real OpenStack behaviour surface are intentionally absent.
+  Success here does not prove fidelity against real provider edge cases,
+  eventual-consistency quirks, or provider-specific failures.
+- More work is still needed before this provider can support meaningfully deep
+  provider-level testing. Its value today is breadth, determinism, and scale,
+  not behavioural completeness.
+- Some operations are no-ops, some are deterministic state mutations, and some
+  are explicit unsupported failures. Callers must not assume one consistent
+  simulation strategy across the whole interface.
+- The in-memory image store is process-local and ephemeral.
+- The package still writes transitional compatibility state such as
+  `Network.Status.Openstack`, so it inherits some of the same historical baggage
+  as the wider repo.
+
+## TODO
+
+- Extend the simulation only where it improves contract, race, bottleneck, or
+  scale testing value; do not grow it into a full fake OpenStack by default.
+- Remove simulated writes to transitional status shapes as the corresponding
+  compatibility fields disappear from the wider system.
+
+## Cross-Package Context
+
+- [../types](../types/README.md) defines the full provider contract this package
+  implements
+- [../../../handler](../../../handler/README.md), [../../../monitor](../../../monitor/README.md),
+  and higher-order integration tests consume this provider to exercise
+  contract-shaped region behaviour without a real cloud

--- a/pkg/providers/types/README.md
+++ b/pkg/providers/types/README.md
@@ -1,0 +1,94 @@
+# pkg/providers/types
+
+## Intention
+
+`pkg/providers/types` defines the provider-agnostic intermediate contract used
+between handlers and concrete providers where the service does not have, or does
+not want to depend on, a first-class custom resource shape for the thing being
+exchanged.
+
+That makes this package a mixed abstraction layer on purpose:
+
+- when the service already has a stable persisted model, provider interfaces
+  still operate directly on `pkg/apis/unikorn/v1alpha1` resources such as
+  `Identity`, `Network`, `SecurityGroup`, `LoadBalancer`, and `Server`
+- when the thing is provider-derived, query-driven, transient, or otherwise not
+  represented as a concrete CRD, this package provides the neutral shape and
+  capability contract instead, for example `Flavor`, `Image`,
+  `ExternalNetwork`, `ServerCreateOptions`, and the image query interfaces
+
+So this package is not "all provider models". It is the intermediate
+portability layer for provider-facing concepts that higher layers still need to
+reason about even when no persisted service-native resource exists for them.
+
+## Links
+
+- [../../apis/unikorn/v1alpha1](../../apis/unikorn/v1alpha1/README.md)
+
+`pkg/apis/unikorn/v1alpha1` defines the service-native persisted resources that
+continue to be passed directly through many provider interface methods.
+
+## Invariants And Guard Rails
+
+- `Provider` is a capability composition interface, not one monolithic "SDK"
+  wrapper. It embeds smaller contracts such as `ImageRead`, `ImageWrite`,
+  `Network`, `Server`, `ServerConsole`, and `ServerSnapshot`.
+- CRD-backed lifecycle operations continue to use repo-native
+  `unikornv1.*` resource types where those are the stable service contract.
+- Provider-derived or non-CRD concepts use the intermediate types defined in
+  this package instead of leaking concrete provider SDK shapes upward.
+- `ImageQuery` is a provider-neutral query-builder contract for image listing
+  and filtering, not just a raw slice-returning helper.
+- `ImageList` is a cached snapshot abstraction rather than a plain slice,
+  shaped to support efficient repeated reads and memoization where provider
+  implementations choose to provide them.
+- `Image.Index()`, `Image.Equal()`, and `Image.DeepCopy()` are part of that
+  cached-snapshot contract, not incidental helpers.
+- `ServerCreateOptions` carries launch-time derived inputs without forcing them
+  into the persisted `Server` CRD shape.
+- Exported errors such as `ErrImageNotReadyForUpload` and
+  `ErrImageStillInUse` are semantic contract values used to communicate provider
+  behaviour upward.
+
+## Caveats
+
+- This package is intentionally not a pure abstraction boundary. It mixes
+  provider-neutral intermediate types with direct use of service-native CRD
+  types where that is the clearer contract.
+- Because of that mixed model, readers should not expect every provider-facing
+  concept to be normalized into this package. Some concepts belong here, others
+  deliberately remain owned by `pkg/apis/unikorn/v1alpha1`.
+- `Image` carries a large amount of behaviourally important state: ownership,
+  tags, readiness, OS identity, package inventory, virtualization mode, and GPU
+  compatibility. It is not a thin transport struct.
+- `Image.Tags` are described here as arbitrary labels, but higher layers in this
+  repository currently derive some service semantics from image tags. See
+  [../../constants](../../constants/README.md) for related discussion of that
+  design smell. Callers should not assume tags are always semantically neutral
+  just because this intermediate model presents them generically.
+- Not every concrete provider is guaranteed to support every concept equally
+  well. This package standardizes the contract surface, but concrete behaviour
+  still depends on provider implementation choices and limitations.
+- There is stale historical scar tissue in the interface layer, especially
+  around old network-detail propagation commentary. That comment block is now a
+  cleanup problem more than a live contract.
+
+## TODO
+
+- Remove the stale network-detail/CAPO-related comment baggage from the
+  `Network` interface so the package does not imply a dead contract still
+  exists.
+- Re-evaluate whether image metadata that currently carries service semantics
+  should remain represented as generic tags in this intermediate model.
+
+## Cross-Package Context
+
+- [../internal/openstack](../internal/openstack/README.md),
+  [../internal/kubernetes](../internal/kubernetes/README.md), and
+  [../internal/simulated](../internal/simulated/README.md) implement these
+  contracts concretely
+- [../../handler](../../handler/README.md) and specific handler subpackages
+  consume these types when converting provider-derived information into API
+  reads and actions
+- [../../monitor](../../monitor/README.md) consumes provider-neutral read-side
+  information such as flavors when observing runtime state

--- a/pkg/providers/util/README.md
+++ b/pkg/providers/util/README.md
@@ -1,0 +1,59 @@
+# pkg/providers/util
+
+## Intention
+
+`pkg/providers/util` is a narrow provider-support package for generating the
+ephemeral SSH keypair currently used as a break-glass access path during
+OpenStack identity provisioning.
+
+It is not a general SSH helper library. Its current job is to create an
+Ed25519 keypair, return the public key in OpenSSH authorized-key format, return
+the private key in PEM form, and hand both back to the OpenStack provider flow
+that installs the public key cloud-side and persists the private key for later
+download or use by higher-order services.
+
+That makes this package a transitional convenience helper rather than a durable
+architectural primitive. The long-term direction is toward SSH certificate
+flows where the service does not handle user private keying material at all.
+
+## Invariants And Guard Rails
+
+- This package exists for one specific workflow: generating the ephemeral SSH
+  keypair used by the OpenStack identity bootstrap path.
+- `GenerateSSHKeyPair()` generates Ed25519 keys. The algorithm is not currently
+  configurable.
+- The returned public key is encoded in OpenSSH authorized-key format.
+- The returned private key is PEM-encoded OpenSSH private key material.
+- The package should not grow into a generic SSH abstraction layer unless there
+  is a concrete second use case that justifies it.
+
+## Caveats
+
+- The helper is described as ephemeral, but the private key is still persisted
+  in provider-backed identity state today so it can be downloaded or consumed
+  later. That means the exposure model is still materially different from a
+  pure certificate-based approach.
+- This is primarily a break-glass convenience path, not the preferred
+  long-term trust model.
+- The package name undersells its sensitivity: it is generating access
+  credentials, not performing low-stakes generic utility work.
+- If server access moves fully to SSH certificate authority flows, this package
+  may become unnecessary for at least some current provisioning paths.
+
+## TODO
+
+- Remove or reduce service handling of private SSH key material as certificate
+  based login flows replace break-glass key download.
+- Re-evaluate whether this package should exist at all once SSH certificate
+  flows are the normal path.
+
+## Cross-Package Context
+
+- [../internal/openstack](../internal/openstack/README.md) consumes this helper
+  while provisioning OpenStack identities
+- [../../apis/unikorn/v1alpha1](../../apis/unikorn/v1alpha1/README.md) defines
+  the persisted `OpenstackIdentity` fields that currently store the generated
+  key metadata and private key
+- [../../openapi](../../openapi/README.md) exposes the current read-side API
+  shape through which higher-order services can still receive this bootstrap
+  material

--- a/pkg/provisioners/README.md
+++ b/pkg/provisioners/README.md
@@ -1,0 +1,36 @@
+# `pkg/provisioners`
+
+This tree contains the controller-side provisioning logic for region resources.
+
+At a high level, the split is:
+
+- `pkg/managers/*`: controller factories and watch registration
+- `pkg/provisioners/managers/*`: per-resource reconcile/provision/deprovision logic
+- `pkg/provisioners/internal/base`: shared helpers for resolving providers and
+  identities from region resources
+
+The overall pattern is conventional across resources:
+
+1. a manager watches one CRD
+2. the reconciler constructs one provisioner
+3. the provisioner resolves any prerequisite identity/provider context
+4. it calls the provider or performs controller-side cleanup/augmentation
+
+This layer is where the platform lifecycle DAG becomes controller behaviour.
+Handlers create or mutate roots and references; provisioners turn that desired
+state into provider-side effects and edge maintenance.
+
+The main deviations from a trivial “call provider create/delete” model are:
+
+- some provisioners must wait for a parent/service-principal identity to be ready
+- some maintain cross-resource reference edges explicitly
+- some release or reconcile identity-side quota allocations on deprovision
+- some augment provider create options, especially for server cloud-init / SSH CA integration
+
+## Cross-Package Context
+
+- [../managers](../managers/README.md) wraps these provisioners in controller factories
+- [../handler](../handler/README.md) documents the API-layer creation of many of
+  the roots and reference edges provisioners later realize
+- [../providers](../providers/README.md) documents the provider contract this
+  layer drives

--- a/pkg/provisioners/internal/base/README.md
+++ b/pkg/provisioners/internal/base/README.md
@@ -1,0 +1,38 @@
+# Base
+
+## Purpose
+
+`pkg/provisioners/internal/base` is the shared helper for manager provisioners.
+
+It provides the common lookup logic for:
+
+- resolving a cloud provider from a resource's `region` label
+- resolving the backing `Identity` from a resource's `identity` label
+- returning both together when a provisioner needs project-scoped provider access
+
+This is small, but important. Most resource provisioners in region are really
+operating against a provider plus an identity-scoped cloud project, and this
+package keeps that resolution logic consistent.
+
+## Invariants And Guard Rails
+
+- The package assumes label discipline is correct. Missing or wrong
+  `RegionLabel`/`IdentityLabel` values are consistency failures, not normal
+  business cases.
+- Provider lookup is region-based, identity lookup is label-based.
+- This package is not where provisioning policy lives; it only resolves the
+  inputs that provisioners need.
+
+## Caveats
+
+- Because it resolves identity from labels, it is tightly coupled to the
+  lifecycle-DAG labeling model documented in the handler layer.
+- This package uses the contextual Kubernetes client from `core/pkg/client`,
+  which means callers must already be running inside the controller/reconciler
+  execution model.
+
+## Cross-Package Context
+
+- [../../README.md](../../README.md) documents the higher-level provisioner split
+- [../../../handler/README.md](../../../handler/README.md) documents the label
+  and root semantics that make these lookups possible

--- a/pkg/provisioners/managers/README.md
+++ b/pkg/provisioners/managers/README.md
@@ -1,0 +1,30 @@
+# `pkg/provisioners/managers`
+
+This tree contains the per-resource controller provisioners used by region
+managers.
+
+The common pattern is:
+
+- hold a typed CRD pointer
+- implement `provisioners.ManagerProvisioner`
+- use [`../internal/base`](../internal/base/README.md) to resolve provider and
+  identity context where needed
+- drive provider create/delete or controller-side cleanup
+
+Most of the packages here are intentionally thin. The interesting architectural
+differences are not “how do they hook into the controller framework” but which
+graph edges they maintain:
+
+- provider-side lifecycle edges
+- identity readiness dependencies
+- allocation/accounting edges
+- explicit reference edges between region resources
+- server-side user-data / SSH CA augmentation
+
+## Packages
+
+- [identity](./identity/README.md)
+- [network](./network/README.md)
+- [security-group](./security-group/README.md)
+- [load-balancer](./load-balancer/README.md)
+- [server](./server/README.md)

--- a/pkg/provisioners/managers/identity/README.md
+++ b/pkg/provisioners/managers/identity/README.md
@@ -1,0 +1,21 @@
+# Identity
+
+`pkg/provisioners/managers/identity` provisions and deprovisions cloud-side
+identity/project scaffolding for region `Identity` resources.
+
+Distinctive behaviour:
+
+- adds and removes the identity-side project reference edge via
+  `identity/pkg/client`
+- delegates actual cloud identity creation/deletion to the provider
+
+This is one of the clearest controller-side lifecycle bridges:
+
+- identity service project lifecycle
+- region identity root
+- provider-side project/user/application-credential state
+
+## Caveats
+
+- This is still tied to the deprecated handler/API identity surface, even though
+  the underlying service-principal concept remains important.

--- a/pkg/provisioners/managers/load-balancer/README.md
+++ b/pkg/provisioners/managers/load-balancer/README.md
@@ -1,0 +1,22 @@
+# Load Balancer
+
+`pkg/provisioners/managers/load-balancer` is intentionally unusual.
+
+Provision is currently a scaffolded no-op that yields, while deprovision still
+has real work to do:
+
+- release identity-side quota allocation on teardown
+
+So this package is mostly an accounting-edge maintainer rather than a full
+provider lifecycle driver today.
+
+## Caveats
+
+- This asymmetry is easy to miss: create/update semantics are currently driven
+  elsewhere, but deprovision still carries cleanup obligations here.
+
+## TODO
+
+- Either implement the intended provider lifecycle here or retire the remaining
+  teardown-only allocation cleanup path if the architecture moves elsewhere for
+  good.

--- a/pkg/provisioners/managers/network/README.md
+++ b/pkg/provisioners/managers/network/README.md
@@ -1,0 +1,18 @@
+# Network
+
+`pkg/provisioners/managers/network` provisions cloud networks once the backing
+identity/service-principal context is ready.
+
+Distinctive behaviour:
+
+- blocks on parent identity readiness before provider create/delete
+- deletes identity-side quota allocation on deprovision for `v2` networks only
+- carries explicit `v1` compatibility debt in that allocation cleanup path
+
+This package is where the hidden service-principal edge behind `Network v2`
+turns into provider-scoped network creation.
+
+## TODO
+
+- Remove the `v1` compatibility branch in deprovision once legacy networks no
+  longer need to coexist with discrete `v2` allocation cleanup.

--- a/pkg/provisioners/managers/security-group/README.md
+++ b/pkg/provisioners/managers/security-group/README.md
@@ -1,0 +1,13 @@
+# Security Group
+
+`pkg/provisioners/managers/security-group` is the straightforward security-group
+provisioner.
+
+Distinctive behaviour:
+
+- waits for identity readiness
+- delegates create/delete to the provider
+
+Compared with siblings, it has very little controller-side policy of its own.
+That is the expected shape for a well-scoped provisioner whose interesting
+semantics already live in the handler/resource graph.

--- a/pkg/provisioners/managers/server/README.md
+++ b/pkg/provisioners/managers/server/README.md
@@ -1,0 +1,34 @@
+# Server
+
+`pkg/provisioners/managers/server` is the richest manager provisioner in the tree.
+
+Distinctive behaviour:
+
+- maintains explicit reference edges from a server to consumed networks,
+  security groups, and optional SSH certificate authority
+- blocks on identity readiness before provider create/delete
+- augments provider create options with managed cloud-init parts for SSH CA use
+- clears or updates consumed-resource references during reprovision and teardown
+
+This is the clearest controller-side expression of the lifecycle DAG model:
+
+- network/security-group/SSH-CA edges are explicit and blocking
+- provider-side server lifecycle is delegated
+- cloud-init augmentation translates higher-level SSH CA semantics into machine
+  bootstrap material
+
+## Caveats
+
+- Reference maintenance here is easy to underappreciate, but it is central to
+  keeping server deletion and dependent-resource blocking semantics correct.
+- The provisioner currently trusts the API not to supply repeated network or
+  security-group IDs, even though the code still carries explicit TODOs to
+  reject duplicates.
+
+## TODO
+
+- Reject repeated network IDs in server specifications at the API boundary
+  rather than relying on provisioner-side reference maintenance to behave
+  sensibly.
+- Reject repeated security-group IDs in server specifications for the same
+  reason.

--- a/pkg/server/README.md
+++ b/pkg/server/README.md
@@ -1,0 +1,168 @@
+# `pkg/server`
+
+This package is the API server composition layer for region.
+
+## Intent
+
+It takes the region service's handler layer and wraps it in the concrete HTTP
+server, OpenAPI router, middleware stack, and runtime dependency construction
+needed to serve the API.
+
+Structurally, it is very close to
+[`identity/pkg/server`](../../../identity/pkg/server/README.md). The important
+difference is that region does not own the full authentication and authorization
+stack locally. Instead it delegates trust assembly back through identity and
+focuses on constructing:
+
+- the shared core middleware pipeline
+- the region-specific OpenAPI server wrapper
+- the outbound identity client used for remote authorization
+- the provider registry used by handlers
+- the thin handler dependency bundle in [`pkg/handler/common`](../handler/common/README.md)
+
+## Middleware Architecture
+
+Like identity, the package composes two middleware layers:
+
+- the shared pre-routing `core` middleware stack
+- the post-routing OpenAPI middleware stack used for validation and audit
+
+### Pre-Routing Core Middleware
+
+The raw router is wrapped in this order:
+
+1. OpenTelemetry
+2. logging
+3. route resolver
+4. CORS
+
+The ordering has the same rationale as identity:
+
+- OpenTelemetry runs first so trace context exists before anything else
+- logging runs early so failures before deep handler logic are still captured
+  with correlation context
+- route resolution must happen before middleware that depends on OpenAPI
+  operation/schema metadata
+- CORS comes after route resolution because its schema-driven behaviour depends
+  on the resolved route
+
+### Post-Routing OpenAPI Middleware
+
+Region then attaches service-specific middleware through the generated OpenAPI
+server wrapper:
+
+1. validator
+2. audit
+
+As with identity, those are applied in reverse by the generated wrapper, so the
+validator/authorizer stage runs before audit and both run before the handler
+implementation.
+
+## The Big Difference From Identity
+
+The trust model is not assembled locally here the way it is in identity.
+
+Identity builds its own local authn/authz runtime:
+
+- JWT issuer
+- OAuth2 authenticator
+- RBAC engine
+- user database
+- local OpenAPI authorizer
+
+Region does not.
+
+Instead, region constructs a remote authorizer using
+[`identity/pkg/middleware/openapi/remote`](../../../identity/pkg/middleware/openapi/remote/README.md)
+and an outbound identity API client configuration. That means:
+
+- identity remains the source of truth for trust and authorization context
+- region server wiring is thinner and more dependent on cross-service identity
+  integration
+- region is implementing a platform-defined server and trust composition
+  contract here, not inventing service-local policy choices about how validation,
+  audit, and authorization should fundamentally work
+- trust breakage here is often really a mismatch between region's remote
+  authorizer use and identity's middleware expectations
+
+## Construction Flow
+
+At a high level, server construction is:
+
+1. build the OpenAPI schema
+2. create the raw router
+3. install the shared pre-routing middleware stack
+4. create the remote identity-backed authorizer
+5. build validator and audit middleware
+6. construct the outbound identity API client
+7. construct the provider registry, including image-cache warmup
+8. assemble [`handler/common.ClientArgs`](../handler/common/README.md)
+9. construct the region handler
+10. attach everything through the generated OpenAPI router and return
+   `http.Server`
+
+That is the main package-specific delta from identity: region server startup
+includes provider bootstrap and remote authorization wiring rather than local
+identity-authority bootstrap.
+
+## Runtime Dependencies
+
+The most important constructed runtime dependencies are:
+
+- an identity API client for remote authorization and handler-side identity
+  operations
+- a provider registry from [`pkg/providers`](../providers/README.md)
+- a thin handler dependency bundle in
+  [`pkg/handler/common`](../handler/common/README.md)
+
+This is why the region handler constructor is much narrower than identity's.
+Most heavy runtime concerns have already been pushed into identity or the
+provider layer before the handler is built.
+
+## Distinctive Operational Behaviour
+
+- `pprof` is started on a separate listener at `:6060`
+- provider startup currently requests image-cache warmup
+- the server relies on a remote trust boundary with identity rather than being
+  a self-contained identity authority
+
+## Invariants And Guard Rails
+
+- The shared `core` middleware stack runs before any region-specific OpenAPI
+  middleware.
+- Middleware ordering is part of the package contract because later stages
+  depend on context established by earlier ones.
+- The server composition choices here should be treated as platform contract,
+  not service-local freedom. Region assembles the prescribed layers; it does
+  not define their high-level trust semantics independently.
+- Region authorization context is expected to be assembled through identity's
+  remote authorizer model, not recreated ad hoc in handlers.
+- Provider construction is a server startup concern, not something individual
+  handlers should perform independently.
+- Handler construction should stay thin and pass through
+  [`handler/common.ClientArgs`](../handler/common/README.md) rather than growing
+  a second identity-like runtime object.
+
+## Caveats
+
+- This package is highly ordering-sensitive, just like identity's server
+  package.
+- The remote authorizer means region server correctness depends on a
+  cross-service contract with identity, not just local code.
+- Provider bootstrap at server start is convenient, but it also means provider
+  readiness and image-cache behaviour are part of API readiness.
+- The separate `pprof` listener is operationally useful, but it is also a
+  second exposed server process concern that deployments must account for.
+
+## Cross-Package Context
+
+- [../handler](../handler/README.md) documents the application layer this
+  package serves
+- [../providers](../providers/README.md) documents the provider registry built
+  here
+- [`../../../identity/pkg/server`](../../../identity/pkg/server/README.md)
+  documents the closely related server composition pattern this package mirrors
+- [`../../../identity/pkg/middleware/openapi/remote`](../../../identity/pkg/middleware/openapi/remote/README.md)
+  documents the remote trust model region relies on
+- [`../../../core/pkg/server/middleware`](../../../core/pkg/server/middleware/README.md)
+  documents the canonical shared pre-routing middleware pipeline composed here


### PR DESCRIPTION
## Summary
- add package-level architecture READMEs across the region service
- add top-level pkg and command rollups, plus provider admin doc splits where needed
- update README.md and CLAUDE.md so the documentation graph is discoverable and maintained

## Notes
- docs-only change
- captures TODOs for follow-up cleanup where the code still carries transitional behaviour