### PR TITLE
feat(e2e): Report API test results with AI Slack analysis

### DIFF
--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -144,7 +144,7 @@ jobs:
   find-staging-constellation:
     name: Resolve UAT test ref
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true' || github.event.inputs.use_staging_constellation == 'false'
+    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true'
     outputs:
       ref: ${{ steps.find.outputs.ref }}
     steps:
@@ -161,7 +161,7 @@ jobs:
     needs: find-staging-constellation
     runs-on: ubuntu-latest
     # Runs only when the resolver produced a UAT checkout ref.
-    if: needs.find-staging-constellation.outputs.ref != ''
+    if: (github.event_name == 'schedule' || github.event.inputs.run_uat == 'true') && needs.find-staging-constellation.outputs.ref != ''
     env:
       ENVIRONMENT: uat
       API_BASE_URL: ${{ vars.UAT_API_BASE_URL }}
@@ -258,6 +258,6 @@ jobs:
         slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
-        title: 'Region API Test Results - ${{ needs.find-staging-constellation.outputs.ref }}'
+        title: 'Region API Test Results'
         enable-ai-analysis: 'true'
         claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -59,6 +59,27 @@ jobs:
       TEST_SECONDARY_AUTH_TOKEN: ${{ secrets.DEV_TEST_SECONDARY_AUTH_TOKEN }}
 
     steps:
