### PR TITLE
Fix network allocation leak

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ make test-unit
 
 ## Test Writing
 
-All new tests must follow the patterns established in `test/api/`:
+Unit tests in `pkg/` use standard Go test functions (`func TestX(t *testing.T)`). The patterns
+below apply to integration and e2e tests in `test/api/`:
 
 - **BDD structure**: Use `Describe > Context > Describe > It` nesting.
   `Describe` names the resource or component. `Context` describes the scenario

--- a/pkg/handler/server/client_v2_test.go
+++ b/pkg/handler/server/client_v2_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -127,11 +128,11 @@ func aclWithSrvNetworkReadOnly(orgID string) *identityapi.Acl {
 	}
 }
 
-func aclWithSrvUpdate(orgID string) *identityapi.Acl {
+func aclWithSrvUpdate() *identityapi.Acl {
 	return &identityapi.Acl{
 		Organizations: &identityapi.AclOrganizationList{
 			{
-				Id: orgID,
+				Id: srvOrganizationID,
 				Endpoints: &identityapi.AclEndpoints{
 					{
 						Name:       "region:networks:v2",
@@ -486,7 +487,7 @@ func TestServerUpdateV2PreservesSSHCertificateAuthority(t *testing.T) {
 		Identity:  mockIdentity,
 	})
 
-	ctx := withPrincipal(rbac.NewContext(t.Context(), aclWithSrvUpdate(srvOrganizationID)))
+	ctx := withPrincipal(rbac.NewContext(t.Context(), aclWithSrvUpdate()))
 
 	request := &openapi.ServerV2Update{
 		Metadata: coreapi.ResourceWriteMetadata{Name: resource.Name},
@@ -528,7 +529,7 @@ func TestServerGetV2ReturnsMACAddress(t *testing.T) {
 		Identity:  mockIdentity,
 	})
 
-	ctx := rbac.NewContext(t.Context(), aclWithSrvUpdate(srvOrganizationID))
+	ctx := rbac.NewContext(t.Context(), aclWithSrvUpdate())
 
 	result, err := c.GetV2(ctx, resource.Name)
 
@@ -537,6 +538,367 @@ func TestServerGetV2ReturnsMACAddress(t *testing.T) {
 	require.Equal(t, resource.Status.PrivateIP, result.Status.PrivateIP)
 	require.Equal(t, resource.Status.PublicIP, result.Status.PublicIP)
 	require.Equal(t, resource.Status.MACAddress, result.Status.MacAddress)
+}
+
+func testServerV2(serverID string) *regionv1.Server {
+	return &regionv1.Server{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serverID,
+			Namespace: srvNamespace,
+			Labels: map[string]string{
+				coreconstants.OrganizationLabel:   srvOrganizationID,
+				coreconstants.ProjectLabel:        srvProjectID,
+				coreconstants.NameLabel:           serverID,
+				constants.RegionLabel:             "test-region",
+				constants.IdentityLabel:           "test-identity",
+				constants.NetworkLabel:            srvNetworkID,
+				constants.ResourceAPIVersionLabel: constants.MarshalAPIVersion(2),
+			},
+		},
+		Spec: regionv1.ServerSpec{
+			FlavorID: "flavor-1",
+			Image:    &regionv1.ServerImage{ID: "image-1"},
+			Networks: []regionv1.ServerNetworkSpec{{ID: srvNetworkID}},
+		},
+	}
+}
+
+func TestServerGetV2Raw_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	k8sClient := newSrvFakeClient(t).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	_, err := c.GetV2Raw(rbac.NewContext(t.Context(), aclWithSrvUpdate()), "nonexistent-server")
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+func TestServerGetV2Raw_MissingAPIVersionLabel(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	resource := &regionv1.Server{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "server-no-version",
+			Namespace: srvNamespace,
+			Labels: map[string]string{
+				coreconstants.OrganizationLabel: srvOrganizationID,
+				coreconstants.ProjectLabel:      srvProjectID,
+			},
+		},
+		Spec: regionv1.ServerSpec{
+			Image:    &regionv1.ServerImage{ID: "image-1"},
+			Networks: []regionv1.ServerNetworkSpec{{ID: srvNetworkID}},
+		},
+	}
+
+	k8sClient := newSrvFakeClient(t, resource).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	_, err := c.GetV2Raw(rbac.NewContext(t.Context(), aclWithSrvUpdate()), resource.Name)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+func TestServerGetV2Raw_WrongAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	resource := &regionv1.Server{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "server-v1",
+			Namespace: srvNamespace,
+			Labels: map[string]string{
+				coreconstants.OrganizationLabel:   srvOrganizationID,
+				coreconstants.ProjectLabel:        srvProjectID,
+				constants.ResourceAPIVersionLabel: constants.MarshalAPIVersion(1),
+			},
+		},
+		Spec: regionv1.ServerSpec{
+			Image:    &regionv1.ServerImage{ID: "image-1"},
+			Networks: []regionv1.ServerNetworkSpec{{ID: srvNetworkID}},
+		},
+	}
+
+	k8sClient := newSrvFakeClient(t, resource).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	_, err := c.GetV2Raw(rbac.NewContext(t.Context(), aclWithSrvUpdate()), resource.Name)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+func TestServerGetV2Raw_NoReadPermission(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	resource := testServerV2("server-no-read")
+
+	k8sClient := newSrvFakeClient(t, resource).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	// org present in ACL but no endpoints — read is denied
+	ctx := rbac.NewContext(t.Context(), &identityapi.Acl{
+		Organizations: &identityapi.AclOrganizationList{{Id: srvOrganizationID}},
+	})
+
+	_, err := c.GetV2Raw(ctx, resource.Name)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsForbidden(err), "expected forbidden, got: %v", err)
+}
+
+func aclWithSrvReadOnly(orgID string) *identityapi.Acl {
+	return &identityapi.Acl{
+		Organizations: &identityapi.AclOrganizationList{{
+			Id: orgID,
+			Endpoints: &identityapi.AclEndpoints{{
+				Name:       "region:servers",
+				Operations: identityapi.AclOperations{identityapi.Read},
+			}},
+		}},
+	}
+}
+
+func TestServerCreateV2_NetworkNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	k8sClient := newSrvFakeClient(t).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := rbac.NewContext(t.Context(), aclWithOrgScopeServerCreate())
+
+	_, err := c.CreateV2(ctx, minimalServerV2CreateRequest())
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+func TestServerUpdateV2_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	k8sClient := newSrvFakeClient(t).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := rbac.NewContext(t.Context(), aclWithSrvUpdate())
+
+	request := &openapi.ServerV2Update{
+		Metadata: coreapi.ResourceWriteMetadata{Name: "nonexistent-server"},
+		Spec:     openapi.ServerV2Spec{FlavorId: "flavor-1", ImageId: "image-1"},
+	}
+
+	_, err := c.UpdateV2(ctx, "nonexistent-server", request)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+func TestServerUpdateV2_NoUpdatePermission(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	resource := testServerV2("server-1")
+
+	k8sClient := newSrvFakeClient(t, resource).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := rbac.NewContext(t.Context(), aclWithSrvReadOnly(srvOrganizationID))
+
+	request := &openapi.ServerV2Update{
+		Metadata: coreapi.ResourceWriteMetadata{Name: resource.Name},
+		Spec:     openapi.ServerV2Spec{FlavorId: resource.Spec.FlavorID, ImageId: resource.Spec.Image.ID},
+	}
+
+	_, err := c.UpdateV2(ctx, resource.Name, request)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsForbidden(err), "expected forbidden, got: %v", err)
+}
+
+func TestServerUpdateV2_ServerBeingDeleted(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	resource := testServerV2("server-1")
+	now := metav1.NewTime(time.Now())
+	resource.DeletionTimestamp = &now
+	resource.Finalizers = []string{"servers.region.unikorn-cloud.org/test"}
+
+	k8sClient := newSrvFakeClient(t, resource).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := withPrincipal(rbac.NewContext(t.Context(), aclWithSrvUpdate()))
+
+	request := &openapi.ServerV2Update{
+		Metadata: coreapi.ResourceWriteMetadata{Name: resource.Name},
+		Spec:     openapi.ServerV2Spec{FlavorId: resource.Spec.FlavorID, ImageId: resource.Spec.Image.ID},
+	}
+
+	_, err := c.UpdateV2(ctx, resource.Name, request)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsBadRequest(err), "expected bad request (server being deleted), got: %v", err)
+}
+
+func TestServerUpdateV2_NetworkGone(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	// server exists but its network has been deleted
+	resource := testServerV2("server-1")
+
+	k8sClient := newSrvFakeClient(t, resource).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := withPrincipal(rbac.NewContext(t.Context(), aclWithSrvUpdate()))
+
+	request := &openapi.ServerV2Update{
+		Metadata: coreapi.ResourceWriteMetadata{Name: resource.Name},
+		Spec:     openapi.ServerV2Spec{FlavorId: resource.Spec.FlavorID, ImageId: resource.Spec.Image.ID},
+	}
+
+	_, err := c.UpdateV2(ctx, resource.Name, request)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found (network gone), got: %v", err)
+}
+
+func TestServerDeleteV2_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	k8sClient := newSrvFakeClient(t).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := rbac.NewContext(t.Context(), aclWithSrvUpdate())
+
+	err := c.DeleteV2(ctx, "nonexistent-server")
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+func TestServerDeleteV2_NoDeletePermission(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	resource := testServerV2("server-1")
+
+	k8sClient := newSrvFakeClient(t, resource).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := rbac.NewContext(t.Context(), aclWithSrvReadOnly(srvOrganizationID))
+
+	err := c.DeleteV2(ctx, resource.Name)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsForbidden(err), "expected forbidden, got: %v", err)
+}
+
+func TestServerStartV2_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+
+	k8sClient := newSrvFakeClient(t).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := rbac.NewContext(t.Context(), aclWithSrvUpdate())
+
+	err := c.StartV2(ctx, "nonexistent-server")
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
 }
 
 // TestServerCreateV2DeterministicID verifies that two creates with the same
