### PR TITLE
docs: fix cross-repo knowledge graph links

### DIFF
--- a/cmd/unikorn-region-project-consumer/README.md
+++ b/cmd/unikorn-region-project-consumer/README.md
@@ -76,5 +76,5 @@ service and are not isolated by per-project namespaces.
 - [../../pkg/handler/README.md](../../pkg/handler/README.md) documents the
   region-side deletion and ownership semantics this command relies on after it
   deletes a root
-- [`../../../identity/pkg/handler/README.md`](../../../identity/pkg/handler/README.md)
+- [`identity/pkg/handler`](https://github.com/nscaledev/uni-identity/blob/main/pkg/handler/README.md)
   documents the identity-side project lifecycle this command listens to

--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -3,9 +3,9 @@
 ## Purpose
 
 This package is the region-specific realization of the generic client machinery
-in [`core/pkg/client`](../../../core/pkg/client/README.md), built on top of
-the outbound identity-aware transport model already established in
-[`identity/pkg/client`](../../../identity/pkg/client/README.md).
+in [`core/pkg/client`](https://github.com/nscaledev/uni-core/blob/main/pkg/client/README.md),
+built on top of the outbound identity-aware transport model already established
+in [`identity/pkg/client`](https://github.com/nscaledev/uni-identity/blob/main/pkg/client/README.md).
 
 Its main job is to construct outbound region API clients that obey the same
 internal service-to-service trust model used elsewhere in the platform.
@@ -14,9 +14,9 @@ In practice that means:
 
 - building generated [OpenAPI](../openapi/README.md) clients for the region API
 - reusing the shared TLS and HTTP client construction from
-  [`core/pkg/client`](../../../core/pkg/client/README.md)
+  [`core/pkg/client`](https://github.com/nscaledev/uni-core/blob/main/pkg/client/README.md)
 - reusing the delegated-principal and trace-propagation model from
-  [`identity/pkg/client`](../../../identity/pkg/client/README.md)
+  [`identity/pkg/client`](https://github.com/nscaledev/uni-identity/blob/main/pkg/client/README.md)
 - exposing a small region-specific helper for network reference lifecycle
 
 This is not a general client-abstraction package. Most of the interesting trust
@@ -67,7 +67,7 @@ package.
 
 It wraps the region API's network-reference endpoints so remote services can add
 or remove dependency references on a `Network` using the shared resource
-reference model from [`core/pkg/manager`](../../../core/pkg/manager/README.md).
+reference model from [`core/pkg/manager`](https://github.com/nscaledev/uni-core/blob/main/pkg/manager/README.md).
 
 That matters because deletion protection is not purely local to region-owned
 descendants. Other services may hold logical dependencies on a network, and the
@@ -85,7 +85,7 @@ normal service boundary.
 - `ControllerClient` is for controller/provisioner-style calls that must derive
   delegated principal context from durable resource metadata.
 - `References` uses the shared resource-reference model from
-  [`core/pkg/manager`](../../../core/pkg/manager/README.md) rather than inventing
+  [`core/pkg/manager`](https://github.com/nscaledev/uni-core/blob/main/pkg/manager/README.md) rather than inventing
   a region-specific dependency identity format.
 - Reference add/remove operations are thin API wrappers intended for normal
   convergent lifecycle use, with success determined by the region API response

--- a/pkg/handler/README.md
+++ b/pkg/handler/README.md
@@ -115,7 +115,7 @@ That means handler scope is reconstructed through:
 - RBAC checks against recovered organization/project bindings
 
 This is one of the biggest architectural differences from
-[`identity/pkg/handler`](../../../identity/pkg/handler/README.md).
+[`identity/pkg/handler`](https://github.com/nscaledev/uni-identity/blob/main/pkg/handler/README.md).
 
 ## Shared Lifecycle Graph
 
@@ -243,11 +243,11 @@ but we do not have transactions.”
 
 - [`../openapi`](../openapi/README.md), which documents the public contract these
   handlers implement
-- [`../../../identity/pkg/middleware/openapi`](../../../identity/pkg/middleware/openapi/README.md),
+- [`identity/pkg/middleware/openapi`](https://github.com/nscaledev/uni-identity/blob/main/pkg/middleware/openapi/README.md),
   which establishes the trusted request context handlers consume
 - [`../apis/unikorn/v1alpha1`](../apis/unikorn/v1alpha1/README.md), which defines
   the persisted storage contract the handlers read and write
 - [`../providers`](../providers/README.md), which documents the provider layer
   many handlers depend on for real cloud-side behaviour
-- [`../../../core/pkg/server/conversion`](../../../core/pkg/server/conversion/README.md),
+- [`core/pkg/server/conversion`](https://github.com/nscaledev/uni-core/blob/main/pkg/server/conversion/README.md),
   which provides shared metadata and conversion helpers used heavily here

--- a/pkg/handler/common/README.md
+++ b/pkg/handler/common/README.md
@@ -74,6 +74,6 @@ ad hoc.
   dependency bundle
 - [../../providers](../../providers/README.md) provides the provider lookup
   façade injected through `ClientArgs`
-- [`identity/pkg/handler/common`](../../../identity/pkg/handler/common/README.md)
+- [`identity/pkg/handler/common`](https://github.com/nscaledev/uni-identity/blob/main/pkg/handler/common/README.md)
   provides identity-specific handler helpers that many concrete region handlers
   also depend on alongside this package

--- a/pkg/handler/loadbalancer/README.md
+++ b/pkg/handler/loadbalancer/README.md
@@ -46,5 +46,5 @@ domain-specific resource handlers.
 ## Cross-Package Context
 
 - [../network](../network/README.md) documents the parent linkage model
-- [../../../core/pkg/server/saga](../../../core/pkg/server/saga/README.md)
+- [core/pkg/server/saga](https://github.com/nscaledev/uni-core/blob/main/pkg/server/saga/README.md)
   documents the compensating-workflow machinery used here

--- a/pkg/handler/network/README.md
+++ b/pkg/handler/network/README.md
@@ -64,5 +64,5 @@ service-principal root.
 - [../storage](../storage/README.md), [../securitygroup](../securitygroup/README.md),
   [../loadbalancer](../loadbalancer/README.md), and [../server](../server/README.md)
   all depend on `Network v2` as a parent/linkage root
-- [../../../core/pkg/server/saga](../../../core/pkg/server/saga/README.md)
+- [core/pkg/server/saga](https://github.com/nscaledev/uni-core/blob/main/pkg/server/saga/README.md)
   documents the saga machinery used heavily here

--- a/pkg/handler/storage/README.md
+++ b/pkg/handler/storage/README.md
@@ -59,7 +59,7 @@ accounting meet.
 
 - [../network](../network/README.md) documents the network dependency used for
   attachments
-- [../../../core/pkg/server/saga](../../../core/pkg/server/saga/README.md)
+- [core/pkg/server/saga](https://github.com/nscaledev/uni-core/blob/main/pkg/server/saga/README.md)
   documents the compensating-workflow machinery used heavily here
-- [`../../../identity/pkg/client`](../../../identity/pkg/client/README.md)
+- [`identity/pkg/client`](https://github.com/nscaledev/uni-identity/blob/main/pkg/client/README.md)
   documents the allocation client helpers this package coordinates with

--- a/pkg/handler/util/README.md
+++ b/pkg/handler/util/README.md
@@ -86,6 +86,6 @@ considered finished.
   helpers when implementing flat region API endpoints
 - [../../openapi](../../openapi/README.md) defines the query-parameter shapes
   these helpers normalize
-- [`identity/pkg/middleware/openapi`](../../../identity/pkg/middleware/openapi/README.md)
+- [`identity/pkg/middleware/openapi`](https://github.com/nscaledev/uni-identity/blob/main/pkg/middleware/openapi/README.md)
   defines the inbound principal derivation path that this package sometimes has
   to complete with additional org/project context

--- a/pkg/openapi/README.md
+++ b/pkg/openapi/README.md
@@ -95,7 +95,8 @@ the primary authoring surface:
 - schema changes can affect documentation, client generation, server binding,
   route resolution, and request/response validation simultaneously
 - shared platform API primitives are imported from
-  [`core/pkg/openapi`](../../core/pkg/openapi), rather than being redefined here
+  [`core/pkg/openapi`](https://github.com/nscaledev/uni-core/blob/main/pkg/openapi/README.md),
+  rather than being redefined here
 - this package carries both deprecated `v1` and preferred `v2` generations in
   one contract, so compatibility changes, migration steps, and publication
   decisions must be made deliberately

--- a/pkg/server/README.md
+++ b/pkg/server/README.md
@@ -9,7 +9,7 @@ server, OpenAPI router, middleware stack, and runtime dependency construction
 needed to serve the API.
 
 Structurally, it is very close to
-[`identity/pkg/server`](../../../identity/pkg/server/README.md). The important
+[`identity/pkg/server`](https://github.com/nscaledev/uni-identity/blob/main/pkg/server/README.md). The important
 difference is that region does not own the full authentication and authorization
 stack locally. Instead it delegates trust assembly back through identity and
 focuses on constructing:
@@ -73,7 +73,7 @@ Identity builds its own local authn/authz runtime:
 Region does not.
 
 Instead, region constructs a remote authorizer using
-[`identity/pkg/middleware/openapi/remote`](../../../identity/pkg/middleware/openapi/remote/README.md)
+[`identity/pkg/middleware/openapi/remote`](https://github.com/nscaledev/uni-identity/tree/main/pkg/middleware/openapi/remote)
 and an outbound identity API client configuration. That means:
 
 - identity remains the source of truth for trust and authorization context
@@ -160,9 +160,9 @@ provider layer before the handler is built.
   package serves
 - [../providers](../providers/README.md) documents the provider registry built
   here
-- [`../../../identity/pkg/server`](../../../identity/pkg/server/README.md)
+- [`identity/pkg/server`](https://github.com/nscaledev/uni-identity/blob/main/pkg/server/README.md)
   documents the closely related server composition pattern this package mirrors
-- [`../../../identity/pkg/middleware/openapi/remote`](../../../identity/pkg/middleware/openapi/remote/README.md)
+- [`identity/pkg/middleware/openapi/remote`](https://github.com/nscaledev/uni-identity/tree/main/pkg/middleware/openapi/remote)
   documents the remote trust model region relies on
-- [`../../../core/pkg/server/middleware`](../../../core/pkg/server/middleware/README.md)
+- [`core/pkg/server/middleware`](https://github.com/nscaledev/uni-core/blob/main/pkg/server/middleware/README.md)
   documents the canonical shared pre-routing middleware pipeline composed here


### PR DESCRIPTION
Replace repo-escaping relative markdown links in the package knowledge graph with explicit GitHub URLs for uni-core and uni-identity. This keeps the documentation graph navigable when viewed on GitHub and avoids broken links caused by paths that walk outside the region repository.
