### PR TITLE
test: avoid double cleanup of file storage

### DIFF
--- a/test/api/suites/filestorage_test.go
+++ b/test/api/suites/filestorage_test.go
@@ -580,6 +580,7 @@ var _ = Describe("File Storage Management", func() {
 						"Storage should be deleted")
 
 				GinkgoWriter.Printf("Confirmed file storage deleted: %s\n", filestorageID)
+				filestorageID = "" // suppress AfterAll cleanup; storage has been confirmed deleted
 			})
 
 			It("should delete the network resource", func() {
@@ -618,18 +619,18 @@ var _ = Describe("File Storage Management", func() {
 			if filestorageID != "" {
 				GinkgoWriter.Printf("Cleaning up test filestorage: %s\n", filestorageID)
 				Expect(regionClient.DeleteFileStorage(ctx, filestorageID)).To(Succeed())
-			}
 
-			if networkID != "" {
-				GinkgoWriter.Printf("Waiting for storage detachment before network cleanup...\n")
+				GinkgoWriter.Printf("Waiting for storage cleanup: %s\n", filestorageID)
 				Eventually(func() error {
 					_, err := regionClient.GetFileStorage(ctx, filestorageID)
 					return err
 				}).WithTimeout(2*time.Minute).
 					WithPolling(5*time.Second).
 					Should(And(HaveOccurred(), MatchError(coreclient.ErrUnexpectedStatusCode)),
-						"Storage should be deleted before network cleanup")
+						"Storage should be deleted during cleanup")
+			}
 
+			if networkID != "" {
 				GinkgoWriter.Printf("Cleaning up test network: %s\n", networkID)
 				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
 			}


### PR DESCRIPTION
## Summary
- Clear the attachment test file storage ID after the ordered delete has confirmed the storage is gone.
- Keep AfterAll responsible only for leftover file storage or network resources.
- Wait for cleanup-triggered storage deletion to settle before deleting any leftover network.

## Why
Stage ran the file storage attachment path and failed in AfterAll because the test deleted the storage explicitly, then cleanup attempted to delete the same storage again. Dev skipped the storage path because no storage classes were allocated, so it did not hit the double-delete path.

## Validation
- go test -tags integration ./test/api/suites -run '^$'
- git diff --check