@@ -690,7 +1052,7 @@ func TestServerUpdateV2RejectsRename(t *testing.T) {
 		Identity:  mockIdentity,
 	})
 
-	ctx := withPrincipal(rbac.NewContext(t.Context(), aclWithSrvUpdate(srvOrganizationID)))
+	ctx := withPrincipal(rbac.NewContext(t.Context(), aclWithSrvUpdate()))
 
 	request := &openapi.ServerV2Update{
 		Metadata: coreapi.ResourceWriteMetadata{Name: "renamed-server"},

--- a/pkg/provisioners/README.md
+++ b/pkg/provisioners/README.md
@@ -27,6 +27,21 @@ The main deviations from a trivial “call provider create/delete” model are:
 - some release or reconcile identity-side quota allocations on deprovision
 - some augment provider create options, especially for server cloud-init / SSH CA integration
 
+## Deprovisioning Partial State
+
+Provisioners must handle deletion from any state a handler or earlier reconcile
+step can leave behind. Teardown should split provider cleanup, reference
+cleanup, and quota/accounting cleanup into separate idempotent steps. Gate each
+step on the minimum recorded state it needs rather than on a broad prerequisite
+such as parent identity readiness.
+
+This matters for partially created resources: an allocation or reference may
+already exist even when the provider resource was never created. Waiting for
+provider prerequisites in that window can block cleanup of the side effects that
+do exist. When a lifecycle edge is subtle, keep the predicate named after the
+state it actually observes and document the partial-state window next to that
+predicate.
+
 ## Cross-Package Context
 
 - [../managers](../managers/README.md) wraps these provisioners in controller factories

--- a/pkg/provisioners/internal/base/identity.go
+++ b/pkg/provisioners/internal/base/identity.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package base
+
+import (
+	"context"
+	"fmt"
+
+	coreclient "github.com/unikorn-cloud/core/pkg/client"
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	identityclient "github.com/unikorn-cloud/identity/pkg/client"
+	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IdentityClientFactory constructs controller-scoped identity service clients.
+type IdentityClientFactory interface {
+	ControllerClient(ctx context.Context, cli client.Client, resource client.Object) (identityapi.ClientWithResponsesInterface, error)
+}
+
+type defaultIdentityClientFactory struct {
+	identityOptions *identityclient.Options
+	clientOptions   *coreclient.HTTPClientOptions
+}
+
+// NewIdentityClientFactory creates the default identity service client factory.
+func NewIdentityClientFactory(identityOptions *identityclient.Options, clientOptions *coreclient.HTTPClientOptions) IdentityClientFactory {
+	return defaultIdentityClientFactory{
+		identityOptions: identityOptions,
+		clientOptions:   clientOptions,
+	}
+}
+
+func (f defaultIdentityClientFactory) ControllerClient(ctx context.Context, cli client.Client, resource client.Object) (identityapi.ClientWithResponsesInterface, error) {
+	return identityclient.New(cli, f.identityOptions, f.clientOptions).ControllerClient(ctx, resource)
+}
+
+// WithIdentity extends Base with access to the identity service API.
+type WithIdentity struct {
+	Base
+
+	IdentityClients IdentityClientFactory
+}
+
+// IdentityClient returns an identity service client scoped to the reconciled resource.
+func (b *WithIdentity) IdentityClient(ctx context.Context, resource client.Object) (identityapi.ClientWithResponsesInterface, error) {
+	cli, err := coreclient.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if b.IdentityClients == nil {
+		return nil, fmt.Errorf("%w: identity client factory not configured", coreerrors.ErrConsistency)
+	}
+
+	return b.IdentityClients.ControllerClient(ctx, cli, resource)
+}

--- a/pkg/provisioners/managers/load-balancer/export_test.go
+++ b/pkg/provisioners/managers/load-balancer/export_test.go
@@ -27,8 +27,10 @@ import (
 func NewForTest(loadbalancer *unikornv1.LoadBalancer, providers providers.Providers) *Provisioner {
 	return &Provisioner{
 		loadbalancer: loadbalancer,
-		Base: base.Base{
-			Providers: providers,
+		WithIdentity: base.WithIdentity{
+			Base: base.Base{
+				Providers: providers,
+			},
 		},
 	}
 }

--- a/pkg/provisioners/managers/load-balancer/provisioner.go
+++ b/pkg/provisioners/managers/load-balancer/provisioner.go
@@ -28,7 +28,6 @@ import (
 	"github.com/unikorn-cloud/core/pkg/manager"
 	"github.com/unikorn-cloud/core/pkg/provisioners"
 	identityclient "github.com/unikorn-cloud/identity/pkg/client"
-	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/providers"
@@ -62,8 +61,8 @@ type Provisioner struct {
 	// options are documented for the type.
 	options *Options
 
-	// Base gives this type methods for getting identities and providers.
-	base.Base
+	// WithIdentity gives this type methods for providers and identity service access.
+	base.WithIdentity
 }
 
 // New returns a new initialized provisioner object.
@@ -73,8 +72,11 @@ func New(options manager.ControllerOptions, providers providers.Providers) provi
 	return &Provisioner{
 		loadbalancer: &unikornv1.LoadBalancer{},
 		options:      o,
-		Base: base.Base{
-			Providers: providers,
+		WithIdentity: base.WithIdentity{
+			Base: base.Base{
+				Providers: providers,
+			},
+			IdentityClients: base.NewIdentityClientFactory(o.identityOptions, &o.clientOptions),
 		},
 	}
 }
@@ -84,15 +86,6 @@ var _ provisioners.ManagerProvisioner = &Provisioner{}
 
 func (p *Provisioner) Object() unikornv1core.ManagableResourceInterface {
 	return p.loadbalancer
-}
-
-func (p *Provisioner) identityClient(ctx context.Context) (identityapi.ClientWithResponsesInterface, error) {
-	client, err := coreclient.FromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return identityclient.New(client, p.options.identityOptions, &p.options.clientOptions).ControllerClient(ctx, p.loadbalancer)
 }
 
 // network resolves the Network referenced by constants.NetworkLabel.
@@ -154,7 +147,7 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 		return err
 	}
 
-	api, err := p.identityClient(ctx)
+	api, err := p.IdentityClient(ctx, p.loadbalancer)
 	if err != nil {
 		return err
 	}

--- a/pkg/provisioners/managers/network/README.md
+++ b/pkg/provisioners/managers/network/README.md
@@ -5,7 +5,9 @@ identity/service-principal context is ready.
 
 Distinctive behaviour:
 
-- blocks on parent identity readiness before provider create/delete
+- blocks on parent identity readiness before provider create
+- skips provider delete when identity is not ready and no provider resource IDs
+  have been recorded, because there is nothing provider-side to remove yet
 - deletes identity-side quota allocation on deprovision for `v2` networks only
 - carries explicit `v1` compatibility debt in that allocation cleanup path
 

--- a/pkg/provisioners/managers/network/export_test.go
+++ b/pkg/provisioners/managers/network/export_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+
+	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/providers"
+	"github.com/unikorn-cloud/region/pkg/provisioners/internal/base"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type staticIdentityClientFactory struct {
+	client identityapi.ClientWithResponsesInterface
+}
+
+func (f staticIdentityClientFactory) ControllerClient(context.Context, client.Client, client.Object) (identityapi.ClientWithResponsesInterface, error) {
+	return f.client, nil
+}
+
+// NewForTest constructs a Provisioner directly for unit tests, bypassing the
+// CLI-options plumbing handled by New.
+func NewForTest(network *unikornv1.Network, providers providers.Providers, identityClient identityapi.ClientWithResponsesInterface) *Provisioner {
+	return &Provisioner{
+		network: network,
+		options: &Options{},
+		WithIdentity: base.WithIdentity{
+			Base: base.Base{
+				Providers: providers,
+			},
+			IdentityClients: staticIdentityClientFactory{
+				client: identityClient,
+			},
+		},
+	}
+}

--- a/pkg/provisioners/managers/network/provisioner.go
+++ b/pkg/provisioners/managers/network/provisioner.go
@@ -88,6 +88,34 @@ func (p *Provisioner) Object() unikornv1core.ManagableResourceInterface {
 	return p.network
 }
 
+func identityReady(identity *unikornv1.Identity) bool {
+	condition, err := identity.StatusConditionRead(unikornv1core.ConditionAvailable)
+	if err != nil {
+		return false
+	}
+
+	return condition.Reason == unikornv1core.ConditionReasonProvisioned
+}
+
+func providerResourceIDsRecorded(network *unikornv1.Network) bool {
+	if network.Status.Openstack == nil {
+		return false
+	}
+
+	return network.Status.Openstack.NetworkID != nil ||
+		network.Status.Openstack.SubnetID != nil ||
+		network.Status.Openstack.VlanID != nil
+}
+
+func needsProviderDelete(identity *unikornv1.Identity, network *unikornv1.Network) bool {
+	// A v2 network can be deleted after the API has created its identity-side
+	// allocation but before provisioning has waited for Identity readiness and
+	// recorded provider resource IDs. In that window there is nothing for the
+	// provider to delete, and waiting for Identity readiness would leak the
+	// allocation.
+	return identityReady(identity) || providerResourceIDsRecorded(network)
+}
+
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	provider, identity, err := p.ProviderAndIdentity(ctx, p.network)
@@ -115,8 +143,10 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 		return err
 	}
 
-	if err := provider.DeleteNetwork(ctx, identity, p.network); err != nil {
-		return err
+	if needsProviderDelete(identity, p.network) {
+		if err := provider.DeleteNetwork(ctx, identity, p.network); err != nil {
+			return err
+		}
 	}
 
 	// Temporary hack, V1 networks don't have a discrete network allocation,

--- a/pkg/provisioners/managers/network/provisioner.go
+++ b/pkg/provisioners/managers/network/provisioner.go
@@ -27,7 +27,6 @@ import (
 	"github.com/unikorn-cloud/core/pkg/manager"
 	"github.com/unikorn-cloud/core/pkg/provisioners"
 	identityclient "github.com/unikorn-cloud/identity/pkg/client"
-	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/providers"
@@ -62,8 +61,8 @@ type Provisioner struct {
 	// options are documented for the type.
 	options *Options
 
-	// Base gives us methods for getting identities and providers.
-	base.Base
+	// WithIdentity gives us methods for providers and identity service access.
+	base.WithIdentity
 }
 
 // New returns a new initialized provisioner object.
@@ -73,8 +72,11 @@ func New(options manager.ControllerOptions, providers providers.Providers) provi
 	return &Provisioner{
 		network: &unikornv1.Network{},
 		options: o,
-		Base: base.Base{
-			Providers: providers,
+		WithIdentity: base.WithIdentity{
+			Base: base.Base{
+				Providers: providers,
+			},
+			IdentityClients: base.NewIdentityClientFactory(o.identityOptions, &o.clientOptions),
 		},
 	}
 }
@@ -84,15 +86,6 @@ var _ provisioners.ManagerProvisioner = &Provisioner{}
 
 func (p *Provisioner) Object() unikornv1core.ManagableResourceInterface {
 	return p.network
-}
-
-func (p *Provisioner) identityClient(ctx context.Context) (identityapi.ClientWithResponsesInterface, error) {
-	client, err := coreclient.FromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return identityclient.New(client, p.options.identityOptions, &p.options.clientOptions).ControllerClient(ctx, p.network)
 }
 
 // Provision implements the Provision interface.
@@ -133,7 +126,7 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 	}
 
 	if v, ok := p.network.Labels[constants.ResourceAPIVersionLabel]; ok && v == constants.MarshalAPIVersion(2) {
-		api, err := p.identityClient(ctx)
+		api, err := p.IdentityClient(ctx, p.network)
 		if err != nil {
 			return err
 		}

--- a/pkg/provisioners/managers/network/provisioner_test.go
+++ b/pkg/provisioners/managers/network/provisioner_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	coreclient "github.com/unikorn-cloud/core/pkg/client"
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
+	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	identitymock "github.com/unikorn-cloud/identity/pkg/openapi/mock"
+	"github.com/unikorn-cloud/identity/pkg/principal"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/handler/common"
+	networkhandler "github.com/unikorn-cloud/region/pkg/handler/network"
+	"github.com/unikorn-cloud/region/pkg/openapi"
+	mockproviders "github.com/unikorn-cloud/region/pkg/providers/mock"
+	mocktypes "github.com/unikorn-cloud/region/pkg/providers/types/mock"
+	networkprovisioner "github.com/unikorn-cloud/region/pkg/provisioners/managers/network"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testNamespace    = "test-namespace"
+	testRegionID     = "region-1"
+	testOrganization = "organization-1"
+	testProject      = "project-1"
+	testAllocationID = "allocation-1"
+	testActor        = "test@example.com"
+	testTokenSubject = "token-actor"
+)
+
+func testClient(t *testing.T, objects ...runtime.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, regionv1.AddToScheme(scheme))
+
+	restMapper := apimeta.NewDefaultRESTMapper([]schema.GroupVersion{regionv1.SchemeGroupVersion})
+	restMapper.Add(regionv1.SchemeGroupVersion.WithKind("Network"), apimeta.RESTScopeNamespace)
+
+	builder := fake.NewClientBuilder().WithScheme(scheme).WithRESTMapper(restMapper)
+	for _, object := range objects {
+		builder = builder.WithRuntimeObjects(object)
+	}
+
+	return builder.Build()
+}
+
+func testRegion() *regionv1.Region {
+	return &regionv1.Region{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRegionID,
+			Namespace: testNamespace,
+		},
+		Spec: regionv1.RegionSpec{
+			Provider: regionv1.ProviderOpenstack,
+		},
+	}
+}
+
+func networkCreateRequest() *openapi.NetworkV2Create {
+	return &openapi.NetworkV2Create{
+		Metadata: coreapi.ResourceWriteMetadata{
+			Name: "test-network",
+		},
+		Spec: openapi.NetworkV2CreateSpec{
+			OrganizationId: testOrganization,
+			ProjectId:      testProject,
+			RegionId:       testRegionID,
+			Prefix:         "10.0.0.0/24",
+			DnsNameservers: []openapi.Ipv4Address{"8.8.8.8"},
+		},
+	}
+}
+
+func networkCreateACL() *identityapi.Acl {
+	return &identityapi.Acl{
+		Organizations: &identityapi.AclOrganizationList{
+			{
+				Id: testOrganization,
+				Projects: &identityapi.AclProjectList{
+					{
+						Id: testProject,
+						Endpoints: identityapi.AclEndpoints{
+							{
+								Name:       "region:networks:v2",
+								Operations: identityapi.AclOperations{identityapi.Create},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func withPrincipal(ctx context.Context) context.Context {
+	ctx = authorization.NewContext(ctx, &authorization.Info{
+		Userinfo: &identityapi.Userinfo{
+			Sub: testTokenSubject,
+		},
+	})
+
+	return principal.NewContext(ctx, &principal.Principal{
+		Actor: testActor,
+	})
+}
+
+func expectAllocationCreate(t *testing.T, mockIdentity *identitymock.MockClientWithResponsesInterface) {
+	t.Helper()
+
+	mockIdentity.EXPECT().
+		PostApiV1OrganizationsOrganizationIDProjectsProjectIDAllocationsWithResponse(gomock.Any(), testOrganization, testProject, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, body identityapi.AllocationWrite, _ ...identityapi.RequestEditorFn) (*identityapi.PostApiV1OrganizationsOrganizationIDProjectsProjectIDAllocationsResponse, error) {
+			require.Equal(t, identityapi.ResourceAllocationList{
+				{Kind: "networks", Committed: 1, Reserved: 0},
+			}, body.Spec.Allocations)
+
+			return &identityapi.PostApiV1OrganizationsOrganizationIDProjectsProjectIDAllocationsResponse{
+				HTTPResponse: &http.Response{StatusCode: http.StatusCreated},
+				JSON201: &identityapi.AllocationRead{
+					Metadata: coreapi.ProjectScopedResourceReadMetadata{
+						Id:             testAllocationID,
+						OrganizationId: testOrganization,
+						ProjectId:      testProject,
+					},
+				},
+			}, nil
+		})
+}
+
+func expectAllocationDelete(mockIdentity *identitymock.MockClientWithResponsesInterface) {
+	mockIdentity.EXPECT().
+		DeleteApiV1OrganizationsOrganizationIDProjectsProjectIDAllocationsAllocationIDWithResponse(gomock.Any(), testOrganization, testProject, testAllocationID).
+		Return(&identityapi.DeleteApiV1OrganizationsOrganizationIDProjectsProjectIDAllocationsAllocationIDResponse{
+			HTTPResponse: &http.Response{StatusCode: http.StatusAccepted},
+		}, nil)
+}
+
+func getNetwork(t *testing.T, cli client.Client, networkID string) *regionv1.Network {
+	t.Helper()
+
+	network := &regionv1.Network{}
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{Namespace: testNamespace, Name: networkID}, network))
+
+	return network
+}
+
+func TestDeprovision_UnreadyIdentityDeletesAllocation(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	region := testRegion()
+	provider := mocktypes.NewMockProvider(ctrl)
+	provider.EXPECT().Region(gomock.Any()).Return(region, nil)
+
+	providers := mockproviders.NewMockProviders(ctrl)
+	providers.EXPECT().LookupCloud(testRegionID).Return(provider, nil).Times(2)
+
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+	expectAllocationCreate(t, mockIdentity)
+	expectAllocationDelete(mockIdentity)
+
+	cli := testClient(t, region)
+	handlerClient := networkhandler.New(common.ClientArgs{
+		Client:    cli,
+		Namespace: testNamespace,
+		Providers: providers,
+		Identity:  mockIdentity,
+	})
+
+	ctx := withPrincipal(rbac.NewContext(t.Context(), networkCreateACL()))
+	created, err := handlerClient.CreateV2(ctx, networkCreateRequest())
+	require.NoError(t, err)
+
+	network := getNetwork(t, cli, created.Metadata.Id)
+	require.Equal(t, constants.MarshalAPIVersion(2), network.Labels[constants.ResourceAPIVersionLabel])
+	require.Equal(t, testAllocationID, network.Annotations[coreconstants.AllocationAnnotation])
+	require.Equal(t, testOrganization, network.Labels[coreconstants.OrganizationPrincipalLabel])
+	require.Equal(t, testProject, network.Labels[coreconstants.ProjectPrincipalLabel])
+	require.Nil(t, network.Status.Openstack)
+
+	identity := &regionv1.Identity{}
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{
+		Namespace: testNamespace,
+		Name:      network.Labels[constants.IdentityLabel],
+	}, identity))
+
+	condition, err := identity.StatusConditionRead(unikornv1core.ConditionAvailable)
+	require.Error(t, err)
+	require.Nil(t, condition)
+
+	provisioner := networkprovisioner.NewForTest(network, providers, mockIdentity)
+	require.NoError(t, provisioner.Deprovision(coreclient.NewContext(t.Context(), cli)))
+}

--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -494,21 +494,29 @@ func (c *APIClient) CreateNetwork(ctx context.Context, request regionopenapi.Net
 }
 
 // GetNetwork gets a specific network by ID.
+// Returns ErrResourceNotFound if the network does not exist.
 func (c *APIClient) GetNetwork(ctx context.Context, networkID string) (*regionopenapi.NetworkV2Read, error) {
 	path := c.endpoints.GetNetwork(networkID)
 
 	//nolint:bodyclose // DoRequest handles response body closing internally
-	_, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
+	resp, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, 0)
 	if err != nil {
 		return nil, fmt.Errorf("getting network: %w", err)
 	}
 
-	var network regionopenapi.NetworkV2Read
-	if err := json.Unmarshal(respBody, &network); err != nil {
-		return nil, fmt.Errorf("unmarshaling network: %w", err)
-	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var network regionopenapi.NetworkV2Read
+		if err := json.Unmarshal(respBody, &network); err != nil {
+			return nil, fmt.Errorf("unmarshaling network: %w", err)
+		}
 
-	return &network, nil
+		return &network, nil
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("network '%s': %w", networkID, coreclient.ErrResourceNotFound)
+	default:
+		return nil, fmt.Errorf("getting network: status %d: %w", resp.StatusCode, coreclient.ErrUnexpectedStatus)
+	}
 }
 
 // UpdateNetwork updates a network resource.
@@ -535,16 +543,24 @@ func (c *APIClient) UpdateNetwork(ctx context.Context, networkID string, request
 }
 
 // DeleteNetwork deletes a network resource.
+// Returns ErrResourceNotFound if the network does not exist.
 func (c *APIClient) DeleteNetwork(ctx context.Context, networkID string) error {
 	path := c.endpoints.DeleteNetwork(networkID)
 
 	//nolint:bodyclose // DoRequest handles response body closing internally
-	_, _, err := c.regionClient.DoRequest(ctx, http.MethodDelete, path, nil, http.StatusAccepted)
+	resp, _, err := c.regionClient.DoRequest(ctx, http.MethodDelete, path, nil, 0)
 	if err != nil {
 		return fmt.Errorf("deleting network: %w", err)
 	}
 
-	return nil
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("network '%s': %w", networkID, coreclient.ErrResourceNotFound)
+	default:
+		return fmt.Errorf("deleting network: status %d: %w", resp.StatusCode, coreclient.ErrUnexpectedStatus)
+	}
 }
 
 // ListLoadBalancers lists all load balancers for a project in a region.
@@ -587,21 +603,29 @@ func (c *APIClient) CreateLoadBalancer(ctx context.Context, request regionopenap
 }
 
 // GetLoadBalancer gets a specific load balancer by ID.
+// Returns ErrResourceNotFound if the load balancer does not exist.
 func (c *APIClient) GetLoadBalancer(ctx context.Context, loadBalancerID string) (*regionopenapi.LoadBalancerV2Read, error) {
 	path := c.endpoints.GetLoadBalancer(loadBalancerID)
 
 	//nolint:bodyclose // DoRequest handles response body closing internally
-	_, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
+	resp, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, 0)
 	if err != nil {
 		return nil, fmt.Errorf("getting loadbalancer: %w", err)
 	}
 
-	var lb regionopenapi.LoadBalancerV2Read
-	if err := json.Unmarshal(respBody, &lb); err != nil {
-		return nil, fmt.Errorf("unmarshaling loadbalancer: %w", err)
-	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var lb regionopenapi.LoadBalancerV2Read
+		if err := json.Unmarshal(respBody, &lb); err != nil {
+			return nil, fmt.Errorf("unmarshaling loadbalancer: %w", err)
+		}
 
-	return &lb, nil
+		return &lb, nil
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("load balancer '%s': %w", loadBalancerID, coreclient.ErrResourceNotFound)
+	default:
+		return nil, fmt.Errorf("getting loadbalancer: status %d: %w", resp.StatusCode, coreclient.ErrUnexpectedStatus)
+	}
 }
 
 // UpdateLoadBalancer updates a load balancer.
@@ -628,16 +652,24 @@ func (c *APIClient) UpdateLoadBalancer(ctx context.Context, loadBalancerID strin
 }
 
 // DeleteLoadBalancer deletes a load balancer.
+// Returns ErrResourceNotFound if the load balancer does not exist.
 func (c *APIClient) DeleteLoadBalancer(ctx context.Context, loadBalancerID string) error {
 	path := c.endpoints.DeleteLoadBalancer(loadBalancerID)
 
 	//nolint:bodyclose // DoRequest handles response body closing internally
-	_, _, err := c.regionClient.DoRequest(ctx, http.MethodDelete, path, nil, http.StatusAccepted)
+	resp, _, err := c.regionClient.DoRequest(ctx, http.MethodDelete, path, nil, 0)
 	if err != nil {
 		return fmt.Errorf("deleting loadbalancer: %w", err)
 	}
 
-	return nil
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("load balancer '%s': %w", loadBalancerID, coreclient.ErrResourceNotFound)
+	default:
+		return fmt.Errorf("deleting loadbalancer: status %d: %w", resp.StatusCode, coreclient.ErrUnexpectedStatus)
+	}
 }
 
 // ListSSHCertificateAuthorities lists SSH certificate authorities for an org and project.

--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -358,6 +358,6 @@ func WaitForLoadBalancerGone(c *APIClient, ctx context.Context, lbID string) {
 		_, err := c.GetLoadBalancer(ctx, lbID)
 		return err
 	}).WithTimeout(2*time.Minute).WithPolling(2*time.Second).
