### PR TITLE
test(api): expand integration test coverage for LBs, networks, and auth

### DIFF
--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -494,21 +494,29 @@ func (c *APIClient) CreateNetwork(ctx context.Context, request regionopenapi.Net
 }
 
 // GetNetwork gets a specific network by ID.
+// Returns ErrResourceNotFound if the network does not exist.
 func (c *APIClient) GetNetwork(ctx context.Context, networkID string) (*regionopenapi.NetworkV2Read, error) {
 	path := c.endpoints.GetNetwork(networkID)
 
 	//nolint:bodyclose // DoRequest handles response body closing internally
-	_, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
+	resp, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, 0)
 	if err != nil {
 		return nil, fmt.Errorf("getting network: %w", err)
 	}
 
-	var network regionopenapi.NetworkV2Read
-	if err := json.Unmarshal(respBody, &network); err != nil {
-		return nil, fmt.Errorf("unmarshaling network: %w", err)
-	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var network regionopenapi.NetworkV2Read
+		if err := json.Unmarshal(respBody, &network); err != nil {
+			return nil, fmt.Errorf("unmarshaling network: %w", err)
+		}
 
-	return &network, nil
+		return &network, nil
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("network '%s': %w", networkID, coreclient.ErrResourceNotFound)
+	default:
+		return nil, fmt.Errorf("getting network: status %d: %w", resp.StatusCode, coreclient.ErrUnexpectedStatus)
+	}
 }
 
 // UpdateNetwork updates a network resource.
@@ -535,16 +543,24 @@ func (c *APIClient) UpdateNetwork(ctx context.Context, networkID string, request
 }
 
 // DeleteNetwork deletes a network resource.
+// Returns ErrResourceNotFound if the network does not exist.
 func (c *APIClient) DeleteNetwork(ctx context.Context, networkID string) error {
 	path := c.endpoints.DeleteNetwork(networkID)
 
 	//nolint:bodyclose // DoRequest handles response body closing internally
-	_, _, err := c.regionClient.DoRequest(ctx, http.MethodDelete, path, nil, http.StatusAccepted)
+	resp, _, err := c.regionClient.DoRequest(ctx, http.MethodDelete, path, nil, 0)
 	if err != nil {
 		return fmt.Errorf("deleting network: %w", err)
 	}
 
-	return nil
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("network '%s': %w", networkID, coreclient.ErrResourceNotFound)
+	default:
+		return fmt.Errorf("deleting network: status %d: %w", resp.StatusCode, coreclient.ErrUnexpectedStatus)
+	}
 }
 
 // ListLoadBalancers lists all load balancers for a project in a region.
@@ -587,21 +603,29 @@ func (c *APIClient) CreateLoadBalancer(ctx context.Context, request regionopenap
 }
 
 // GetLoadBalancer gets a specific load balancer by ID.
+// Returns ErrResourceNotFound if the load balancer does not exist.
 func (c *APIClient) GetLoadBalancer(ctx context.Context, loadBalancerID string) (*regionopenapi.LoadBalancerV2Read, error) {
 	path := c.endpoints.GetLoadBalancer(loadBalancerID)
 
 	//nolint:bodyclose // DoRequest handles response body closing internally
-	_, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
+	resp, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, 0)
 	if err != nil {
 		return nil, fmt.Errorf("getting loadbalancer: %w", err)
 	}
 
-	var lb regionopenapi.LoadBalancerV2Read
-	if err := json.Unmarshal(respBody, &lb); err != nil {
-		return nil, fmt.Errorf("unmarshaling loadbalancer: %w", err)
-	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var lb regionopenapi.LoadBalancerV2Read
+		if err := json.Unmarshal(respBody, &lb); err != nil {
+			return nil, fmt.Errorf("unmarshaling loadbalancer: %w", err)
+		}
 
-	return &lb, nil
+		return &lb, nil
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("load balancer '%s': %w", loadBalancerID, coreclient.ErrResourceNotFound)
+	default:
+		return nil, fmt.Errorf("getting loadbalancer: status %d: %w", resp.StatusCode, coreclient.ErrUnexpectedStatus)
+	}
 }
 
 // UpdateLoadBalancer updates a load balancer.
@@ -628,16 +652,24 @@ func (c *APIClient) UpdateLoadBalancer(ctx context.Context, loadBalancerID strin
 }
 
 // DeleteLoadBalancer deletes a load balancer.
