### PR TITLE
ci: support selected-ref UAT runs

### DIFF
--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -16,6 +16,10 @@ on:
         description: 'Use the staged constellation tag for UAT checkout'
         type: boolean
         default: true
+      skip_slack_notifications:
+        description: 'Skip Slack notifications'
+        type: boolean
+        default: false
       focus:
         description: 'Test suite to run'
         required: false
@@ -104,7 +108,7 @@ jobs:
 
     - name: Send Slack Notification
       uses: nscaledev/quality-tooling/.github/actions/slack-test-notifications@main
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && github.event.inputs.skip_slack_notifications != 'true' }}
       with:
         test-results-path: test-results.json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -198,7 +202,7 @@ jobs:
 
     - name: Send Slack Notification
       uses: nscaledev/quality-tooling/.github/actions/slack-test-notifications@main
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && github.event.inputs.skip_slack_notifications != 'true' }}
       with:
         test-results-path: test-results.json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -119,12 +119,12 @@ jobs:
   find-staging-constellation:
     name: Resolve UAT test ref
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true'
+    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true' || github.event.inputs.use_staging_constellation == 'false'
     outputs:
       ref: ${{ steps.find.outputs.ref }}
     steps:
     - name: Resolve UAT checkout ref
-      uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@codex/uni-find-staging-ref-override
+      uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@main
       id: find
       with:
         service: uni-region
@@ -135,8 +135,8 @@ jobs:
     name: API Tests (uat)
     needs: find-staging-constellation
     runs-on: ubuntu-latest
-    # Runs only when UAT was requested and the resolver produced a checkout ref.
-    if: (github.event_name == 'schedule' || github.event.inputs.run_uat == 'true') && needs.find-staging-constellation.outputs.ref != ''
+    # Runs only when the resolver produced a UAT checkout ref.
+    if: needs.find-staging-constellation.outputs.ref != ''
     env:
       ENVIRONMENT: uat
       API_BASE_URL: ${{ vars.UAT_API_BASE_URL }}
@@ -208,3 +208,4 @@ jobs:
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         environment: uat
+        title: 'Region API Test Results - ${{ needs.find-staging-constellation.outputs.ref }}'

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -119,7 +119,7 @@ jobs:
   find-staging-constellation:
     name: Resolve UAT test ref
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true' || github.event.inputs.use_staging_constellation == 'false'
+    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true'
     outputs:
       ref: ${{ steps.find.outputs.ref }}
     steps:
@@ -135,8 +135,8 @@ jobs:
     name: API Tests (uat)
     needs: find-staging-constellation
     runs-on: ubuntu-latest
-    # Runs only when the resolver produced a UAT checkout ref.
-    if: needs.find-staging-constellation.outputs.ref != ''
+    # Runs only when UAT was requested and the resolver produced a checkout ref.
+    if: (github.event_name == 'schedule' || github.event.inputs.run_uat == 'true') && needs.find-staging-constellation.outputs.ref != ''
     env:
       ENVIRONMENT: uat
       API_BASE_URL: ${{ vars.UAT_API_BASE_URL }}

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -12,6 +12,10 @@ on:
         description: 'Run UAT tests'
         type: boolean
         default: false
+      use_staging_constellation:
+        description: 'Use the staged constellation tag for UAT checkout'
+        type: boolean
+        default: true
       focus:
         description: 'Test suite to run'
         required: false
@@ -109,24 +113,26 @@ jobs:
         title: 'Region API Test Results'
 
   find-staging-constellation:
-    name: Find staging constellation
+    name: Resolve UAT test ref
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true'
+    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true' || github.event.inputs.use_staging_constellation == 'false'
     outputs:
-      tag: ${{ steps.find.outputs.tag }}
+      ref: ${{ steps.find.outputs.ref }}
     steps:
-    - uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@main
+    - name: Resolve UAT checkout ref
+      uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@codex/uni-find-staging-ref-override
       id: find
       with:
         service: uni-region
         releases-read-token: ${{ secrets.RELEASES_READ_TOKEN }}
+        use-staging-constellation: ${{ github.event_name == 'schedule' || github.event.inputs.use_staging_constellation != 'false' }}
 
   API-Tests-UAT:
     name: API Tests (uat)
     needs: find-staging-constellation
     runs-on: ubuntu-latest