-		Should(And(HaveOccurred(), MatchError(coreclient.ErrUnexpectedStatusCode)),
+		Should(And(HaveOccurred(), MatchError(coreclient.ErrResourceNotFound)),
 			"load balancer should eventually be deleted")
 }

--- a/test/api/suites/auth_test.go
+++ b/test/api/suites/auth_test.go
@@ -1,0 +1,62 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,testpackage,gci // dot imports and package naming standard for Ginkgo, import grouping
+package suites
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/unikorn-cloud/region/test/api"
+)
+
+var _ = Describe("Authentication Enforcement", func() {
+	Context("When requests are made without a valid auth token", func() {
+		var unauthClient *api.APIClient
+
+		BeforeEach(func() {
+			unauthConfig := *config
+			unauthConfig.AuthToken = ""
+			unauthClient = api.NewAPIClientWithConfig(&unauthConfig)
+		})
+
+		Describe("Given no Authorization header on the main API", func() {
+			It("should return 401 when listing regions", func() {
+				path := unauthClient.GetListRegionsPath(config.OrgID)
+				resp, _, err := unauthClient.DoRequest(ctx, http.MethodGet, path, nil, 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+				GinkgoWriter.Printf("Unauthenticated list regions returned %d as expected\n", resp.StatusCode)
+			})
+		})
+
+		Describe("Given no Authorization header on the region service API", func() {
+			It("should return 401 when listing networks", func() {
+				path := unauthClient.GetEndpoints().ListNetworks(config.OrgID, config.ProjectID, config.RegionID)
+				resp, _, err := unauthClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+				GinkgoWriter.Printf("Unauthenticated list networks returned %d as expected\n", resp.StatusCode)
+			})
+		})
+	})
+})

--- a/test/api/suites/filestorage_test.go
+++ b/test/api/suites/filestorage_test.go
@@ -330,6 +330,7 @@ var _ = Describe("File Storage Management", func() {
 		var filestorageID string
 		var filestorageName string
 		var storageClassID string
+		var filestorageDeleteRequested bool
 		var networkID string
 		var networkName string
 
@@ -570,6 +571,7 @@ var _ = Describe("File Storage Management", func() {
 
 				err := regionClient.DeleteFileStorage(ctx, filestorageID)
 				Expect(err).NotTo(HaveOccurred())
+				filestorageDeleteRequested = true
 
 				GinkgoWriter.Printf("Deleted file storage: %s\n", filestorageID)
 
@@ -619,8 +621,11 @@ var _ = Describe("File Storage Management", func() {
 		AfterAll(func() {
 			// Delete storage first to detach from network
 			if filestorageID != "" {
-				GinkgoWriter.Printf("Cleaning up test filestorage: %s\n", filestorageID)
-				Expect(regionClient.DeleteFileStorage(ctx, filestorageID)).To(Succeed())
+				if !filestorageDeleteRequested {
+					GinkgoWriter.Printf("Cleaning up test filestorage: %s\n", filestorageID)
+					Expect(regionClient.DeleteFileStorage(ctx, filestorageID)).To(Succeed())
+					filestorageDeleteRequested = true
+				}
 
 				GinkgoWriter.Printf("Waiting for storage cleanup: %s\n", filestorageID)
 				Eventually(func() error {

--- a/test/api/suites/loadbalancers_test.go
+++ b/test/api/suites/loadbalancers_test.go
@@ -21,6 +21,7 @@ limitations under the License.
 package suites
 
 import (
+	"bytes"
 	"errors"
 	"net/http"
 	"time"
@@ -59,7 +60,7 @@ var _ = Describe("LoadBalancer", func() {
 					}
 					api.WaitForLoadBalancerGone(regionClient, ctx, lbID)
 				}
-				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil {
+				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
 				}
 			})
@@ -69,6 +70,8 @@ var _ = Describe("LoadBalancer", func() {
 			members := []regionopenapi.LoadBalancerMemberV2{
 				{Address: "10.0.1.10", Port: 8080},
 			}
+			var originalVIP *regionopenapi.Ipv4Address
+			var deletedLBID string
 
 			It("creates a load balancer in Pending state", func() {
 				createReq = api.NewLoadBalancerPayload(networkID).
@@ -170,10 +173,10 @@ var _ = Describe("LoadBalancer", func() {
 				Expect(roundTrip.Spec.Listeners[0].Pool.Members).To(Equal(updatedMembers))
 			})
 
-			It("eventually clears status.publicIP when publicIP is toggled to false", func() {
+			It("accepts an update toggling publicIP to false", func() {
 				current, err := regionClient.GetLoadBalancer(ctx, lbID)
 				Expect(err).NotTo(HaveOccurred())
-				originalVIP := current.Status.VipAddress
+				originalVIP = current.Status.VipAddress
 
 				spec := current.Spec
 				spec.PublicIP = ptr.To(false)
@@ -185,7 +188,9 @@ var _ = Describe("LoadBalancer", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(putResp.Spec.PublicIP).NotTo(BeNil())
 				Expect(*putResp.Spec.PublicIP).To(BeFalse())
+			})
 
+			It("eventually clears status.publicIP and preserves the VIP after publicIP is toggled", func() {
 				Eventually(func(g Gomega) *regionopenapi.Ipv4Address {
 					got, err := regionClient.GetLoadBalancer(ctx, lbID)
 					g.Expect(err).NotTo(HaveOccurred())
@@ -197,16 +202,18 @@ var _ = Describe("LoadBalancer", func() {
 				Expect(final.Status.VipAddress).To(Equal(originalVIP), "VIP must be preserved across publicIP toggle")
 			})
 
-			It("deletes the load balancer and confirms it disappears", func() {
+			It("deletes the load balancer", func() {
+				deletedLBID = lbID
 				Expect(regionClient.DeleteLoadBalancer(ctx, lbID)).To(Succeed())
 				api.WaitForLoadBalancerGone(regionClient, ctx, lbID)
+				lbID = "" // suppress cleanup re-delete
+			})
 
-				path := regionClient.GetEndpoints().GetLoadBalancer(lbID)
+			It("is no longer accessible after deletion", func() {
+				path := regionClient.GetEndpoints().GetLoadBalancer(deletedLBID)
 				resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).NotTo(Equal(http.StatusOK))
-
-				lbID = "" // suppress cleanup re-delete
 			})
 		})
 	})
@@ -232,7 +239,7 @@ var _ = Describe("LoadBalancer", func() {
 					}
 					api.WaitForLoadBalancerGone(regionClient, ctx, lbID)
 				}
-				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil {
+				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
 				}
 			})
@@ -293,7 +300,7 @@ var _ = Describe("LoadBalancer", func() {
 					}
 					api.WaitForLoadBalancerGone(regionClient, ctx, lbID)
 				}
-				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil {
+				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
 				}
 			})
@@ -336,6 +343,33 @@ var _ = Describe("LoadBalancer", func() {
 
 				api.WaitForLoadBalancerGone(regionClient, ctx, lbID)
 				lbID = "" // suppress cleanup re-delete
+			})
+		})
+	})
+
+	Context("When accessing a load balancer that does not exist", func() {
+		Describe("Given a non-existent load balancer ID", func() {
+			It("should return not found on GET", func() {
+				_, err := regionClient.GetLoadBalancer(ctx, "00000000-0000-0000-0000-000000000000")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+
+			It("should return not found on DELETE", func() {
+				err := regionClient.DeleteLoadBalancer(ctx, "00000000-0000-0000-0000-000000000000")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("When creating a load balancer with an invalid request body", func() {
+		Describe("Given an empty request body", func() {
+			It("should reject the request", func() {
+				path := regionClient.GetEndpoints().CreateLoadBalancer()
+				resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodPost, path, bytes.NewReader([]byte("")), 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(BeNumerically(">=", http.StatusBadRequest))
 			})
 		})
 	})

--- a/test/api/suites/networks_test.go
+++ b/test/api/suites/networks_test.go
@@ -21,6 +21,8 @@ limitations under the License.
 package suites
 
 import (
+	"bytes"
+	"errors"
 	"net/http"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
 	regionopenapi "github.com/unikorn-cloud/region/pkg/openapi"
 	"github.com/unikorn-cloud/region/test/api"
 )
@@ -150,43 +153,106 @@ var _ = Describe("Network Management", func() {
 			})
 		})
 
-		Describe("Given the network is deleted", func() {
-			It("should succeed", func() {
-				if networkID == "" {
-					Skip("No network ID available - create step may have been skipped or failed")
-				}
+		Context("When the network is deleted", func() {
+			Describe("Given a provisioned network", func() {
+				It("should succeed", func() {
+					if networkID == "" {
+						Skip("No network ID available - create step may have been skipped or failed")
+					}
 
-				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
+					Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
 
-				GinkgoWriter.Printf("Deleted network: %s\n", networkID)
-				deletedNetworkID = networkID
-				networkID = "" // suppress AfterAll cleanup — already deleted
-			})
+					GinkgoWriter.Printf("Deleted network: %s\n", networkID)
+					deletedNetworkID = networkID
+					networkID = "" // suppress AfterAll cleanup — already deleted
+				})
 
-			It("should return 404 on subsequent reads", func() {
-				if deletedNetworkID == "" {
-					Skip("No deleted network ID available - delete step may have been skipped or failed")
-				}
+				It("should return 404 on subsequent reads", func() {
+					if deletedNetworkID == "" {
+						Skip("No deleted network ID available - delete step may have been skipped or failed")
+					}
 
-				Eventually(func() bool {
-					_, err := regionClient.GetNetwork(ctx, deletedNetworkID)
-					return err != nil
-				}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(BeTrue())
+					Eventually(func() bool {
+						_, err := regionClient.GetNetwork(ctx, deletedNetworkID)
+						return err != nil
+					}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(BeTrue())
 
-				path := regionClient.GetEndpoints().GetNetwork(deletedNetworkID)
-				resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+					path := regionClient.GetEndpoints().GetNetwork(deletedNetworkID)
+					resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 
-				GinkgoWriter.Printf("Confirmed network deleted: %s\n", deletedNetworkID)
+					GinkgoWriter.Printf("Confirmed network deleted: %s\n", deletedNetworkID)
+				})
 			})
 		})
 
 		AfterAll(func() {
 			if networkID != "" {
 				GinkgoWriter.Printf("Cleaning up network: %s\n", networkID)
-				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
+				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
+					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
+				}
 			}
+		})
+	})
+
+	Context("When accessing a network that does not exist", func() {
+		Describe("Given a non-existent network ID", func() {
+			It("should return not found on GET", func() {
+				_, err := regionClient.GetNetwork(ctx, "00000000-0000-0000-0000-000000000000")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+
+			It("should return not found on DELETE", func() {
+				err := regionClient.DeleteNetwork(ctx, "00000000-0000-0000-0000-000000000000")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("When creating a network with an invalid request body", func() {
+		Describe("Given an empty request body", func() {
+			It("should reject the request", func() {
+				path := regionClient.GetEndpoints().CreateNetwork()
+				resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodPost, path, bytes.NewReader([]byte("")), 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(BeNumerically(">=", http.StatusBadRequest))
+			})
+		})
+	})
+
+	Context("When testing cross-organization resource isolation", Ordered, func() {
+		var networkID string
+
+		BeforeAll(func() {
+			if secondaryClient == nil {
+				Skip("TEST_SECONDARY_ORG_ID and TEST_SECONDARY_AUTH_TOKEN not configured")
+			}
+
+			created, err := regionClient.CreateNetwork(ctx, api.NewNetworkPayload(config.OrgID, config.ProjectID, config.RegionID).Build())
+			Expect(err).NotTo(HaveOccurred(), "failed to create network fixture")
+			networkID = created.Metadata.Id
+			DeferCleanup(func() {
+				GinkgoWriter.Printf("Cleaning up cross-org isolation network fixture: %s\n", networkID)
+				_ = regionClient.DeleteNetwork(ctx, networkID)
+			})
+			GinkgoWriter.Printf("Created network fixture for cross-org isolation test: %s\n", networkID)
+		})
+
+		Describe("Given a network owned by the primary organization", func() {
+			It("should not be accessible via GET by the secondary organization", func() {
+				path := secondaryClient.GetEndpoints().GetNetwork(networkID)
+				resp, _, err := secondaryClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Or(
+					Equal(http.StatusNotFound),
+					Equal(http.StatusForbidden),
+				))
+				GinkgoWriter.Printf("Cross-org GET network %s returned %d as expected\n", networkID, resp.StatusCode)
+			})
 		})
 	})
 })

--- a/test/api/suites/securitygroups_test.go
+++ b/test/api/suites/securitygroups_test.go
@@ -21,7 +21,9 @@ limitations under the License.
 package suites
 
 import (
+	"bytes"
 	"errors"
+	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -47,7 +49,9 @@ var _ = Describe("SecurityGroup", func() {
 			networkID = network.Metadata.Id
 			DeferCleanup(func() {
 				GinkgoWriter.Printf("Cleaning up network fixture: %s\n", networkID)
-				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
+				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
+					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
+				}
 			})
 			GinkgoWriter.Printf("Created network fixture: %s\n", networkID)
 
@@ -60,12 +64,16 @@ var _ = Describe("SecurityGroup", func() {
 					return
 				}
 				GinkgoWriter.Printf("Cleaning up security group: %s\n", sgID)
-				Expect(regionClient.DeleteSecurityGroup(ctx, sgID)).To(Succeed())
+				if err := regionClient.DeleteSecurityGroup(ctx, sgID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
+					GinkgoWriter.Printf("Warning: cleanup delete security group %s: %v\n", sgID, err)
+				}
 			})
 			GinkgoWriter.Printf("Created security group: %s (%s)\n", created.Metadata.Name, sgID)
 		})
 
 		Describe("Given a network fixture and valid configuration", func() {
+			var deletedSGID string
+
 			It("should create a security group with correct response fields", func() {
 				Expect(sgID).NotTo(BeEmpty())
 				Expect(createReq.Metadata.Name).NotTo(BeEmpty())
@@ -134,21 +142,23 @@ var _ = Describe("SecurityGroup", func() {
 				GinkgoWriter.Printf("Updated security group rules: %s\n", sgID)
 			})
 
-			It("should delete the security group and confirm it is no longer found", func() {
-				deletedID := sgID
-				Expect(regionClient.DeleteSecurityGroup(ctx, deletedID)).To(Succeed())
+			It("should delete the security group", func() {
+				deletedSGID = sgID
+				Expect(regionClient.DeleteSecurityGroup(ctx, deletedSGID)).To(Succeed())
 				sgID = "" // suppress DeferCleanup — already deleted
-				GinkgoWriter.Printf("Deleted security group: %s\n", deletedID)
+				GinkgoWriter.Printf("Deleted security group: %s\n", deletedSGID)
+			})
 
+			It("should not be found after deletion", func() {
 				Eventually(func() error {
-					_, err := regionClient.GetSecurityGroup(ctx, deletedID)
+					_, err := regionClient.GetSecurityGroup(ctx, deletedSGID)
 					return err
 				}).WithTimeout(30*time.Second).
 					WithPolling(2*time.Second).
 					Should(And(HaveOccurred(), MatchError(coreclient.ErrResourceNotFound)),
 						"deleted security group should eventually return not found")
 
-				GinkgoWriter.Printf("Confirmed security group deleted: %s\n", deletedID)
+				GinkgoWriter.Printf("Confirmed security group deleted: %s\n", deletedSGID)
 			})
 		})
 	})
@@ -159,6 +169,17 @@ var _ = Describe("SecurityGroup", func() {
 				_, err := regionClient.GetSecurityGroup(ctx, "00000000-0000-0000-0000-000000000000")
 				Expect(err).To(HaveOccurred())
 				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("When creating a security group with an invalid request body", func() {
+		Describe("Given an empty request body", func() {
+			It("should reject the request", func() {
+				path := regionClient.GetEndpoints().CreateSecurityGroup()
+				resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodPost, path, bytes.NewReader([]byte("")), 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(BeNumerically(">=", http.StatusBadRequest))
 			})
 		})
 	})


### PR DESCRIPTION
In end to end testing, we sometimes see left-over allocations. In at least one case it's caused by a test failing before the an implicitly-created OpenStack Identity is ready. The cleanup thunk deletes the Network, but this doesn't clean everything up.

This fix comes in three parts:
- refactor the provisioners, elaborating on the base.Base struct, so that the identity client (used for allocations) can be injected;
- add a test that the deletion does release the allocation;
- fix the underlying problem by only attempting to delete the OpenStack network if the identity is ready or it's already been created in OpenStack

Reversing the latter two steps shows that the test fails without the fix, and succeeds with it.