+// Returns ErrResourceNotFound if the load balancer does not exist.
 func (c *APIClient) DeleteLoadBalancer(ctx context.Context, loadBalancerID string) error {
 	path := c.endpoints.DeleteLoadBalancer(loadBalancerID)
 
 	//nolint:bodyclose // DoRequest handles response body closing internally
-	_, _, err := c.regionClient.DoRequest(ctx, http.MethodDelete, path, nil, http.StatusAccepted)
+	resp, _, err := c.regionClient.DoRequest(ctx, http.MethodDelete, path, nil, 0)
 	if err != nil {
 		return fmt.Errorf("deleting loadbalancer: %w", err)
 	}
 
-	return nil
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("load balancer '%s': %w", loadBalancerID, coreclient.ErrResourceNotFound)
+	default:
+		return fmt.Errorf("deleting loadbalancer: status %d: %w", resp.StatusCode, coreclient.ErrUnexpectedStatus)
+	}
 }
 
 // ListSSHCertificateAuthorities lists SSH certificate authorities for an org and project.

--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -358,6 +358,6 @@ func WaitForLoadBalancerGone(c *APIClient, ctx context.Context, lbID string) {
 		_, err := c.GetLoadBalancer(ctx, lbID)
 		return err
 	}).WithTimeout(2*time.Minute).WithPolling(2*time.Second).
-		Should(And(HaveOccurred(), MatchError(coreclient.ErrUnexpectedStatusCode)),
+		Should(And(HaveOccurred(), MatchError(coreclient.ErrResourceNotFound)),
 			"load balancer should eventually be deleted")
 }

--- a/test/api/suites/auth_test.go
+++ b/test/api/suites/auth_test.go
@@ -1,0 +1,62 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,testpackage,gci // dot imports and package naming standard for Ginkgo, import grouping
+package suites
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/unikorn-cloud/region/test/api"
+)
+
+var _ = Describe("Authentication Enforcement", func() {
+	Context("When requests are made without a valid auth token", func() {
+		var unauthClient *api.APIClient
+
+		BeforeEach(func() {
+			unauthConfig := *config
+			unauthConfig.AuthToken = ""
+			unauthClient = api.NewAPIClientWithConfig(&unauthConfig)
+		})
+
+		Describe("Given no Authorization header on the main API", func() {
+			It("should return 401 when listing regions", func() {
+				path := unauthClient.GetListRegionsPath(config.OrgID)
+				resp, _, err := unauthClient.DoRequest(ctx, http.MethodGet, path, nil, 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+				GinkgoWriter.Printf("Unauthenticated list regions returned %d as expected\n", resp.StatusCode)
+			})
+		})
+
+		Describe("Given no Authorization header on the region service API", func() {
+			It("should return 401 when listing networks", func() {
+				path := unauthClient.GetEndpoints().ListNetworks(config.OrgID, config.ProjectID, config.RegionID)
+				resp, _, err := unauthClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+				GinkgoWriter.Printf("Unauthenticated list networks returned %d as expected\n", resp.StatusCode)
+			})
+		})
+	})
+})

--- a/test/api/suites/loadbalancers_test.go
+++ b/test/api/suites/loadbalancers_test.go
@@ -60,7 +60,7 @@ var _ = Describe("LoadBalancer", func() {
 					}
 					api.WaitForLoadBalancerGone(regionClient, ctx, lbID)
 				}
-				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil {
+				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
 				}
 			})