+    - name: Log workflow inputs
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        RUN_DEV: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_dev || 'true' }}
+        RUN_UAT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_uat || 'false' }}
+        USE_STAGING_CONSTELLATION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.use_staging_constellation || 'true' }}
+        SKIP_SLACK_NOTIFICATIONS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_slack_notifications || 'false' }}
+        FOCUS: ${{ github.event.inputs.focus || 'All' }}
+        REGION_ID_OVERRIDE: ${{ inputs.region_id || '<default>' }}
+      run: |
+        cat <<EOF >> "$GITHUB_STEP_SUMMARY"
+        ### Workflow Input Parameters
+        - **Event:** \`$EVENT_NAME\`
+        - **Run Dev:** \`$RUN_DEV\`
+        - **Run UAT:** \`$RUN_UAT\`
+        - **Use Staging Constellation:** \`$USE_STAGING_CONSTELLATION\`
+        - **Skip Slack Notifications:** \`$SKIP_SLACK_NOTIFICATIONS\`
+        - **Focus:** \`$FOCUS\`
+        - **Region ID Override:** \`$REGION_ID_OVERRIDE\`
+        EOF
+
     - name: Checkout
       uses: actions/checkout@v4
 
@@ -155,6 +176,29 @@ jobs:
       TEST_SECONDARY_AUTH_TOKEN: ${{ secrets.UAT_TEST_SECONDARY_AUTH_TOKEN }}
 
     steps:
+    - name: Log workflow inputs
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        RUN_DEV: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_dev || 'true' }}
+        RUN_UAT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_uat || 'false' }}
+        USE_STAGING_CONSTELLATION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.use_staging_constellation || 'true' }}
+        SKIP_SLACK_NOTIFICATIONS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_slack_notifications || 'false' }}
+        FOCUS: ${{ github.event.inputs.focus || 'All' }}
+        REGION_ID_OVERRIDE: ${{ inputs.region_id || '<default>' }}
+        UAT_CHECKOUT_REF: ${{ needs.find-staging-constellation.outputs.ref }}
+      run: |
+        cat <<EOF >> "$GITHUB_STEP_SUMMARY"
+        ### Workflow Input Parameters
+        - **Event:** \`$EVENT_NAME\`
+        - **Run Dev:** \`$RUN_DEV\`
+        - **Run UAT:** \`$RUN_UAT\`
+        - **Use Staging Constellation:** \`$USE_STAGING_CONSTELLATION\`
+        - **Skip Slack Notifications:** \`$SKIP_SLACK_NOTIFICATIONS\`
+        - **Focus:** \`$FOCUS\`
+        - **Region ID Override:** \`$REGION_ID_OVERRIDE\`
+        - **UAT Checkout Ref:** \`$UAT_CHECKOUT_REF\`
+        EOF
+
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -132,13 +132,13 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
       if: ${{ !cancelled() }}
       with:
         test-results-path: test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: dev
         title: 'Region API Test Results'
@@ -230,13 +230,13 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
       if: ${{ !cancelled() }}
       with:
         test-results-path: test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
         title: 'Region API Test Results'

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -106,15 +106,19 @@ jobs:
         linear-priority: '3'
         max-failures: '5'
 
-    - name: Send Slack Notification
-      uses: nscaledev/quality-tooling/.github/actions/slack-test-notifications@main
-      if: ${{ !cancelled() && github.event.inputs.skip_slack_notifications != 'true' }}
+    - name: Report API Test Results
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
+      if: ${{ !cancelled() }}
       with:
         test-results-path: test-results.json
+        format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: dev
         title: 'Region API Test Results'
+        enable-ai-analysis: 'true'
+        claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
   find-staging-constellation:
     name: Resolve UAT test ref
@@ -200,12 +204,16 @@ jobs:
         linear-priority: '3'
         max-failures: '5'
 
-    - name: Send Slack Notification
-      uses: nscaledev/quality-tooling/.github/actions/slack-test-notifications@main
-      if: ${{ !cancelled() && github.event.inputs.skip_slack_notifications != 'true' }}
+    - name: Report API Test Results
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
+      if: ${{ !cancelled() }}
       with:
         test-results-path: test-results.json
+        format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
         title: 'Region API Test Results - ${{ needs.find-staging-constellation.outputs.ref }}'
+        enable-ai-analysis: 'true'
+        claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -41,23 +41,9 @@ permissions:
   contents: read
 
 jobs:
-  API-Tests-Dev:
-    name: API Tests (dev)
+  workflow-inputs-summary:
+    name: Workflow input summary
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event.inputs.run_dev == 'true'
-    env:
-      ENVIRONMENT: dev
-      API_BASE_URL: ${{ vars.DEV_API_BASE_URL }}
-      REGION_BASE_URL: ${{ vars.DEV_REGION_BASE_URL }}
-      API_AUTH_TOKEN: ${{ secrets.DEV_API_AUTH_TOKEN }}
-      TEST_ORG_ID: ${{ vars.DEV_TEST_ORG_ID }}
-      TEST_PROJECT_ID: ${{ vars.DEV_TEST_PROJECT_ID }}
-      TEST_REGION_ID: ${{ inputs.region_id || vars.DEV_TEST_REGION_ID }}
-      TEST_NETWORK_ID: ${{ vars.DEV_TEST_NETWORK_ID }}
-      TEST_PRIVATE_REGION_ID: ${{ vars.DEV_TEST_PRIVATE_REGION_ID }}
-      TEST_SECONDARY_ORG_ID: ${{ vars.DEV_TEST_SECONDARY_ORG_ID }}
-      TEST_SECONDARY_AUTH_TOKEN: ${{ secrets.DEV_TEST_SECONDARY_AUTH_TOKEN }}
-
     steps:
     - name: Log workflow inputs
       env:
@@ -80,6 +66,24 @@ jobs:
         - **Region ID Override:** \`$REGION_ID_OVERRIDE\`
         EOF
 
+  API-Tests-Dev:
+    name: API Tests (dev)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event.inputs.run_dev == 'true'
+    env:
+      ENVIRONMENT: dev
+      API_BASE_URL: ${{ vars.DEV_API_BASE_URL }}
+      REGION_BASE_URL: ${{ vars.DEV_REGION_BASE_URL }}
+      API_AUTH_TOKEN: ${{ secrets.DEV_API_AUTH_TOKEN }}
+      TEST_ORG_ID: ${{ vars.DEV_TEST_ORG_ID }}
+      TEST_PROJECT_ID: ${{ vars.DEV_TEST_PROJECT_ID }}
+      TEST_REGION_ID: ${{ inputs.region_id || vars.DEV_TEST_REGION_ID }}
+      TEST_NETWORK_ID: ${{ vars.DEV_TEST_NETWORK_ID }}
+      TEST_PRIVATE_REGION_ID: ${{ vars.DEV_TEST_PRIVATE_REGION_ID }}
+      TEST_SECONDARY_ORG_ID: ${{ vars.DEV_TEST_SECONDARY_ORG_ID }}
+      TEST_SECONDARY_AUTH_TOKEN: ${{ secrets.DEV_TEST_SECONDARY_AUTH_TOKEN }}
+
+    steps:
     - name: Checkout
       uses: actions/checkout@v4
 
@@ -176,29 +180,6 @@ jobs:
       TEST_SECONDARY_AUTH_TOKEN: ${{ secrets.UAT_TEST_SECONDARY_AUTH_TOKEN }}
 
     steps:
-    - name: Log workflow inputs
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        RUN_DEV: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_dev || 'true' }}
-        RUN_UAT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_uat || 'false' }}
-        USE_STAGING_CONSTELLATION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.use_staging_constellation || 'true' }}
-        SKIP_SLACK_NOTIFICATIONS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_slack_notifications || 'false' }}
-        FOCUS: ${{ github.event.inputs.focus || 'All' }}
-        REGION_ID_OVERRIDE: ${{ inputs.region_id || '<default>' }}
-        UAT_CHECKOUT_REF: ${{ needs.find-staging-constellation.outputs.ref }}
-      run: |
-        cat <<EOF >> "$GITHUB_STEP_SUMMARY"
-        ### Workflow Input Parameters
-        - **Event:** \`$EVENT_NAME\`
-        - **Run Dev:** \`$RUN_DEV\`
-        - **Run UAT:** \`$RUN_UAT\`
-        - **Use Staging Constellation:** \`$USE_STAGING_CONSTELLATION\`
-        - **Skip Slack Notifications:** \`$SKIP_SLACK_NOTIFICATIONS\`
-        - **Focus:** \`$FOCUS\`
-        - **Region ID Override:** \`$REGION_ID_OVERRIDE\`
-        - **UAT Checkout Ref:** \`$UAT_CHECKOUT_REF\`
-        EOF
-
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -113,7 +113,7 @@ jobs:
         test-results-path: test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: dev
         title: 'Region API Test Results'
@@ -211,7 +211,7 @@ jobs:
         test-results-path: test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
         title: 'Region API Test Results - ${{ needs.find-staging-constellation.outputs.ref }}'


### PR DESCRIPTION
## Summary
- Replace the existing Slack test notification step with the shared `test-results-report@main` action for dev and UAT API test jobs.
- Send Ginkgo JSON results through the report action, using `SLACK_WEBHOOK_URL` and keeping Slack delivery configurable via `skip_slack_notifications`.
- Enable Claude analysis for API test reports while preserving the latest UAT selected-ref/staging constellation workflow from `main`.
- Log workflow input parameters once in the build summary for easier manual-run debugging.
- Sample [build](https://github.com/nscaledev/uni-region/actions/runs/26182133497), slack msg
<img width="1238" height="605" alt="Screenshot 2026-05-20 at 19 50 02" src="https://github.com/user-attachments/assets/5bfc79c7-819c-4297-a1e2-513d83ce6eb2" />

## Testing
- YAML parse check passed locally.
- `git diff --check -- .github/workflows/test-api.yaml` passed locally.