### PR TITLE
feat(monitor): add scheduling duration metric and source provision duration from Nova timestamps

### DIFF
--- a/charts/region/crds/region.unikorn-cloud.org_servers.yaml
+++ b/charts/region/crds/region.unikorn-cloud.org_servers.yaml
@@ -208,6 +208,12 @@ spec:
                   - type
                   type: object
                 type: array
+              launchedAt:
+                description: |-
+                  LaunchedAt is the time Nova booted the VM, sourced from OS-SRV-USG:launched_at.
+                  Nil until the server has been observed Running at least once.
+                format: date-time
+                type: string
               macAddress:
                 description: MACAddress is the MAC address of the server's primary
                   network interface.

--- a/charts/region/crds/region.unikorn-cloud.org_servers.yaml
+++ b/charts/region/crds/region.unikorn-cloud.org_servers.yaml
@@ -210,8 +210,8 @@ spec:
                 type: array
               launchedAt:
                 description: |-
-                  LaunchedAt is the time Nova booted the VM, sourced from OS-SRV-USG:launched_at.
-                  Nil until the server has been observed Running at least once.
+                  LaunchedAt is the time the provider booted the VM. Nil until the server has
+                  been observed Running at least once.
                 format: date-time
                 type: string
               macAddress:
@@ -231,6 +231,12 @@ spec:
                 type: string
               publicIP:
                 description: PublicIP is the public IP address of the server.
+                type: string
+              scheduledAt:
+                description: |-
+                  ScheduledAt is the time the provider accepted and processed the creation request.
+                  Nil until the server has been observed in the provider at least once.
+                format: date-time
                 type: string
             type: object
         required:

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -916,6 +916,9 @@ type ServerStatus struct {
 	PublicIP *string `json:"publicIP,omitempty"`
 	// MACAddress is the MAC address of the server's primary network interface.
 	MACAddress *string `json:"macAddress,omitempty"`
+	// LaunchedAt is the time Nova booted the VM, sourced from OS-SRV-USG:launched_at.
+	// Nil until the server has been observed Running at least once.
+	LaunchedAt *metav1.Time `json:"launchedAt,omitempty"`
 }
 
 // OpenstackServerList is a typed list of servers.

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -916,9 +916,12 @@ type ServerStatus struct {
 	PublicIP *string `json:"publicIP,omitempty"`
 	// MACAddress is the MAC address of the server's primary network interface.
 	MACAddress *string `json:"macAddress,omitempty"`
-	// LaunchedAt is the time Nova booted the VM, sourced from OS-SRV-USG:launched_at.
-	// Nil until the server has been observed Running at least once.
+	// LaunchedAt is the time the provider booted the VM. Nil until the server has
+	// been observed Running at least once.
 	LaunchedAt *metav1.Time `json:"launchedAt,omitempty"`
+	// ScheduledAt is the time the provider accepted and processed the creation request.
+	// Nil until the server has been observed in the provider at least once.
+	ScheduledAt *metav1.Time `json:"scheduledAt,omitempty"`
 }
 
 // OpenstackServerList is a typed list of servers.

--- a/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
@@ -2517,6 +2517,10 @@ func (in *ServerStatus) DeepCopyInto(out *ServerStatus) {
 		in, out := &in.LaunchedAt, &out.LaunchedAt
 		*out = (*in).DeepCopy()
 	}