-    # Runs only when find-staging-constellation resolved a tag.
-    if: needs.find-staging-constellation.outputs.tag != ''
+    # Runs only when the resolver produced a UAT checkout ref.
+    if: needs.find-staging-constellation.outputs.ref != ''
     env:
       ENVIRONMENT: uat
       API_BASE_URL: ${{ vars.UAT_API_BASE_URL }}
@@ -144,7 +150,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        ref: ${{ needs.find-staging-constellation.outputs.tag }}
+        ref: ${{ needs.find-staging-constellation.outputs.ref }}
 
     - name: Setup Go
       uses: actions/setup-go@v3

--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ Trigger the workflow manually from the Actions tab:
 4. Leave **use_staging_constellation** enabled to test UAT from the staged
    constellation tag. Disable it to test UAT from the branch or tag selected in
    GitHub's manual workflow picker.
-5. View results in the workflow run and download test artifacts
+5. Set **skip_slack_notifications** to `true` to suppress Slack messages for the
+   run.
+6. View results in the workflow run and download test artifacts
 
 ## Contract Testing
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,10 @@ Trigger the workflow manually from the Actions tab:
    - **Run Dev tests** (checked by default)
    - **Run UAT tests** (unchecked by default)
    - Can run one, both, or neither
-4. View results in the workflow run and download test artifacts
+4. Leave **use_staging_constellation** enabled to test UAT from the staged
+   constellation tag. Disable it to test UAT from the branch or tag selected in
+   GitHub's manual workflow picker.
+5. View results in the workflow run and download test artifacts
 
 ## Contract Testing
 

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ Trigger the workflow manually from the Actions tab:
    - **Run Dev tests** (checked by default)
    - **Run UAT tests** (unchecked by default)
    - Can run one, both, or neither
-4. Leave **use_staging_constellation** enabled to test UAT from the staged
-   constellation tag. Disable it to test UAT from the branch or tag selected in
-   GitHub's manual workflow picker.
+4. When **Run UAT tests** is selected, leave **use_staging_constellation**
+   enabled to test UAT from the staged constellation tag. Disable it to test UAT
+   from the branch or tag selected in GitHub's manual workflow picker.
 5. Set **skip_slack_notifications** to `true` to suppress Slack messages for the
    run.
 6. View results in the workflow run and download test artifacts

--- a/README.md
+++ b/README.md
@@ -160,9 +160,12 @@ Trigger the workflow manually from the Actions tab:
    - **Run Dev tests** (checked by default)
    - **Run UAT tests** (unchecked by default)
    - Can run one, both, or neither
-4. When **Run UAT tests** is selected, leave **use_staging_constellation**
-   enabled to test UAT from the staged constellation tag. Disable it to test UAT
-   from the branch or tag selected in GitHub's manual workflow picker.
+4. Scheduled UAT runs check out the staged constellation tag resolved by the
+   workflow. Manual UAT runs use the same staged constellation lookup by default.
+   To run UAT against the branch or tag selected in GitHub's manual workflow
+   picker instead, set **use_staging_constellation** to `false`. Disabling
+   **use_staging_constellation** is enough to trigger the UAT job for that
+   selected ref.
 5. Set **skip_slack_notifications** to `true` to suppress Slack messages for the
    run.
 6. View results in the workflow run and download test artifacts


### PR DESCRIPTION
## Summary
- Add a `use_staging_constellation` workflow input, defaulting to the existing staging constellation lookup.
- Use the shared resolver `ref` output for UAT checkout so both staged tags and manually selected workflow refs work.
- Allow manual UAT runs from the branch/tag selected in the GitHub run picker when staging lookup is disabled.
- Include the resolved UAT checkout ref in the UAT Slack notification title.
- Add `skip_slack_notifications` to suppress Slack messages for a manual run.

## Dependency
- Requires nscaledev/quality-tooling#6 to be merged so `uni-find-staging-constellation@main` exposes the new `use-staging-constellation` input and `ref` output.

## Backward Compatibility
- Scheduled runs and existing manual runs keep using the staged constellation by default.
- Slack notifications continue by default unless `skip_slack_notifications` is set to `true`.
- UAT still skips when the resolver does not produce a checkout ref.

## Validation
- Parsed `.github/workflows/test-api.yaml` as YAML
- `git diff --check`