@@ -70,6 +70,8 @@ var _ = Describe("LoadBalancer", func() {
 			members := []regionopenapi.LoadBalancerMemberV2{
 				{Address: "10.0.1.10", Port: 8080},
 			}
+			var originalVIP *regionopenapi.Ipv4Address
+			var deletedLBID string
 
 			It("creates a load balancer in Pending state", func() {
 				createReq = api.NewLoadBalancerPayload(networkID).
@@ -171,10 +173,10 @@ var _ = Describe("LoadBalancer", func() {
 				Expect(roundTrip.Spec.Listeners[0].Pool.Members).To(Equal(updatedMembers))
 			})
 
-			It("eventually clears status.publicIP when publicIP is toggled to false", func() {
+			It("accepts an update toggling publicIP to false", func() {
 				current, err := regionClient.GetLoadBalancer(ctx, lbID)
 				Expect(err).NotTo(HaveOccurred())
-				originalVIP := current.Status.VipAddress
+				originalVIP = current.Status.VipAddress
 
 				spec := current.Spec
 				spec.PublicIP = ptr.To(false)
@@ -186,7 +188,9 @@ var _ = Describe("LoadBalancer", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(putResp.Spec.PublicIP).NotTo(BeNil())
 				Expect(*putResp.Spec.PublicIP).To(BeFalse())
+			})
 
+			It("eventually clears status.publicIP and preserves the VIP after publicIP is toggled", func() {
 				Eventually(func(g Gomega) *regionopenapi.Ipv4Address {
 					got, err := regionClient.GetLoadBalancer(ctx, lbID)
 					g.Expect(err).NotTo(HaveOccurred())
@@ -198,16 +202,18 @@ var _ = Describe("LoadBalancer", func() {
 				Expect(final.Status.VipAddress).To(Equal(originalVIP), "VIP must be preserved across publicIP toggle")
 			})
 
-			It("deletes the load balancer and confirms it disappears", func() {
+			It("deletes the load balancer", func() {
+				deletedLBID = lbID
 				Expect(regionClient.DeleteLoadBalancer(ctx, lbID)).To(Succeed())
 				api.WaitForLoadBalancerGone(regionClient, ctx, lbID)
+				lbID = "" // suppress cleanup re-delete
+			})
 
-				path := regionClient.GetEndpoints().GetLoadBalancer(lbID)
+			It("is no longer accessible after deletion", func() {
+				path := regionClient.GetEndpoints().GetLoadBalancer(deletedLBID)
 				resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).NotTo(Equal(http.StatusOK))
-
-				lbID = "" // suppress cleanup re-delete
 			})
 		})
 	})
@@ -233,7 +239,7 @@ var _ = Describe("LoadBalancer", func() {
 					}
 					api.WaitForLoadBalancerGone(regionClient, ctx, lbID)
 				}
-				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil {
+				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
 				}
 			})
@@ -294,7 +300,7 @@ var _ = Describe("LoadBalancer", func() {
 					}
 					api.WaitForLoadBalancerGone(regionClient, ctx, lbID)
 				}
-				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil {
+				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
 				}
 			})

--- a/test/api/suites/loadbalancers_test.go
+++ b/test/api/suites/loadbalancers_test.go
@@ -21,6 +21,7 @@ limitations under the License.
 package suites
 
 import (
+	"bytes"
 	"errors"
 	"net/http"
 	"time"
@@ -336,6 +337,33 @@ var _ = Describe("LoadBalancer", func() {
 
 				api.WaitForLoadBalancerGone(regionClient, ctx, lbID)
 				lbID = "" // suppress cleanup re-delete
+			})
+		})
+	})
+
+	Context("When accessing a load balancer that does not exist", func() {
+		Describe("Given a non-existent load balancer ID", func() {
+			It("should return not found on GET", func() {
+				_, err := regionClient.GetLoadBalancer(ctx, "00000000-0000-0000-0000-000000000000")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+
+			It("should return not found on DELETE", func() {
+				err := regionClient.DeleteLoadBalancer(ctx, "00000000-0000-0000-0000-000000000000")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("When creating a load balancer with an invalid request body", func() {
+		Describe("Given an empty request body", func() {
+			It("should reject the request", func() {
+				path := regionClient.GetEndpoints().CreateLoadBalancer()
+				resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodPost, path, bytes.NewReader([]byte("")), 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(BeNumerically(">=", http.StatusBadRequest))
 			})
 		})
 	})

--- a/test/api/suites/networks_test.go
+++ b/test/api/suites/networks_test.go
@@ -21,6 +21,8 @@ limitations under the License.
 package suites
 
 import (
+	"bytes"
+	"errors"
 	"net/http"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
 	regionopenapi "github.com/unikorn-cloud/region/pkg/openapi"
 	"github.com/unikorn-cloud/region/test/api"
 )
@@ -187,6 +190,65 @@ var _ = Describe("Network Management", func() {
 				GinkgoWriter.Printf("Cleaning up network: %s\n", networkID)
 				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
 			}
+		})
+	})
+
+	Context("When accessing a network that does not exist", func() {
+		Describe("Given a non-existent network ID", func() {
+			It("should return not found on GET", func() {
+				_, err := regionClient.GetNetwork(ctx, "00000000-0000-0000-0000-000000000000")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+
+			It("should return not found on DELETE", func() {
+				err := regionClient.DeleteNetwork(ctx, "00000000-0000-0000-0000-000000000000")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("When creating a network with an invalid request body", func() {
+		Describe("Given an empty request body", func() {
+			It("should reject the request", func() {
+				path := regionClient.GetEndpoints().CreateNetwork()
+				resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodPost, path, bytes.NewReader([]byte("")), 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(BeNumerically(">=", http.StatusBadRequest))
+			})
+		})
+	})
+
+	Context("When a secondary organization attempts to access a network by ID", Ordered, func() {
+		var networkID string
+
+		BeforeAll(func() {
+			if secondaryClient == nil {
+				Skip("TEST_SECONDARY_ORG_ID and TEST_SECONDARY_AUTH_TOKEN not configured")
+			}
+
+			created, err := regionClient.CreateNetwork(ctx, api.NewNetworkPayload(config.OrgID, config.ProjectID, config.RegionID).Build())
+			Expect(err).NotTo(HaveOccurred(), "failed to create network fixture")
+			networkID = created.Metadata.Id
+			DeferCleanup(func() {
+				GinkgoWriter.Printf("Cleaning up cross-org isolation network fixture: %s\n", networkID)
+				_ = regionClient.DeleteNetwork(ctx, networkID)
+			})
+			GinkgoWriter.Printf("Created network fixture for cross-org isolation test: %s\n", networkID)
+		})
+
+		Describe("Given a network owned by the primary organization", func() {
+			It("should not be accessible via GET by the secondary organization", func() {
+				path := secondaryClient.GetEndpoints().GetNetwork(networkID)
+				resp, _, err := secondaryClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Or(
+					Equal(http.StatusNotFound),
+					Equal(http.StatusForbidden),
+				))
+				GinkgoWriter.Printf("Cross-org GET network %s returned %d as expected\n", networkID, resp.StatusCode)
+			})
 		})
 	})
 })

--- a/test/api/suites/networks_test.go
+++ b/test/api/suites/networks_test.go
@@ -153,42 +153,46 @@ var _ = Describe("Network Management", func() {
 			})
 		})
 
-		Describe("Given the network is deleted", func() {
-			It("should succeed", func() {
-				if networkID == "" {
-					Skip("No network ID available - create step may have been skipped or failed")
-				}
+		Context("When the network is deleted", func() {
+			Describe("Given a provisioned network", func() {
+				It("should succeed", func() {
+					if networkID == "" {
+						Skip("No network ID available - create step may have been skipped or failed")
+					}
 
-				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
+					Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
 
-				GinkgoWriter.Printf("Deleted network: %s\n", networkID)
-				deletedNetworkID = networkID
-				networkID = "" // suppress AfterAll cleanup — already deleted
-			})
+					GinkgoWriter.Printf("Deleted network: %s\n", networkID)
+					deletedNetworkID = networkID
+					networkID = "" // suppress AfterAll cleanup — already deleted
+				})
 
-			It("should return 404 on subsequent reads", func() {
-				if deletedNetworkID == "" {
-					Skip("No deleted network ID available - delete step may have been skipped or failed")
-				}
+				It("should return 404 on subsequent reads", func() {
+					if deletedNetworkID == "" {
+						Skip("No deleted network ID available - delete step may have been skipped or failed")
+					}
 
-				Eventually(func() bool {
-					_, err := regionClient.GetNetwork(ctx, deletedNetworkID)
-					return err != nil
-				}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(BeTrue())
+					Eventually(func() bool {
+						_, err := regionClient.GetNetwork(ctx, deletedNetworkID)
+						return err != nil
+					}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(BeTrue())
 
-				path := regionClient.GetEndpoints().GetNetwork(deletedNetworkID)
-				resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+					path := regionClient.GetEndpoints().GetNetwork(deletedNetworkID)
+					resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 
-				GinkgoWriter.Printf("Confirmed network deleted: %s\n", deletedNetworkID)
+					GinkgoWriter.Printf("Confirmed network deleted: %s\n", deletedNetworkID)
+				})
 			})
 		})
 
 		AfterAll(func() {
 			if networkID != "" {
 				GinkgoWriter.Printf("Cleaning up network: %s\n", networkID)
-				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
+				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
+					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
+				}
 			}
 		})
 	})
@@ -220,7 +224,7 @@ var _ = Describe("Network Management", func() {
 		})
 	})
 
-	Context("When a secondary organization attempts to access a network by ID", Ordered, func() {
+	Context("When testing cross-organization resource isolation", Ordered, func() {
 		var networkID string
 
 		BeforeAll(func() {

--- a/test/api/suites/securitygroups_test.go
+++ b/test/api/suites/securitygroups_test.go
@@ -49,7 +49,9 @@ var _ = Describe("SecurityGroup", func() {
 			networkID = network.Metadata.Id
 			DeferCleanup(func() {
 				GinkgoWriter.Printf("Cleaning up network fixture: %s\n", networkID)
-				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
+				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
+					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
+				}
 			})
 			GinkgoWriter.Printf("Created network fixture: %s\n", networkID)
 
@@ -62,12 +64,16 @@ var _ = Describe("SecurityGroup", func() {
 					return
 				}
 				GinkgoWriter.Printf("Cleaning up security group: %s\n", sgID)
-				Expect(regionClient.DeleteSecurityGroup(ctx, sgID)).To(Succeed())
+				if err := regionClient.DeleteSecurityGroup(ctx, sgID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
+					GinkgoWriter.Printf("Warning: cleanup delete security group %s: %v\n", sgID, err)
+				}
 			})
 			GinkgoWriter.Printf("Created security group: %s (%s)\n", created.Metadata.Name, sgID)
 		})
 
 		Describe("Given a network fixture and valid configuration", func() {
+			var deletedSGID string
+
 			It("should create a security group with correct response fields", func() {
 				Expect(sgID).NotTo(BeEmpty())
 				Expect(createReq.Metadata.Name).NotTo(BeEmpty())
@@ -136,21 +142,23 @@ var _ = Describe("SecurityGroup", func() {
 				GinkgoWriter.Printf("Updated security group rules: %s\n", sgID)
 			})
 
-			It("should delete the security group and confirm it is no longer found", func() {
-				deletedID := sgID
-				Expect(regionClient.DeleteSecurityGroup(ctx, deletedID)).To(Succeed())
+			It("should delete the security group", func() {
+				deletedSGID = sgID
+				Expect(regionClient.DeleteSecurityGroup(ctx, deletedSGID)).To(Succeed())
 				sgID = "" // suppress DeferCleanup — already deleted
-				GinkgoWriter.Printf("Deleted security group: %s\n", deletedID)
+				GinkgoWriter.Printf("Deleted security group: %s\n", deletedSGID)
+			})
 
+			It("should not be found after deletion", func() {
 				Eventually(func() error {
-					_, err := regionClient.GetSecurityGroup(ctx, deletedID)
+					_, err := regionClient.GetSecurityGroup(ctx, deletedSGID)
 					return err
 				}).WithTimeout(30*time.Second).
 					WithPolling(2*time.Second).
 					Should(And(HaveOccurred(), MatchError(coreclient.ErrResourceNotFound)),
 						"deleted security group should eventually return not found")
 
-				GinkgoWriter.Printf("Confirmed security group deleted: %s\n", deletedID)
+				GinkgoWriter.Printf("Confirmed security group deleted: %s\n", deletedSGID)
 			})
 		})
 	})

--- a/test/api/suites/securitygroups_test.go
+++ b/test/api/suites/securitygroups_test.go
@@ -21,7 +21,9 @@ limitations under the License.
 package suites
 
 import (
+	"bytes"
 	"errors"
+	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -159,6 +161,17 @@ var _ = Describe("SecurityGroup", func() {
 				_, err := regionClient.GetSecurityGroup(ctx, "00000000-0000-0000-0000-000000000000")
 				Expect(err).To(HaveOccurred())
 				Expect(errors.Is(err, coreclient.ErrResourceNotFound)).To(BeTrue())
+			})
+		})
+	})
+
+	Context("When creating a security group with an invalid request body", func() {
+		Describe("Given an empty request body", func() {
+			It("should reject the request", func() {
+				path := regionClient.GetEndpoints().CreateSecurityGroup()
+				resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodPost, path, bytes.NewReader([]byte("")), 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(BeNumerically(">=", http.StatusBadRequest))
 			})
 		})
 	})


### PR DESCRIPTION
## Changes

### Client fixes
- `GetNetwork`, `DeleteNetwork`, `GetLoadBalancer`, `DeleteLoadBalancer` now use `DoRequest(0)` + explicit
  status switch, matching the pattern used by the security group and SSH CA methods. 404 responses now
  return `ErrResourceNotFound` instead of `ErrUnexpectedStatusCode`.
- `WaitForLoadBalancerGone` updated to match the corrected error type.

### New tests
- **Auth**: unauthenticated requests to both the compute API and region service API return 401.
- **Load balancers**: not-found GET/DELETE, invalid body rejection, idempotent delete (repeated
  deletes return 202/404), UDP listener with no `idleTimeoutSeconds`, publicIP toggle (clears
  `status.publicIP`, preserves VIP address).
- **Networks**: not-found GET/DELETE, invalid body rejection, cross-org isolation (secondary org
  cannot access a network owned by the primary org).
- **Security groups**: invalid body rejection.

Closes INST-935