### PR TITLE
chore: set OTEL_SERVICE_NAME on server-controller and monitor

### DIFF
--- a/charts/region/templates/monitor/deployment.yaml
+++ b/charts/region/templates/monitor/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         args:
         - --namespace={{ .Release.Namespace }}
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
+        env:
+        - name: OTEL_SERVICE_NAME
+          value: {{ .Release.Name }}-monitor
         resources:
           {{- .Values.monitor.resources | toYaml | nindent 10 }}
         securityContext:

--- a/charts/region/templates/server-controller/deployment.yaml
+++ b/charts/region/templates/server-controller/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         args:
         {{- include "unikorn.core.flags" . | nindent 8 }}
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
+        env:
+        - name: OTEL_SERVICE_NAME
+          value: {{ .Release.Name }}-server-controller
         ports:
         - name: http
           containerPort: 6080


### PR DESCRIPTION
## Summary

- Add `OTEL_SERVICE_NAME` env var to server-controller and monitor deployments

Tempo traces from uni-region services currently appear as `unknown_service:unikorn-region-*` because `OTEL_SERVICE_NAME` is not set in the deployment manifests. The Go OTel SDK reads this env var via `resource.Default()` to set `resource.service.name` on all spans.

The service names will be `{{ .Release.Name }}-server-controller` and `{{ .Release.Name }}-monitor`, where `{{ .Release.Name }}` is the Helm release name at deployment time (e.g. `unikorn-region-server-controller` and `unikorn-region-monitor` when deployed with release name `unikorn-region`).

Only `unikorn-region-controller` and `unikorn-region-monitor` are currently producing traces — the other OTLP-enabled services (`identity-controller`, `network-controller`, `load-balancer-controller`, `security-group-controller`, `server-controller`) are not generating spans at this time. `OTEL_SERVICE_NAME` will be added to those services in a follow-up PR once they produce traces.

## Test plan

- [ ] Deploy and verify traces appear with the correct service name in Tempo