+	if in.ScheduledAt != nil {
+		in, out := &in.ScheduledAt, &out.ScheduledAt
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
@@ -2513,6 +2513,10 @@ func (in *ServerStatus) DeepCopyInto(out *ServerStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.LaunchedAt != nil {
+		in, out := &in.LaunchedAt, &out.LaunchedAt
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -75,12 +75,6 @@ const (
 	// ServerLabel creates an indexable linkage between resources and an
 	// owning entity.
 	ServerLabel = "regions.unikorn-cloud.org/server-id"
-	// ServerPendingEntryTimeAnnotation records when a server entered the Pending phase.
-	// Value is an RFC 3339 UTC timestamp. The region monitor is the sole writer of this
-	// annotation: it is stamped on Pending entry and removed on Pending exit. Manual edits
-	// to the timestamp value while the server remains Pending are not corrected — the
-	// existing annotation is left intact until the server next leaves or re-enters Pending.
-	ServerPendingEntryTimeAnnotation = "regions.unikorn-cloud.org/pending-entry-time"
 )
 
 const (

--- a/pkg/monitor/health/server/README.md
+++ b/pkg/monitor/health/server/README.md
@@ -7,7 +7,8 @@ patches Kubernetes status, logs lifecycle transitions, and exports OTel metrics
 for:
 
 - current server counts by state/region/flavor
-- pending-to-running provision duration
+- provision duration (`Uni CreationTimestamp → Nova launched_at`)
+- scheduling duration (`Uni CreationTimestamp → Nova created_at`)
 
 This makes it a bridge between provider-observed reality and the platform's
 status/telemetry model.
@@ -17,16 +18,12 @@ status/telemetry model.
 - resolves provider and flavor context per region and caches it for a poll cycle
 - updates server status through provider `UpdateServerState(...)`
 - logs phase and health-condition transitions
-- stamps and clears the pending-entry-time annotation used for provision-duration
-  measurement
 - rebuilds gauge counts from the effective server set each cycle
 
 ## Invariants And Guard Rails
 
 - Fatal context cancellation/deadline errors abort the poll cycle; most
   per-server/provider failures are logged and skipped.
-- Annotation patch failures for pending-entry time are non-fatal and retried on
-  later polls.
 - Servers skipped because region/provider resolution fails are absent from the
   gauge for that cycle rather than misreported as a fake state.
 
@@ -34,5 +31,17 @@ status/telemetry model.
 
 - This package is intentionally eventual and observational; it does not make
   provider state changes happen, it notices and projects them.
-- Metric correctness depends on poll cadence and on the pending-entry annotation
-  surviving long enough to observe the transition.
+- `unikorn_region_server_provision_duration_seconds` measures
+  `CreationTimestamp → OS-SRV-USG:launched_at`. `launched_at` is when the
+  hypervisor boots the instance, not when the guest OS finishes booting. For
+  VMs this gap is negligible (<1 min); for baremetal it can be ~15 minutes.
+  Closing it requires a guest-side signal (e.g. cloud-init phone-home) and is
+  out of scope here.
+- `unikorn_region_server_scheduling_duration_seconds` measures
+  `CreationTimestamp → Nova created_at` (when Nova accepted the request).
+  Together the two histograms decompose pre-boot latency into scheduling
+  overhead and Nova allocation time.
+- Both duration metrics fire only once per server, on the first
+  Pending → Running transition where the relevant Nova timestamp is non-nil.
+  Negative durations (clock skew between the Uni controller and Nova) are
+  logged and skipped rather than recorded.

--- a/pkg/monitor/health/server/check.go
+++ b/pkg/monitor/health/server/check.go
@@ -34,6 +34,8 @@ import (
 	"github.com/unikorn-cloud/region/pkg/providers"
 	providertypes "github.com/unikorn-cloud/region/pkg/providers/types"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -70,8 +72,30 @@ func serverLogger(ctx context.Context, s *unikornv1.Server) logr.Logger {
 	)
 }
 
-// onPhaseTransition logs the phase change and records a provisioning histogram
-// observation on Pending → Running.
+// recordDurationIfFirstObservation records a histogram observation for a duration
+// measured from creationTime to timestamp. It only fires when the timestamp is
+// newly populated (was nil before, non-nil now), ensuring each server produces at
+// most one observation across stop/restart cycles.
+func (c *Checker) recordDurationIfFirstObservation(ctx context.Context, server *unikornv1.Server, logKey string, previous, current *metav1.Time, record func(time.Duration)) {
+	if previous != nil || current == nil {
+		return
+	}
+
+	duration := current.Sub(server.CreationTimestamp.Time)
+	if duration < 0 {
+		serverLogger(ctx, server).Info("skipping duration metric: negative duration (clock skew?)",
+			logKey, current.Time,
+			"created_at", server.CreationTimestamp.Time,
+		)
+
+		return
+	}
+
+	record(duration)
+}
+
+// onPhaseTransition logs the phase change and records provisioning histogram
+// observations on the first Pending → Running transition.
 // Precondition: region label validated by Check; identity label validated by checkServer.
 func (c *Checker) onPhaseTransition(ctx context.Context, server, updated *unikornv1.Server, regionID, regionName, flavorID, flavorName string) {
 	if server.Status.Phase == updated.Status.Phase {
@@ -91,21 +115,11 @@ func (c *Checker) onPhaseTransition(ctx context.Context, server, updated *unikor
 		return
 	}
 
-	if updated.Status.LaunchedAt == nil {
-		return
-	}
+	c.recordDurationIfFirstObservation(ctx, server, "launched_at", server.Status.LaunchedAt, updated.Status.LaunchedAt,
+		func(d time.Duration) { c.metrics.RecordProvision(ctx, d, regionID, regionName, flavorID, flavorName) })
 
-	duration := updated.Status.LaunchedAt.Sub(server.CreationTimestamp.Time)
-	if duration < 0 {
-		serverLogger(ctx, server).Info("skipping provision duration: negative duration (clock skew?)",
-			"launched_at", updated.Status.LaunchedAt.Time,
-			"created_at", server.CreationTimestamp.Time,
-		)
-
-		return
-	}
-
-	c.metrics.RecordProvision(ctx, duration, regionID, regionName, flavorID, flavorName)
+	c.recordDurationIfFirstObservation(ctx, server, "scheduled_at", server.Status.ScheduledAt, updated.Status.ScheduledAt,
+		func(d time.Duration) { c.metrics.RecordScheduling(ctx, d, regionID, regionName, flavorID, flavorName) })
 }
 
 // logStateTransition emits a structured log entry when the server's ConditionHealthy

--- a/pkg/monitor/health/server/check.go
+++ b/pkg/monitor/health/server/check.go
@@ -34,8 +34,6 @@ import (
 	"github.com/unikorn-cloud/region/pkg/providers"
 	providertypes "github.com/unikorn-cloud/region/pkg/providers/types"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -93,19 +91,21 @@ func (c *Checker) onPhaseTransition(ctx context.Context, server, updated *unikor
 		return
 	}
 
-	// Read from server (pre-patch state): the annotation was stamped in a prior poll cycle.
-	entryTimeStr, ok := server.GetAnnotations()[constants.ServerPendingEntryTimeAnnotation]
-	if !ok {
+	if updated.Status.LaunchedAt == nil {
 		return
 	}
 
-	t, err := time.Parse(time.RFC3339, entryTimeStr)
-	if err != nil {
-		log.FromContext(ctx).Error(err, "skipping provision duration: invalid pending-entry-time annotation")
+	duration := updated.Status.LaunchedAt.Sub(server.CreationTimestamp.Time)
+	if duration < 0 {
+		serverLogger(ctx, server).Info("skipping provision duration: negative duration (clock skew?)",
+			"launched_at", updated.Status.LaunchedAt.Time,
+			"created_at", server.CreationTimestamp.Time,
+		)
+
 		return
 	}
 
-	c.metrics.RecordProvision(ctx, time.Since(t), regionID, regionName, flavorID, flavorName)
+	c.metrics.RecordProvision(ctx, duration, regionID, regionName, flavorID, flavorName)
 }
 
 // logStateTransition emits a structured log entry when the server's ConditionHealthy
@@ -139,39 +139,6 @@ func (c *Checker) logStateTransition(ctx context.Context, server, updated *uniko
 		"to_state", string(newCondition.Reason),
 		"duration_ms", newCondition.LastTransitionTime.Sub(durationSource).Milliseconds(),
 	)
-}
-
-// managePendingAnnotation stamps the phase-entry time annotation when a server enters
-// the Pending phase, and removes it when the server leaves Pending. Removing on exit
-// bounds measurement error to at most one poll period across stop/start cycles and
-// partial patch failures.
-//
-// Note: a stop/start cycle that completes entirely between two polls is not detected —
-// the stale timestamp persists until Running is observed. Acceptable given histogram
-// granularity.
-func (c *Checker) managePendingAnnotation(ctx context.Context, updated *unikornv1.Server) error {
-	_, hasAnnot := updated.GetAnnotations()[constants.ServerPendingEntryTimeAnnotation]
-
-	if updated.Status.Phase != unikornv1.InstanceLifecyclePhasePending {
-		if !hasAnnot {
-			return nil
-		}
-
-		patch := updated.DeepCopy()
-		delete(patch.Annotations, constants.ServerPendingEntryTimeAnnotation)
-
-		return c.client.Patch(ctx, patch, client.MergeFromWithOptions(updated, &client.MergeFromWithOptimisticLock{}))
-	}
-
-	if hasAnnot {
-		return nil
-	}
-
-	// Server just entered Pending: stamp the current time.
-	patch := updated.DeepCopy()
-	metav1.SetMetaDataAnnotation(&patch.ObjectMeta, constants.ServerPendingEntryTimeAnnotation, time.Now().UTC().Format(time.RFC3339))
-
-	return c.client.Patch(ctx, patch, client.MergeFromWithOptions(updated, &client.MergeFromWithOptimisticLock{}))
 }
 
 // resolveRegionName returns the display name for a region from the provider,
@@ -234,15 +201,6 @@ func (c *Checker) checkServer(ctx context.Context, server *unikornv1.Server, pro
 
 	c.onPhaseTransition(ctx, server, updated, regionID, regionName, flavorID, flavorName)
 	c.logStateTransition(ctx, server, updated)
-
-	// managePendingAnnotation must run after Status().Patch: controller-runtime rewrites
-	// updated (including ResourceVersion) from the server response, so the optimistic-lock
-	// base for the annotation patch is always fresh. Reordering this call is a bug.
-	if err := c.managePendingAnnotation(ctx, updated); err != nil {
-		// Annotation patch failures are non-fatal: the next poll will re-attempt.
-		// Aborting the loop here would block all subsequent servers for a transient error.
-		serverLogger(ctx, server).Error(err, "failed to patch pending-entry annotation")
-	}
 
 	return &checkedServer{server: updated, regionID: regionID, regionName: regionName, flavorID: flavorID, flavorName: flavorName}, nil
 }

--- a/pkg/monitor/health/server/check_test.go
+++ b/pkg/monitor/health/server/check_test.go
@@ -221,14 +221,6 @@ func runCheck(t *testing.T, srv *unikornv1.Server, updateFn func(*unikornv1.Serv
 	return sink, err
 }
 
-func runCheckWithClient(t *testing.T, srv *unikornv1.Server, updateFn func(*unikornv1.Server)) (client.Client, error) {
-	t.Helper()
-
-	k8sClient, _, err := runCheckFull(t, srv, updateFn)
-
-	return k8sClient, err
-}
-
 // TestCheckServerLogsOnPhaseChange verifies that a phase transition log is emitted when
 // the server's lifecycle phase changes, and that it contains the required fields.
 func TestCheckServerLogsOnPhaseChange(t *testing.T) {
@@ -370,114 +362,11 @@ func TestCheckServerLogsBothOnCombinedChange(t *testing.T) {
 	require.Len(t, sink.entriesWithMsg("instance state transition"), 1)
 }
 
-// TestStampPendingAnnotationFreshEntry verifies that the phase-entry time annotation is
-// written when a server transitions into Pending for the first time.
-func TestStampPendingAnnotationFreshEntry(t *testing.T) {
-	t.Parallel()
-
-	srv := serverFixture(unikornv1.InstanceLifecyclePhaseRunning)
-
-	before := time.Now().Truncate(time.Second)
-
-	k8sClient, err := runCheckWithClient(t, srv, func(s *unikornv1.Server) {
-		s.Status.Phase = unikornv1.InstanceLifecyclePhasePending
-	})
-
-	require.NoError(t, err)
-
-	result := &unikornv1.Server{}
-	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKey{Namespace: namespace, Name: serverID}, result))
-
-	entryTimeStr, ok := result.Annotations[constants.ServerPendingEntryTimeAnnotation]
-	require.True(t, ok, "phase-entry-time annotation should be present")
-
-	entryTime, err := time.Parse(time.RFC3339, entryTimeStr)
-	require.NoError(t, err)
-	require.False(t, entryTime.Before(before), "annotation timestamp should not predate the check")
-}
-
-// TestStampPendingAnnotationNoOverwrite verifies that the annotation is not overwritten
-// when the server remains in Pending and the annotation already exists.
-func TestStampPendingAnnotationNoOverwrite(t *testing.T) {
-	t.Parallel()
-
-	original := time.Now().Add(-5 * time.Minute).Truncate(time.Second)
-
-	srv := serverFixture(unikornv1.InstanceLifecyclePhasePending)
-	srv.Annotations = map[string]string{
-		constants.ServerPendingEntryTimeAnnotation: original.UTC().Format(time.RFC3339),
-	}
-
-	k8sClient, err := runCheckWithClient(t, srv, func(s *unikornv1.Server) {
-		s.Status.Phase = unikornv1.InstanceLifecyclePhasePending
-	})
-
-	require.NoError(t, err)
-
-	result := &unikornv1.Server{}
-	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKey{Namespace: namespace, Name: serverID}, result))
-
-	require.Equal(t, original.UTC().Format(time.RFC3339), result.Annotations[constants.ServerPendingEntryTimeAnnotation],
-		"annotation should not be overwritten while server remains in Pending")
-}
-
-// TestAnnotationRemovedOnLeavingPending verifies that the phase-entry time annotation is
-// deleted when a server leaves the Pending phase, preventing stale timestamps from being
-// used if the server re-enters Pending between polls.
-func TestAnnotationRemovedOnLeavingPending(t *testing.T) {
-	t.Parallel()
-
-	srv := serverFixture(unikornv1.InstanceLifecyclePhasePending)
-	srv.Annotations = map[string]string{
-		constants.ServerPendingEntryTimeAnnotation: time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339),
-	}
-
-	k8sClient, err := runCheckWithClient(t, srv, func(s *unikornv1.Server) {
-		s.Status.Phase = unikornv1.InstanceLifecyclePhaseRunning
-	})
-
-	require.NoError(t, err)
-
-	result := &unikornv1.Server{}
-	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKey{Namespace: namespace, Name: serverID}, result))
-
-	_, ok := result.Annotations[constants.ServerPendingEntryTimeAnnotation]
-	require.False(t, ok, "phase-entry-time annotation should be removed when server leaves Pending")
-}
-
-// TestStampPendingAnnotationRewriteOnReentry verifies that the annotation is stamped with
-// the current time when a server re-enters Pending (e.g. after a stop/start cycle).
-// Because the annotation is cleaned up on exit, re-entry always gets a fresh timestamp.
-func TestStampPendingAnnotationRewriteOnReentry(t *testing.T) {
-	t.Parallel()
-
-	// Server is currently Running in k8s with no annotation (cleaned up when it left Pending).
-	srv := serverFixture(unikornv1.InstanceLifecyclePhaseRunning)
-
-	before := time.Now().Truncate(time.Second)
-
-	k8sClient, err := runCheckWithClient(t, srv, func(s *unikornv1.Server) {
-		s.Status.Phase = unikornv1.InstanceLifecyclePhasePending
-	})
-
-	require.NoError(t, err)
-
-	result := &unikornv1.Server{}
-	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKey{Namespace: namespace, Name: serverID}, result))
-
-	entryTimeStr, ok := result.Annotations[constants.ServerPendingEntryTimeAnnotation]
-	require.True(t, ok, "phase-entry-time annotation should be present on re-entry into Pending")
-
-	entryTime, err := time.Parse(time.RFC3339, entryTimeStr)
-	require.NoError(t, err)
-	require.False(t, entryTime.Before(before), "annotation should be stamped with current time")
-}
-
-// TestCheckServerNoHistogramWhenAnnotationMissing verifies that no histogram observation
-// is recorded when a server transitions Pending → Running without a pending-entry-time
-// annotation. This can happen if the server was already Pending when the monitor was
-// first deployed, or if a previous annotation patch failed.
-func TestCheckServerNoHistogramWhenAnnotationMissing(t *testing.T) {
+// TestCheckServerNoHistogramWhenLaunchedAtNil verifies that no histogram observation is
+// recorded when a server transitions Pending → Running but LaunchedAt is not set. This
+// can happen for servers that booted before this field was introduced, or on providers
+// that do not populate OS-SRV-USG:launched_at.
+func TestCheckServerNoHistogramWhenLaunchedAtNil(t *testing.T) {
 	t.Parallel()
 
 	meter, reader := newTestMeter(t)
@@ -485,7 +374,7 @@ func TestCheckServerNoHistogramWhenAnnotationMissing(t *testing.T) {
 	m, err := healthserver.NewMetrics(meter)
 	require.NoError(t, err)
 
-	srv := serverFixture(unikornv1.InstanceLifecyclePhasePending) // no annotation
+	srv := serverFixture(unikornv1.InstanceLifecyclePhasePending)
 
 	ctrl := gomock.NewController(t)
 
@@ -494,6 +383,7 @@ func TestCheckServerNoHistogramWhenAnnotationMissing(t *testing.T) {
 		UpdateServerState(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ *unikornv1.Identity, s *unikornv1.Server) error {
 			s.Status.Phase = unikornv1.InstanceLifecyclePhaseRunning
+			// LaunchedAt intentionally not set
 			return nil
 		})
 	mockProvider.EXPECT().
@@ -516,9 +406,9 @@ func TestCheckServerNoHistogramWhenAnnotationMissing(t *testing.T) {
 	require.Empty(t, points)
 }
 
-// TestCheckServerRecordsProvisionDurationOnPendingToRunning verifies that a server with a
-// pre-stamped pending-entry annotation that transitions Pending → Running results in a
-// histogram observation with the correct duration and region attribute.
+// TestCheckServerRecordsProvisionDurationOnPendingToRunning verifies that a Pending →
+// Running transition with LaunchedAt set produces a histogram observation whose duration
+// equals LaunchedAt − CreationTimestamp.
 func TestCheckServerRecordsProvisionDurationOnPendingToRunning(t *testing.T) {
 	t.Parallel()
 
@@ -527,12 +417,11 @@ func TestCheckServerRecordsProvisionDurationOnPendingToRunning(t *testing.T) {
 	m, err := healthserver.NewMetrics(meter)
 	require.NoError(t, err)
 
-	entryTime := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+	createdAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+	launchedAt := createdAt.Add(2 * time.Minute)
 
 	srv := serverFixture(unikornv1.InstanceLifecyclePhasePending)
-	srv.Annotations = map[string]string{
-		constants.ServerPendingEntryTimeAnnotation: entryTime.UTC().Format(time.RFC3339),
-	}
+	srv.CreationTimestamp = metav1.NewTime(createdAt)
 
 	ctrl := gomock.NewController(t)
 
@@ -541,6 +430,9 @@ func TestCheckServerRecordsProvisionDurationOnPendingToRunning(t *testing.T) {
 		UpdateServerState(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ *unikornv1.Identity, s *unikornv1.Server) error {
 			s.Status.Phase = unikornv1.InstanceLifecyclePhaseRunning
+			t := metav1.NewTime(launchedAt)
+			s.Status.LaunchedAt = &t
+
 			return nil
 		})
 	mockProvider.EXPECT().
@@ -570,8 +462,8 @@ func TestCheckServerRecordsProvisionDurationOnPendingToRunning(t *testing.T) {
 }
 
 // runFallbackCheck builds a Checker with the given provider mocks and runs Check
-// against a Pending server that has a pending-entry-time annotation, transitioning
-// to Running. Asserts the histogram recorded exactly one point and returns its
+// against a Pending server that transitions to Running with LaunchedAt set.
+// Asserts the histogram recorded exactly one point and returns its
 // region_id, region_name, flavor_id, flavor_name attribute values.
 func runFallbackCheck(t *testing.T, setupRegion, setupFlavor func(*mocktypes.MockProvider)) (string, string, string, string) {
 	t.Helper()
@@ -581,12 +473,11 @@ func runFallbackCheck(t *testing.T, setupRegion, setupFlavor func(*mocktypes.Moc
 	m, err := healthserver.NewMetrics(meter)
 	require.NoError(t, err)
 
-	entryTime := time.Now().Add(-time.Minute).Truncate(time.Second)
+	createdAt := time.Now().Add(-time.Minute).Truncate(time.Second)
+	launchedAt := createdAt.Add(time.Minute)
 
 	srv := serverFixture(unikornv1.InstanceLifecyclePhasePending)
-	srv.Annotations = map[string]string{
-		constants.ServerPendingEntryTimeAnnotation: entryTime.UTC().Format(time.RFC3339),
-	}
+	srv.CreationTimestamp = metav1.NewTime(createdAt)
 
 	ctrl := gomock.NewController(t)
 
@@ -595,6 +486,9 @@ func runFallbackCheck(t *testing.T, setupRegion, setupFlavor func(*mocktypes.Moc
 		UpdateServerState(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ *unikornv1.Identity, s *unikornv1.Server) error {
 			s.Status.Phase = unikornv1.InstanceLifecyclePhaseRunning
+			t := metav1.NewTime(launchedAt)
+			s.Status.LaunchedAt = &t
+
 			return nil
 		})
 	setupRegion(mockProvider)

--- a/pkg/monitor/health/server/check_test.go
+++ b/pkg/monitor/health/server/check_test.go
@@ -362,11 +362,60 @@ func TestCheckServerLogsBothOnCombinedChange(t *testing.T) {
 	require.Len(t, sink.entriesWithMsg("instance state transition"), 1)
 }
 
-// TestCheckServerNoHistogramWhenLaunchedAtNil verifies that no histogram observation is
-// recorded when a server transitions Pending → Running but LaunchedAt is not set. This
-// can happen for servers that booted before this field was introduced, or on providers
-// that do not populate OS-SRV-USG:launched_at.
-func TestCheckServerNoHistogramWhenLaunchedAtNil(t *testing.T) {
+// TestCheckServerNoHistogramOnClockSkew verifies that no histogram observation is recorded
+// when a timestamp precedes CreationTimestamp (clock skew between Uni and Nova).
+func TestCheckServerNoHistogramOnClockSkew(t *testing.T) {
+	t.Parallel()
+
+	meter, reader := newTestMeter(t)
+
+	m, err := healthserver.NewMetrics(meter)
+	require.NoError(t, err)
+
+	createdAt := time.Now().Truncate(time.Second)
+	// launchedAt is before createdAt — simulates clock skew.
+	launchedAt := metav1.NewTime(createdAt.Add(-30 * time.Second))
+
+	srv := serverFixture(unikornv1.InstanceLifecyclePhasePending)
+	srv.CreationTimestamp = metav1.NewTime(createdAt)
+
+	ctrl := gomock.NewController(t)
+
+	mockProvider := mocktypes.NewMockProvider(ctrl)
+	mockProvider.EXPECT().
+		UpdateServerState(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *unikornv1.Identity, s *unikornv1.Server) error {
+			s.Status.Phase = unikornv1.InstanceLifecyclePhaseRunning
+			s.Status.LaunchedAt = &launchedAt
+
+			return nil
+		})
+	mockProvider.EXPECT().
+		Region(gomock.Any()).
+		Return(regionFixture(), nil).
+		AnyTimes()
+	mockProvider.EXPECT().
+		Flavors(gomock.Any()).
+		Return(providerTypes.FlavorList{{ID: flavorID, Name: flavorName}}, nil).
+		AnyTimes()
+
+	mockProviders := mockproviders.NewMockProviders(ctrl)
+	mockProviders.EXPECT().LookupCloud(regionID).Return(mockProvider, nil).AnyTimes()
+
+	sink := newCaptureSink()
+	ctx := logr.NewContext(t.Context(), logr.New(sink))
+	checker := healthserver.New(newFakeClient(t, identityFixture(), srv), namespace, mockProviders, m)
+	require.NoError(t, checker.Check(ctx))
+
+	require.Empty(t, collectHistogram(t, reader))
+	require.NotEmpty(t, sink.entriesWithMsg("skipping duration metric: negative duration (clock skew?)"))
+}
+
+// TestCheckServerNoHistogramWhenTimestampsNil verifies that no histogram observations are
+// recorded when a server transitions Pending → Running but neither LaunchedAt nor
+// ScheduledAt is set. This can happen for servers that booted before these fields were
+// introduced, or on providers that do not populate the relevant Nova fields.
+func TestCheckServerNoHistogramWhenTimestampsNil(t *testing.T) {
 	t.Parallel()
 
 	meter, reader := newTestMeter(t)
@@ -383,7 +432,7 @@ func TestCheckServerNoHistogramWhenLaunchedAtNil(t *testing.T) {
 		UpdateServerState(gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ *unikornv1.Identity, s *unikornv1.Server) error {
 			s.Status.Phase = unikornv1.InstanceLifecyclePhaseRunning
-			// LaunchedAt intentionally not set
+			// LaunchedAt and ScheduledAt intentionally not set
 			return nil
 		})
 	mockProvider.EXPECT().
@@ -402,8 +451,8 @@ func TestCheckServerNoHistogramWhenLaunchedAtNil(t *testing.T) {
 	checker := healthserver.New(newFakeClient(t, identityFixture(), srv), namespace, mockProviders, m)
 	require.NoError(t, checker.Check(ctx))
 
-	points := collectHistogram(t, reader)
-	require.Empty(t, points)
+	require.Empty(t, collectHistogram(t, reader))
+	require.Empty(t, collectSchedulingHistogram(t, reader))
 }
 
 // TestCheckServerRecordsProvisionDurationOnPendingToRunning verifies that a Pending →
@@ -454,11 +503,120 @@ func TestCheckServerRecordsProvisionDurationOnPendingToRunning(t *testing.T) {
 	points := collectHistogram(t, reader)
 	require.Len(t, points, 1)
 	assert.Equal(t, uint64(1), points[0].Count)
-	assert.GreaterOrEqual(t, points[0].Sum, (2 * time.Minute).Seconds())
+	assert.InDelta(t, (2 * time.Minute).Seconds(), points[0].Sum, 0.001)
 	assert.Equal(t, regionID, attrValue(points[0].Attributes, "region_id"))
 	assert.Equal(t, regionName, attrValue(points[0].Attributes, "region_name"))
 	assert.Equal(t, flavorID, attrValue(points[0].Attributes, "flavor_id"))
 	assert.Equal(t, flavorName, attrValue(points[0].Attributes, "flavor_name"))
+}
+
+// TestCheckServerRecordsSchedulingDurationOnPendingToRunning verifies that a Pending →
+// Running transition with ScheduledAt set produces a scheduling histogram observation
+// whose duration equals ScheduledAt − CreationTimestamp.
+func TestCheckServerRecordsSchedulingDurationOnPendingToRunning(t *testing.T) {
+	t.Parallel()
+
+	meter, reader := newTestMeter(t)
+
+	m, err := healthserver.NewMetrics(meter)
+	require.NoError(t, err)
+
+	createdAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+	scheduledAt := createdAt.Add(10 * time.Second)
+
+	srv := serverFixture(unikornv1.InstanceLifecyclePhasePending)
+	srv.CreationTimestamp = metav1.NewTime(createdAt)
+
+	ctrl := gomock.NewController(t)
+
+	mockProvider := mocktypes.NewMockProvider(ctrl)
+	mockProvider.EXPECT().
+		UpdateServerState(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *unikornv1.Identity, s *unikornv1.Server) error {
+			s.Status.Phase = unikornv1.InstanceLifecyclePhaseRunning
+			t := metav1.NewTime(scheduledAt)
+			s.Status.ScheduledAt = &t
+
+			return nil
+		})
+	mockProvider.EXPECT().
+		Region(gomock.Any()).
+		Return(regionFixture(), nil).
+		AnyTimes()
+	mockProvider.EXPECT().
+		Flavors(gomock.Any()).
+		Return(providerTypes.FlavorList{{ID: flavorID, Name: flavorName}}, nil).
+		AnyTimes()
+
+	mockProviders := mockproviders.NewMockProviders(ctrl)
+	mockProviders.EXPECT().LookupCloud(regionID).Return(mockProvider, nil).AnyTimes()
+
+	ctx := logr.NewContext(t.Context(), logr.Discard())
+	checker := healthserver.New(newFakeClient(t, identityFixture(), srv), namespace, mockProviders, m)
+	require.NoError(t, checker.Check(ctx))
+
+	points := collectSchedulingHistogram(t, reader)
+	require.Len(t, points, 1)
+	assert.Equal(t, uint64(1), points[0].Count)
+	assert.InDelta(t, (10 * time.Second).Seconds(), points[0].Sum, 0.001)
+	assert.Equal(t, regionID, attrValue(points[0].Attributes, "region_id"))
+	assert.Equal(t, regionName, attrValue(points[0].Attributes, "region_name"))
+	assert.Equal(t, flavorID, attrValue(points[0].Attributes, "flavor_id"))
+	assert.Equal(t, flavorName, attrValue(points[0].Attributes, "flavor_name"))
+
+	// Provision histogram must be empty: LaunchedAt was not set.
+	require.Empty(t, collectHistogram(t, reader))
+}
+
+// TestCheckServerNoHistogramOnRestartAfterFirstBoot verifies that neither histogram
+// fires on a second Pending → Running transition when LaunchedAt and ScheduledAt are
+// already set from the first boot.
+func TestCheckServerNoHistogramOnRestartAfterFirstBoot(t *testing.T) {
+	t.Parallel()
+
+	meter, reader := newTestMeter(t)
+
+	m, err := healthserver.NewMetrics(meter)
+	require.NoError(t, err)
+
+	launchedAt := metav1.NewTime(time.Now().Add(-time.Minute))
+	scheduledAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+
+	// Server already has both timestamps from its first boot.
+	srv := serverFixture(unikornv1.InstanceLifecyclePhasePending)
+	srv.Status.LaunchedAt = &launchedAt
+	srv.Status.ScheduledAt = &scheduledAt
+
+	ctrl := gomock.NewController(t)
+
+	mockProvider := mocktypes.NewMockProvider(ctrl)
+	mockProvider.EXPECT().
+		UpdateServerState(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *unikornv1.Identity, s *unikornv1.Server) error {
+			s.Status.Phase = unikornv1.InstanceLifecyclePhaseRunning
+			s.Status.LaunchedAt = &launchedAt
+			s.Status.ScheduledAt = &scheduledAt
+
+			return nil
+		})
+	mockProvider.EXPECT().
+		Region(gomock.Any()).
+		Return(regionFixture(), nil).
+		AnyTimes()
+	mockProvider.EXPECT().
+		Flavors(gomock.Any()).
+		Return(providerTypes.FlavorList{{ID: flavorID, Name: flavorName}}, nil).
+		AnyTimes()
+
+	mockProviders := mockproviders.NewMockProviders(ctrl)
+	mockProviders.EXPECT().LookupCloud(regionID).Return(mockProvider, nil).AnyTimes()
+
+	ctx := logr.NewContext(t.Context(), logr.Discard())
+	checker := healthserver.New(newFakeClient(t, identityFixture(), srv), namespace, mockProviders, m)
+	require.NoError(t, checker.Check(ctx))
+
+	require.Empty(t, collectHistogram(t, reader))
+	require.Empty(t, collectSchedulingHistogram(t, reader))
 }
 
 // runFallbackCheck builds a Checker with the given provider mocks and runs Check

--- a/pkg/monitor/health/server/metrics.go
+++ b/pkg/monitor/health/server/metrics.go
@@ -47,8 +47,9 @@ type Metrics struct {
 	mu          sync.RWMutex
 	stateCounts map[StateMetricsKey]int64
 
-	stateGauge    metric.Int64ObservableGauge
-	provisionHist metric.Float64Histogram
+	stateGauge     metric.Int64ObservableGauge
+	provisionHist  metric.Float64Histogram
+	schedulingHist metric.Float64Histogram
 }
 
 // NewMetrics creates and registers OTel instruments on the given meter.
@@ -63,17 +64,27 @@ func NewMetrics(meter metric.Meter) (*Metrics, error) {
 
 	provisionHist, err := meter.Float64Histogram(
 		"unikorn_region_server_provision_duration_seconds",
-		metric.WithDescription("Duration of the Pending phase, observed on Pending to Running transition."),
+		metric.WithDescription("Duration from Uni Server CR creation to Nova booting the VM (OS-SRV-USG:launched_at), observed on first Pending to Running transition. For VMs this is close to guest-ready time (<1 min gap); for baremetal the guest OS may need ~15 more minutes to boot."),
 		metric.WithExplicitBucketBoundaries(5, 15, 30, 60, 120, 300, 600, 900, 1800, 3600),
 	)
 	if err != nil {
 		return nil, err
 	}
 
+	schedulingHist, err := meter.Float64Histogram(
+		"unikorn_region_server_scheduling_duration_seconds",
+		metric.WithDescription("Duration from Uni Server CR creation to Nova creating the server (created timestamp), observed on first Pending to Running transition."),
+		metric.WithExplicitBucketBoundaries(1, 5, 10, 30, 60, 120, 300),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	m := &Metrics{
-		stateCounts:   make(map[StateMetricsKey]int64),
-		stateGauge:    stateGauge,
-		provisionHist: provisionHist,
+		stateCounts:    make(map[StateMetricsKey]int64),
+		stateGauge:     stateGauge,
+		provisionHist:  provisionHist,
+		schedulingHist: schedulingHist,
 	}
 
 	if _, err := meter.RegisterCallback(m.collectStateCounts, m.stateGauge); err != nil {
@@ -118,6 +129,19 @@ func (m *Metrics) SetStateCounts(counts map[StateMetricsKey]int64) {
 // RecordProvision observes a Pending → Running provisioning duration.
 func (m *Metrics) RecordProvision(ctx context.Context, d time.Duration, regionID, regionName, flavorID, flavorName string) {
 	m.provisionHist.Record(ctx, d.Seconds(),
+		metric.WithAttributes(
+			attribute.String(attrRegionID, regionID),
+			attribute.String(attrRegionName, regionName),
+			attribute.String(attrFlavorID, flavorID),
+			attribute.String(attrFlavorName, flavorName),
+		),
+	)
+}
+
+// RecordScheduling observes the duration from Uni Server CR creation to Nova accepting
+// the request, measured on the Pending → Running transition.
+func (m *Metrics) RecordScheduling(ctx context.Context, d time.Duration, regionID, regionName, flavorID, flavorName string) {
+	m.schedulingHist.Record(ctx, d.Seconds(),
 		metric.WithAttributes(
 			attribute.String(attrRegionID, regionID),
 			attribute.String(attrRegionName, regionName),

--- a/pkg/monitor/health/server/metrics_test.go
+++ b/pkg/monitor/health/server/metrics_test.go
@@ -76,11 +76,9 @@ func collectGauge(t *testing.T, reader *sdkmetric.ManualReader) []metricdata.Dat
 	return nil
 }
 
-// collectHistogram returns all data points for unikorn_region_server_provision_duration_seconds.
-func collectHistogram(t *testing.T, reader *sdkmetric.ManualReader) []metricdata.HistogramDataPoint[float64] {
+// collectNamedHistogram returns all data points for the named histogram metric.
+func collectNamedHistogram(t *testing.T, reader *sdkmetric.ManualReader, name string) []metricdata.HistogramDataPoint[float64] {
 	t.Helper()
-
-	const name = "unikorn_region_server_provision_duration_seconds"
 
 	var rm metricdata.ResourceMetrics
 
@@ -98,6 +96,20 @@ func collectHistogram(t *testing.T, reader *sdkmetric.ManualReader) []metricdata
 	}
 
 	return nil
+}
+
+// collectHistogram returns all data points for unikorn_region_server_provision_duration_seconds.
+func collectHistogram(t *testing.T, reader *sdkmetric.ManualReader) []metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+
+	return collectNamedHistogram(t, reader, "unikorn_region_server_provision_duration_seconds")
+}
+
+// collectSchedulingHistogram returns all data points for unikorn_region_server_scheduling_duration_seconds.
+func collectSchedulingHistogram(t *testing.T, reader *sdkmetric.ManualReader) []metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+
+	return collectNamedHistogram(t, reader, "unikorn_region_server_scheduling_duration_seconds")
 }
 
 func TestSetStateCountsReplacesMap(t *testing.T) {
@@ -154,23 +166,55 @@ func TestCollectStateCountsEmitsCorrectObservations(t *testing.T) {
 	assert.Equal(t, int64(2), counts["stopped"])
 }
 
-func TestRecordProvisionRecordsWithCorrectAttributes(t *testing.T) {
+func TestRecordDurationMetricsRecordWithCorrectAttributes(t *testing.T) {
 	t.Parallel()
 
-	meter, reader := newTestMeter(t)
+	cases := []struct {
+		name     string
+		duration time.Duration
+		record   func(*testing.T, *healthserver.Metrics, time.Duration)
+		collect  func(*testing.T, *sdkmetric.ManualReader) []metricdata.HistogramDataPoint[float64]
+	}{
+		{
+			name:     "provision",
+			duration: 90 * time.Second,
+			record: func(t *testing.T, m *healthserver.Metrics, d time.Duration) {
+				t.Helper()
+				m.RecordProvision(t.Context(), d, "region-1", "Test Region", "flavor-1", "m1.small")
+			},
+			collect: collectHistogram,
+		},
+		{
+			name:     "scheduling",
+			duration: 15 * time.Second,
+			record: func(t *testing.T, m *healthserver.Metrics, d time.Duration) {
+				t.Helper()
+				m.RecordScheduling(t.Context(), d, "region-1", "Test Region", "flavor-1", "m1.small")
+			},
+			collect: collectSchedulingHistogram,
+		},
+	}
 
-	m, err := healthserver.NewMetrics(meter)
-	require.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	m.RecordProvision(t.Context(), 90*time.Second, "region-1", "Test Region", "flavor-1", "m1.small")
+			meter, reader := newTestMeter(t)
 
-	points := collectHistogram(t, reader)
-	require.Len(t, points, 1)
+			m, err := healthserver.NewMetrics(meter)
+			require.NoError(t, err)
 
-	assert.Equal(t, uint64(1), points[0].Count)
-	assert.InDelta(t, 90.0, points[0].Sum, 0.001)
-	assert.Equal(t, "region-1", attrValue(points[0].Attributes, "region_id"))
-	assert.Equal(t, "Test Region", attrValue(points[0].Attributes, "region_name"))
-	assert.Equal(t, "flavor-1", attrValue(points[0].Attributes, "flavor_id"))
-	assert.Equal(t, "m1.small", attrValue(points[0].Attributes, "flavor_name"))
+			tc.record(t, m, tc.duration)
+
+			points := tc.collect(t, reader)
+			require.Len(t, points, 1)
+
+			assert.Equal(t, uint64(1), points[0].Count)
+			assert.InDelta(t, tc.duration.Seconds(), points[0].Sum, 0.001)
+			assert.Equal(t, "region-1", attrValue(points[0].Attributes, "region_id"))
+			assert.Equal(t, "Test Region", attrValue(points[0].Attributes, "region_name"))
+			assert.Equal(t, "flavor-1", attrValue(points[0].Attributes, "flavor_id"))
+			assert.Equal(t, "m1.small", attrValue(points[0].Attributes, "flavor_name"))
+		})
+	}
 }

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -2058,16 +2058,24 @@ func setServerPhase(ctx context.Context, server *unikornv1.Server, openstackserv
 		return
 	}
 
+	// Both timestamps are set unconditionally (not gated on power state): Nova
+	// populates created and launched_at on every server response once set, and
+	// neither value changes after the server's first boot.
+	if !openstackserver.Created.IsZero() {
+		t := metav1.NewTime(openstackserver.Created)
+		server.Status.ScheduledAt = &t
+	}
+
+	if !openstackserver.LaunchedAt.IsZero() {
+		t := metav1.NewTime(openstackserver.LaunchedAt)
+		server.Status.LaunchedAt = &t
+	}
+
 	switch openstackserver.PowerState {
 	case servers.NOSTATE:
 		// No state information available. We will keep the phase as it is.
 	case servers.RUNNING:
 		server.Status.Phase = unikornv1.InstanceLifecyclePhaseRunning
-
-		if !openstackserver.LaunchedAt.IsZero() {
-			t := metav1.NewTime(openstackserver.LaunchedAt)
-			server.Status.LaunchedAt = &t
-		}
 	case servers.SHUTDOWN:
 		server.Status.Phase = unikornv1.InstanceLifecyclePhaseStopped
 	case servers.CRASHED:

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -2063,6 +2063,11 @@ func setServerPhase(ctx context.Context, server *unikornv1.Server, openstackserv
 		// No state information available. We will keep the phase as it is.
 	case servers.RUNNING:
 		server.Status.Phase = unikornv1.InstanceLifecyclePhaseRunning
+
+		if !openstackserver.LaunchedAt.IsZero() {
+			t := metav1.NewTime(openstackserver.LaunchedAt)
+			server.Status.LaunchedAt = &t
+		}
 	case servers.SHUTDOWN:
 		server.Status.Phase = unikornv1.InstanceLifecyclePhaseStopped
 	case servers.CRASHED:


### PR DESCRIPTION
## Summary

- Replaces the annotation-based Pending-entry timestamp with \`OS-SRV-USG:launched_at\` from Nova, which is set at the exact moment the hypervisor boots the VM — independent of poll period
- Adds \`unikorn_region_server_scheduling_duration_seconds\` histogram measuring \`Uni CreationTimestamp → Nova created_at\` (time from CR creation until Nova accepted and processed the creation request, covering Uni reconcile overhead and Nova's initial scheduling work)
- Together the two histograms share the same origin (\`Uni CreationTimestamp\`); their difference (\`provision − scheduling\`) isolates Nova allocation + hypervisor boot time from Uni reconcile overhead
- Adds \`ScheduledAt\` and \`LaunchedAt\` to \`ServerStatus\`; both sourced from Nova on every provider observation
- Both metrics fire only once per server (nil→non-nil guard prevents duplicate observations on stop/restart cycles)
- Removes \`managePendingAnnotation\` and \`ServerPendingEntryTimeAnnotation\` entirely
- Updates \`unikorn_region_server_provision_duration_seconds\` description to accurately reflect what it measures

## Caveats

\`launched_at\` is when the hypervisor boots the instance, not when the guest OS finishes booting. For VMs this gap is negligible (<1 min); for baremetal it can be ~15 minutes. Closing it requires a guest-side signal and is out of scope here.

## Test plan

- [x] Unit tests updated and passing (\`make test-unit\`)
- [x] All lint/validate checks pass (\`make lint\`, \`make validate\`)
- [x] Generated deepcopy and CRD YAML regenerated and checked in
- [x] Verified Nova populates \`OS-SRV-USG:launched_at\` and \`created\` on real running servers in the dev cluster before deploying

Closes [INST-727](https://linear.app/nscale-workspace/issue/INST-727/observability-phase-4b-define-custom-otel-metrics-for-server-lifecycle).