### PR TITLE
ci: pin UAT nightly tests to staged constellation tag

### DIFF
--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -108,10 +108,25 @@ jobs:
         environment: dev
         title: 'Region API Test Results'
 
-  API-Tests-UAT:
-    name: API Tests (uat)
+  find-staging-constellation:
+    name: Find staging constellation
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true'
+    outputs:
+      tag: ${{ steps.find.outputs.tag }}
+    steps:
+    - uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@main
+      id: find
+      with:
+        service: uni-region
+        releases-read-token: ${{ secrets.RELEASES_READ_TOKEN }}
+
+  API-Tests-UAT:
+    name: API Tests (uat)
+    needs: find-staging-constellation
+    runs-on: ubuntu-latest
+    # Runs only when find-staging-constellation resolved a tag.
+    if: needs.find-staging-constellation.outputs.tag != ''
     env:
       ENVIRONMENT: uat
       API_BASE_URL: ${{ vars.UAT_API_BASE_URL }}
@@ -128,6 +143,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ needs.find-staging-constellation.outputs.tag }}
 
     - name: Setup Go
       uses: actions/setup-go@v3


### PR DESCRIPTION
## Summary

- UAT nightly tests previously checked out `HEAD` of `main`, meaning the test code could be ahead of what was actually deployed to staging
- Adds a `find-staging-constellation` preflight job using [`nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation`](https://github.com/nscaledev/quality-tooling/tree/main/.github/actions/uni-find-staging-constellation) that scans open PRs in `nscaledev/uni-releases` for a `status: candidate` constellation, extracts the pinned `uni-region` version, and checks out at that exact tag before running tests
- Constellation content is fetched by PR head SHA (not branch name) so it works even when the PR branch has been deleted

## Behaviour

| Scenario | Result |
|---|---|
| No open candidate constellation PR | UAT job cleanly skipped |
| Candidate found, version missing | Hard failure — no silent false pass |
| Candidate found, tag resolved | UAT tests run against the deployed version |

## Prerequisites
- [x] `RELEASES_READ_TOKEN` secret added to this repo (read access to `nscaledev/uni-releases`)

Closes INST-903