### PR TITLE
Unblock deleting unprovisioned resources

### DIFF
--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -188,6 +188,9 @@ There are a few Octavia-specific constraints worth preserving:
   load-balancer client pins microversion `2.22` so that protocol is available.
 - Floating IP cleanup runs before cascade-deleting the load balancer because the
   cascade removes the VIP port that otherwise anchors the floating IP lookup.
+- Load balancer delete only proceeds when Octavia reports `ACTIVE` or `ERROR`;
+  `PENDING_*` states are in-flight operations and must be retried after they
+  settle, while `DELETED` or not found are treated as already gone.
 - Delete remains idempotent for resources that failed before Octavia state was
   recorded locally. Missing Octavia endpoints or incomplete service-principal
   state must not keep those never-realized `LoadBalancer` resources stuck on

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -91,6 +91,10 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
 - `OpenstackIdentity` is the remaining persisted provider-state anchor. It
   currently stores the secret-bearing user/project/application-credential and
   bootstrap state needed to operate on behalf of a region `Identity`.
+- Identity deletion treats user-scoped compute cleanup as best effort when the
+  recorded service principal cannot authenticate. The region-level identity
+  cleanup still runs so identities that failed part-way through provisioning do
+  not pin finalizers indefinitely.
 - The package relies heavily on deterministic naming and metadata conventions to
   re-find cloud-side resources. This is a convention-heavy contract, not magic:
   - identity-scoped resources use fixed generated names
@@ -184,6 +188,10 @@ There are a few Octavia-specific constraints worth preserving:
   load-balancer client pins microversion `2.22` so that protocol is available.
 - Floating IP cleanup runs before cascade-deleting the load balancer because the
   cascade removes the VIP port that otherwise anchors the floating IP lookup.
+- Delete remains idempotent for resources that failed before Octavia state was
+  recorded locally. Missing Octavia endpoints or incomplete service-principal
+  state must not keep those never-realized `LoadBalancer` resources stuck on
+  finalizers.
 
 ## Caveats
 

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -1331,6 +1331,18 @@ func (p *Provider) CreateIdentity(ctx context.Context, identity *unikornv1.Ident
 	return nil
 }
 
+func openstackIdentityHasComputeState(identity *unikornv1.OpenstackIdentity) bool {
+	return identity.Spec.SSHKeyName != nil || identity.Spec.ServerGroupID != nil
+}
+
+func canSkipOpenStackIdentityComputeDelete(err error) bool {
+	if gophercloud.ResponseCodeIs(err, http.StatusUnauthorized) {
+		return true
+	}
+
+	return kerrors.IsNotFound(err) || errors.Is(err, coreerrors.ErrConsistency)
+}
+
 // DeleteIdentity cleans up an identity for cloud infrastructure.
 //
 //nolint:cyclop,gocognit
@@ -1344,50 +1356,53 @@ func (p *Provider) DeleteIdentity(ctx context.Context, identity *unikornv1.Ident
 		return nil
 	}
 
-	// User never even created, so nothing else will have been.
-	if openstackIdentity.Spec.UserID == nil {
-		return nil
-	}
-
-	// Rescope to the user/project...
-	compute, err := p.computeFromServicePrincipal(ctx, identity)
-	if err != nil {
-		return err
-	}
-
-	if openstackIdentity.Spec.SSHKeyName != nil {
-		if err := compute.DeleteKeypair(ctx, keyPairName); err != nil {
-			if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+	if openstackIdentityHasComputeState(openstackIdentity) {
+		// Rescope to the user/project to delete project-local compute extras.
+		// If the service principal was never fully usable, continue to
+		// admin-scoped identity cleanup instead of pinning the finalizer.
+		compute, err := p.computeFromServicePrincipal(ctx, identity)
+		if err != nil {
+			if !canSkipOpenStackIdentityComputeDelete(err) {
 				return err
+			}
+		} else {
+			if openstackIdentity.Spec.SSHKeyName != nil {
+				if err := compute.DeleteKeypair(ctx, keyPairName); err != nil {
+					if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) && !canSkipOpenStackIdentityComputeDelete(err) {
+						return err
+					}
+				}
+			}
+
+			if openstackIdentity.Spec.ServerGroupID != nil {
+				if err := compute.DeleteServerGroup(ctx, *openstackIdentity.Spec.ServerGroupID); err != nil {
+					if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) && !canSkipOpenStackIdentityComputeDelete(err) {
+						return err
+					}
+				}
 			}
 		}
 	}
 
-	if openstackIdentity.Spec.ServerGroupID != nil {
-		if err := compute.DeleteServerGroup(ctx, *openstackIdentity.Spec.ServerGroupID); err != nil {
-			if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
-				return err
+	if openstackIdentity.Spec.UserID != nil || openstackIdentity.Spec.ProjectID != nil {
+		identityService, err := p.openstack.identity(ctx)
+		if err != nil {
+			return err
+		}
+
+		if openstackIdentity.Spec.UserID != nil {
+			if err := identityService.DeleteUser(ctx, *openstackIdentity.Spec.UserID); err != nil {
+				if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+					return err
+				}
 			}
 		}
-	}
 
-	identityService, err := p.openstack.identity(ctx)
-	if err != nil {
-		return err
-	}
-
-	if openstackIdentity.Spec.UserID != nil {
-		if err := identityService.DeleteUser(ctx, *openstackIdentity.Spec.UserID); err != nil {
-			if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
-				return err
-			}
-		}
-	}
-
-	if openstackIdentity.Spec.ProjectID != nil {
-		if err := identityService.DeleteProject(ctx, *openstackIdentity.Spec.ProjectID); err != nil {
-			if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
-				return err
+		if openstackIdentity.Spec.ProjectID != nil {
+			if err := identityService.DeleteProject(ctx, *openstackIdentity.Spec.ProjectID); err != nil {
+				if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+					return err
+				}
 			}
 		}
 	}
@@ -1659,6 +1674,10 @@ func (p *Provider) CreateNetwork(ctx context.Context, identity *unikornv1.Identi
 	return nil
 }
 
+func networkHasOpenStackState(network *unikornv1.Network) bool {
+	return network.Status.Openstack != nil && network.Status.Openstack.NetworkID != nil
+}
+
 // DeleteNetwork deletes a physical network.
 //
 //nolint:gocognit,cyclop
@@ -1670,6 +1689,10 @@ func (p *Provider) DeleteNetwork(ctx context.Context, identity *unikornv1.Identi
 	// deallocation.
 	networking, err := p.privilegedNetworkFromServicePrincipal(ctx, identity)
 	if err != nil {
+		if !networkHasOpenStackState(network) {
+			return nil
+		}
+
 		return err
 	}
 
@@ -1992,7 +2015,15 @@ func (p *Provider) DeleteSecurityGroup(ctx context.Context, identity *unikornv1.
 
 	openstackIdentity, err := p.GetOpenstackIdentity(ctx, identity)
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+
 		return err
+	}
+
+	if openstackIdentity.Spec.ProjectID == nil {
+		return nil
 	}
 
 	region, credentials := p.openstack.regionSnapshot()
@@ -3440,12 +3471,42 @@ func (p *Provider) createLoadBalancer(ctx context.Context, lbClient LoadBalancin
 	return nil
 }
 
+func loadBalancerHasOpenStackState(loadBalancer *unikornv1.LoadBalancer) bool {
+	return loadBalancer.Status.VIPAddress != nil || loadBalancer.Status.PublicIP != nil
+}
+
+func canSkipUnprovisionedLoadBalancerDelete(loadBalancer *unikornv1.LoadBalancer, err error) bool {
+	if loadBalancerHasOpenStackState(loadBalancer) {
+		return false
+	}
+
+	var endpointNotFound *gophercloud.ErrEndpointNotFound
+	if errors.As(err, &endpointNotFound) {
+		return true
+	}
+
+	var serviceNotFound *gophercloud.ErrServiceNotFound
+	if errors.As(err, &serviceNotFound) {
+		return true
+	}
+
+	if gophercloud.ResponseCodeIs(err, http.StatusUnauthorized) {
+		return true
+	}
+
+	return kerrors.IsNotFound(err) || errors.Is(err, coreerrors.ErrConsistency)
+}
+
 // DeleteLoadBalancer removes the Octavia topology and any attached floating
 // IP idempotently. It yields while Octavia is in any PENDING_* state and
 // after issuing a cascade delete so the next reconcile can confirm completion.
 func (p *Provider) DeleteLoadBalancer(ctx context.Context, identity *unikornv1.Identity, loadBalancer *unikornv1.LoadBalancer) error {
 	lbClient, err := p.loadBalancerFromServicePrincipal(ctx, identity)
 	if err != nil {
+		if canSkipUnprovisionedLoadBalancerDelete(loadBalancer, err) {
+			return nil
+		}
+
 		return err
 	}
 

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -1335,6 +1335,10 @@ func openstackIdentityHasComputeState(identity *unikornv1.OpenstackIdentity) boo
 	return identity.Spec.SSHKeyName != nil || identity.Spec.ServerGroupID != nil
 }
 
+func openstackIdentityHasIdentityState(identity *unikornv1.OpenstackIdentity) bool {
+	return identity.Spec.UserID != nil || identity.Spec.ProjectID != nil
+}
+
 func canSkipOpenStackIdentityComputeDelete(err error) bool {
 	if gophercloud.ResponseCodeIs(err, http.StatusUnauthorized) {
 		return true
@@ -1343,9 +1347,104 @@ func canSkipOpenStackIdentityComputeDelete(err error) bool {
 	return kerrors.IsNotFound(err) || errors.Is(err, coreerrors.ErrConsistency)
 }
 
+func canIgnoreOpenStackIdentityComputeDelete(err error) bool {
+	return gophercloud.ResponseCodeIs(err, http.StatusNotFound) || canSkipOpenStackIdentityComputeDelete(err)
+}
+
+func deleteOpenStackIdentityKeypair(ctx context.Context, compute ComputeInterface, identity *unikornv1.OpenstackIdentity) error {
+	if identity.Spec.SSHKeyName == nil {
+		return nil
+	}
+
+	err := compute.DeleteKeypair(ctx, keyPairName)
+	if err == nil || canIgnoreOpenStackIdentityComputeDelete(err) {
+		return nil
+	}
+
+	return err
+}
+
+func deleteOpenStackIdentityServerGroup(ctx context.Context, compute ComputeInterface, identity *unikornv1.OpenstackIdentity) error {
+	if identity.Spec.ServerGroupID == nil {
+		return nil
+	}
+
+	err := compute.DeleteServerGroup(ctx, *identity.Spec.ServerGroupID)
+	if err == nil || canIgnoreOpenStackIdentityComputeDelete(err) {
+		return nil
+	}
+
+	return err
+}
+
+func (p *Provider) deleteOpenStackIdentityComputeState(ctx context.Context, identity *unikornv1.Identity, openstackIdentity *unikornv1.OpenstackIdentity) error {
+	if !openstackIdentityHasComputeState(openstackIdentity) {
+		return nil
+	}
+
+	// Rescope to the user/project to delete project-local compute extras. If
+	// the service principal was never fully usable, continue to admin-scoped
+	// identity cleanup instead of pinning the finalizer.
+	compute, err := p.computeFromServicePrincipal(ctx, identity)
+	if err != nil {
+		if canSkipOpenStackIdentityComputeDelete(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if err := deleteOpenStackIdentityKeypair(ctx, compute, openstackIdentity); err != nil {
+		return err
+	}
+
+	return deleteOpenStackIdentityServerGroup(ctx, compute, openstackIdentity)
+}
+
+func deleteOpenStackUser(ctx context.Context, identityService *IdentityClient, userID *string) error {
+	if userID == nil {
+		return nil
+	}
+
+	err := identityService.DeleteUser(ctx, *userID)
+	if err == nil || gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+		return nil
+	}
+
+	return err
+}
+
+func deleteOpenStackProject(ctx context.Context, identityService *IdentityClient, projectID *string) error {
+	if projectID == nil {
+		return nil
+	}
+
+	err := identityService.DeleteProject(ctx, *projectID)
+	if err == nil || gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+		return nil
+	}
+
+	return err
+}
+
+func (p *Provider) deleteOpenStackIdentityResources(ctx context.Context, identity *unikornv1.OpenstackIdentity) error {
+	if !openstackIdentityHasIdentityState(identity) {
+		return nil
+	}
+
+	identityService, err := p.openstack.identity(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := deleteOpenStackUser(ctx, identityService, identity.Spec.UserID); err != nil {
+		return err
+	}
+
+	return deleteOpenStackProject(ctx, identityService, identity.Spec.ProjectID)
+}
+
 // DeleteIdentity cleans up an identity for cloud infrastructure.
-//
-//nolint:cyclop,gocognit
 func (p *Provider) DeleteIdentity(ctx context.Context, identity *unikornv1.Identity) error {
 	openstackIdentity, err := p.GetOpenstackIdentity(ctx, identity)
 	if err != nil {
@@ -1356,55 +1455,12 @@ func (p *Provider) DeleteIdentity(ctx context.Context, identity *unikornv1.Ident
 		return nil
 	}
 
-	if openstackIdentityHasComputeState(openstackIdentity) {
-		// Rescope to the user/project to delete project-local compute extras.
-		// If the service principal was never fully usable, continue to
-		// admin-scoped identity cleanup instead of pinning the finalizer.
-		compute, err := p.computeFromServicePrincipal(ctx, identity)
-		if err != nil {
-			if !canSkipOpenStackIdentityComputeDelete(err) {
-				return err
-			}
-		} else {
-			if openstackIdentity.Spec.SSHKeyName != nil {
-				if err := compute.DeleteKeypair(ctx, keyPairName); err != nil {
-					if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) && !canSkipOpenStackIdentityComputeDelete(err) {
-						return err
-					}
-				}
-			}
-
-			if openstackIdentity.Spec.ServerGroupID != nil {
-				if err := compute.DeleteServerGroup(ctx, *openstackIdentity.Spec.ServerGroupID); err != nil {
-					if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) && !canSkipOpenStackIdentityComputeDelete(err) {
-						return err
-					}
-				}
-			}
-		}
+	if err := p.deleteOpenStackIdentityComputeState(ctx, identity, openstackIdentity); err != nil {
+		return err
 	}
 
-	if openstackIdentity.Spec.UserID != nil || openstackIdentity.Spec.ProjectID != nil {
-		identityService, err := p.openstack.identity(ctx)
-		if err != nil {
-			return err
-		}
-
-		if openstackIdentity.Spec.UserID != nil {
-			if err := identityService.DeleteUser(ctx, *openstackIdentity.Spec.UserID); err != nil {
-				if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
-					return err
-				}
-			}
-		}
-
-		if openstackIdentity.Spec.ProjectID != nil {
-			if err := identityService.DeleteProject(ctx, *openstackIdentity.Spec.ProjectID); err != nil {
-				if !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
-					return err
-				}
-			}
-		}
+	if err := p.deleteOpenStackIdentityResources(ctx, openstackIdentity); err != nil {
+		return err
 	}
 
 	if err := p.client.Delete(ctx, openstackIdentity); err != nil {

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -3596,10 +3596,21 @@ func (p *Provider) deleteLoadBalancer(ctx context.Context, lbClient LoadBalancin
 		return err
 	}
 
-	if osLB.ProvisioningStatus == "PENDING_CREATE" ||
-		osLB.ProvisioningStatus == "PENDING_UPDATE" ||
-		osLB.ProvisioningStatus == "PENDING_DELETE" {
+	switch osLB.ProvisioningStatus {
+	case "PENDING_CREATE", "PENDING_UPDATE", "PENDING_DELETE":
+		// Octavia rejects mutations while any PENDING_* action is in flight.
+		// Wait for the operation to settle before probing the VIP port or
+		// issuing the cascade delete.
 		return provisioners.ErrYield
+	case "ACTIVE", "ERROR":
+		// These are the Octavia states where delete is actionable.
+	case "DELETED":
+		loadBalancer.Status.PublicIP = nil
+		loadBalancer.Status.VIPAddress = nil
+
+		return nil
+	default:
+		return fmt.Errorf("%w: octavia loadbalancer %q in unexpected state %q", coreerrors.ErrConsistency, osLB.Name, osLB.ProvisioningStatus)
 	}
 
 	// FIP first — cascade kills the VIP port, after which the FIP would leak.

--- a/pkg/providers/internal/openstack/provider_race_test.go
+++ b/pkg/providers/internal/openstack/provider_race_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package openstack_test
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -59,16 +58,7 @@ func newFakeOpenstack(t *testing.T) *fakeOpenstack {
 func (f *fakeOpenstack) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		// Treat all POSTs as Keystone authentication requests.
-		w.Header().Set("X-Subject-Token", "test-token")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintf(w, `{"token":{"catalog":[
-			{"type":"identity","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
-			{"type":"compute","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
-			{"type":"image","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
-			{"type":"network","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]}
-			],"expires_at":"2099-01-01T00:00:00.000000Z"}}`,
-			f.ts.URL)
+		writeOpenstackAuthCatalog(w, f.ts.URL)
 
 		return
 	}
@@ -78,14 +68,7 @@ func (f *fakeOpenstack) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// (expects a version list that includes v2.1 so compute/image/network pass the
 	// endpointSupportsVersion check).  The doubly-enveloped format satisfies both.
 	if r.URL.Path == "/" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w,
-			`{"versions":{"values":[
-				{"id":"v2.1","status":"CURRENT","links":[{"href":%q,"rel":"self"}]},
-				{"id":"v3","status":"current","links":[{"href":%q,"rel":"self"}]}
-				]}}`,
-			f.ts.URL+"/v2.1/", f.ts.URL+"/v3/")
+		writeOpenstackVersions(w, f.ts.URL)
 
 		return
 	}
@@ -95,12 +78,9 @@ func (f *fakeOpenstack) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// serviceClientRefresh, and write p.region — creating the race window.
 	time.Sleep(10 * time.Millisecond)
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-
 	// A single flavor is enough; more would flood TSan's 4-cell shadow with reads
 	// of p.region and evict the writer's write record before it can be matched.
-	fmt.Fprintf(w, `{"flavors":[{"id":"f1","name":"m1.small","vcpus":1,"ram":1024,"disk":10,"swap":""}]}`)
+	writeOpenstackFlavors(w)
 }
 
 // newRaceTestClient creates a controller-runtime fake client whose scheme covers

--- a/pkg/providers/internal/openstack/provider_test.go
+++ b/pkg/providers/internal/openstack/provider_test.go
@@ -18,8 +18,13 @@ limitations under the License.
 package openstack_test
 
 import (
+	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -52,6 +57,8 @@ import (
 	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack/mock"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 
+	k8sv1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/ptr"
@@ -230,6 +237,101 @@ func networkMatcher(network *regionv1.Network) gomock.Matcher {
 	return gomock.Cond(func(x *regionv1.Network) bool {
 		return x.Name == network.Name
 	})
+}
+
+func identityFixture() *regionv1.Identity {
+	return &regionv1.Identity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      identityID,
+			Namespace: "default",
+		},
+	}
+}
+
+func openstackIdentityFixture(identity *regionv1.Identity) *regionv1.OpenstackIdentity {
+	return &regionv1.OpenstackIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      identity.Name,
+			Namespace: identity.Namespace,
+		},
+		Spec: regionv1.OpenstackIdentitySpec{
+			UserID:    ptr.To("user-id"),
+			Password:  ptr.To("password"),
+			ProjectID: ptr.To("project-id"),
+		},
+	}
+}
+
+func newIdentityDeleteOpenStack(t *testing.T, serviceUserID, serviceProjectID string, deletedUser, deletedProject *atomic.Bool) *httptest.Server {
+	t.Helper()
+
+	var server *httptest.Server
+
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+
+				return
+			}
+
+			if strings.Contains(string(body), fmt.Sprintf("%q", serviceUserID)) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprint(w, `{"error":{"code":401,"message":"The request you have made requires authentication.","title":"Unauthorized"}}`)
+
+				return
+			}
+
+			w.Header().Set("X-Subject-Token", "test-token")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"token":{"catalog":[
+				{"type":"identity","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
+				{"type":"compute","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
+				{"type":"image","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
+				{"type":"network","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]}
+				],"expires_at":"2099-01-01T00:00:00.000000Z"}}`,
+				server.URL)
+
+			return
+		}
+
+		if r.URL.Path == "/" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w,
+				`{"versions":{"values":[
+					{"id":"v2.1","status":"CURRENT","links":[{"href":%q,"rel":"self"}]},
+					{"id":"v3","status":"current","links":[{"href":%q,"rel":"self"}]}
+					]}}`,
+				server.URL+"/v2.1/", server.URL+"/v3/")
+
+			return
+		}
+
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/users/"+serviceUserID) {
+			deletedUser.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+
+			return
+		}
+
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/projects/"+serviceProjectID) {
+			deletedProject.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"flavors":[{"id":"f1","name":"m1.small","vcpus":1,"ram":1024,"disk":10,"swap":""}]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	return server
 }
 
 func openstackNetworkFixture(network *regionv1.Network) *openstack.NetworkExt {
@@ -1693,6 +1795,63 @@ func TestResolveServerKeyName(t *testing.T) {
 
 		require.Empty(t, openstack.ResolveServerKeyName(server, identity))
 	})
+}
+
+func TestDeleteIdentitySkipsUnauthorizedComputeCleanup(t *testing.T) {
+	t.Parallel()
+
+	identity := identityFixture()
+	openstackIdentity := openstackIdentityFixture(identity)
+	openstackIdentity.Spec.UserID = ptr.To("service-user-id")
+	openstackIdentity.Spec.ProjectID = ptr.To("service-project-id")
+	openstackIdentity.Spec.SSHKeyName = ptr.To("unikorn-openstack-provider")
+	openstackIdentity.Spec.ServerGroupID = ptr.To("server-group-id")
+
+	var deletedUser atomic.Bool
+	var deletedProject atomic.Bool
+
+	server := newIdentityDeleteOpenStack(t, *openstackIdentity.Spec.UserID, *openstackIdentity.Spec.ProjectID, &deletedUser, &deletedProject)
+
+	region := &regionv1.Region{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-region",
+			Namespace: "default",
+		},
+		Spec: regionv1.RegionSpec{
+			Openstack: &regionv1.RegionOpenstackSpec{
+				Endpoint: server.URL,
+				ServiceAccountSecret: &regionv1.NamespacedObject{
+					Name:      "test-secret",
+					Namespace: "default",
+				},
+			},
+		},
+	}
+
+	secret := &k8sv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"domain-id":  []byte("admin-domain-id"),
+			"user-id":    []byte("admin-user-id"),
+			"password":   []byte("admin-password"),
+			"project-id": []byte("admin-project-id"),
+		},
+	}
+
+	kubeClient := newRaceTestClient(t, region, secret, openstackIdentity)
+	provider, err := openstack.New(t.Context(), kubeClient, kubeClient, region, openstack.Options{})
+	require.NoError(t, err)
+
+	require.NoError(t, provider.DeleteIdentity(t.Context(), identity))
+
+	var result regionv1.OpenstackIdentity
+	err = kubeClient.Get(t.Context(), client.ObjectKeyFromObject(openstackIdentity), &result)
+	require.True(t, kerrors.IsNotFound(err))
+	require.True(t, deletedUser.Load())
+	require.True(t, deletedProject.Load())
 }
 
 func TestServerForCreate(t *testing.T) {
@@ -3424,5 +3583,161 @@ func TestDeleteLoadBalancerRaces(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, lb.Status.PublicIP)
 		require.Nil(t, lb.Status.VIPAddress)
+	})
+}
+
+func TestDeleteLoadBalancerMissingEndpoint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("UnprovisionedNoOp", func(t *testing.T) {
+		t.Parallel()
+
+		ks := newFakeOpenstack(t)
+		identity := identityFixture()
+		openstackIdentity := openstackIdentityFixture(identity)
+		network := loadBalancerNetworkFixture()
+		lb := loadBalancerFixture(network)
+
+		region := regionFixture()
+		region.Spec.Openstack.Endpoint = ks.ts.URL
+
+		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), region)
+
+		require.NoError(t, p.DeleteLoadBalancer(t.Context(), identity, lb))
+	})
+
+	t.Run("ProvisionedPropagates", func(t *testing.T) {
+		t.Parallel()
+
+		ks := newFakeOpenstack(t)
+		identity := identityFixture()
+		openstackIdentity := openstackIdentityFixture(identity)
+		network := loadBalancerNetworkFixture()
+		lb := loadBalancerFixture(network)
+		lb.Status.VIPAddress = &corev1.IPv4Address{IP: net.ParseIP("10.0.0.42").To4()}
+
+		region := regionFixture()
+		region.Spec.Openstack.Endpoint = ks.ts.URL
+
+		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), region)
+
+		err := p.DeleteLoadBalancer(t.Context(), identity, lb)
+		require.Error(t, err)
+
+		var endpointNotFound *gophercloud.ErrEndpointNotFound
+		require.ErrorAs(t, err, &endpointNotFound)
+	})
+}
+
+func TestDeleteLoadBalancerUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Run("UnprovisionedNoOp", func(t *testing.T) {
+		t.Parallel()
+
+		identity := identityFixture()
+		openstackIdentity := openstackIdentityFixture(identity)
+		network := loadBalancerNetworkFixture()
+		lb := loadBalancerFixture(network)
+
+		region := regionFixture()
+		region.Spec.Openstack.Endpoint = server.URL
+
+		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), region)
+
+		require.NoError(t, p.DeleteLoadBalancer(t.Context(), identity, lb))
+	})
+
+	t.Run("ProvisionedPropagates", func(t *testing.T) {
+		t.Parallel()
+
+		identity := identityFixture()
+		openstackIdentity := openstackIdentityFixture(identity)
+		network := loadBalancerNetworkFixture()
+		lb := loadBalancerFixture(network)
+		lb.Status.VIPAddress = &corev1.IPv4Address{IP: net.ParseIP("10.0.0.42").To4()}
+
+		region := regionFixture()
+		region.Spec.Openstack.Endpoint = server.URL
+
+		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), region)
+
+		err := p.DeleteLoadBalancer(t.Context(), identity, lb)
+		require.Error(t, err)
+		require.True(t, gophercloud.ResponseCodeIs(err, http.StatusUnauthorized))
+	})
+}
+
+func TestDeleteNetworkWithoutProviderState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ClientSetupErrorNoOp", func(t *testing.T) {
+		t.Parallel()
+
+		identity := identityFixture()
+		openstackIdentity := openstackIdentityFixture(identity)
+		openstackIdentity.Spec.ProjectID = nil
+
+		network := networkFixture()
+		network.Namespace = identity.Namespace
+		network.Status.Openstack = nil
+
+		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), regionFixture())
+
+		require.NoError(t, p.DeleteNetwork(t.Context(), identity, network))
+	})
+
+	t.Run("RecordedProviderStatePropagates", func(t *testing.T) {
+		t.Parallel()
+
+		identity := identityFixture()
+		openstackIdentity := openstackIdentityFixture(identity)
+		openstackIdentity.Spec.ProjectID = nil
+
+		network := networkFixture()
+		network.Namespace = identity.Namespace
+		network.Status.Openstack = &regionv1.NetworkStatusOpenstack{
+			NetworkID: ptr.To("network-id"),
+		}
+
+		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), regionFixture())
+
+		err := p.DeleteNetwork(t.Context(), identity, network)
+		require.ErrorIs(t, err, errors.ErrConsistency)
+	})
+}
+
+func TestDeleteSecurityGroupWithoutProviderState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MissingOpenstackIdentityNoOp", func(t *testing.T) {
+		t.Parallel()
+
+		identity := identityFixture()
+		securityGroup := securityGroupFixture()
+		securityGroup.Namespace = identity.Namespace
+
+		p := openstack.NewTestProvider(getClient(t, nil), regionFixture())
+
+		require.NoError(t, p.DeleteSecurityGroup(t.Context(), identity, securityGroup))
+	})
+
+	t.Run("MissingProjectNoOp", func(t *testing.T) {
+		t.Parallel()
+
+		identity := identityFixture()
+		openstackIdentity := openstackIdentityFixture(identity)
+		openstackIdentity.Spec.ProjectID = nil
+		securityGroup := securityGroupFixture()
+		securityGroup.Namespace = identity.Namespace
+
+		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), regionFixture())
+
+		require.NoError(t, p.DeleteSecurityGroup(t.Context(), identity, securityGroup))
 	})
 }

--- a/pkg/providers/internal/openstack/provider_test.go
+++ b/pkg/providers/internal/openstack/provider_test.go
@@ -197,12 +197,35 @@ const (
 	sshKeyName     = "skeleton"
 )
 
+type regionFixtureOption func(*regionv1.Region)
+
 // regionFixture creates a region definition.
-func regionFixture() *regionv1.Region {
-	return &regionv1.Region{
+func regionFixture(opts ...regionFixtureOption) *regionv1.Region {
+	region := &regionv1.Region{
 		Spec: regionv1.RegionSpec{
 			Openstack: &regionv1.RegionOpenstackSpec{},
 		},
+	}
+
+	for _, opt := range opts {
+		opt(region)
+	}
+
+	return region
+}
+
+func withOpenstackEndpoint(endpoint string) regionFixtureOption {
+	return func(region *regionv1.Region) {
+		region.Spec.Openstack.Endpoint = endpoint
+	}
+}
+
+func withOpenstackServiceAccountSecret(name, namespace string) regionFixtureOption {
+	return func(region *regionv1.Region) {
+		region.Spec.Openstack.ServiceAccountSecret = &regionv1.NamespacedObject{
+			Name:      name,
+			Namespace: namespace,
+		}
 	}
 }
 
@@ -229,6 +252,14 @@ func networkFixture() *regionv1.Network {
 			Openstack: &regionv1.NetworkStatusOpenstack{},
 		},
 	}
+}
+
+func networkForDeleteFixture(identity *regionv1.Identity, status *regionv1.NetworkStatusOpenstack) *regionv1.Network {
+	network := networkFixture()
+	network.Namespace = identity.Namespace
+	network.Status.Openstack = status
+
+	return network
 }
 
 // networkMatcher is used to check mock function call parameters, as the object
@@ -262,6 +293,51 @@ func openstackIdentityFixture(identity *regionv1.Identity) *regionv1.OpenstackId
 	}
 }
 
+func openstackServiceAccountSecretFixture(name, namespace string) *k8sv1.Secret {
+	return &k8sv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"domain-id":  []byte("admin-domain-id"),
+			"user-id":    []byte("admin-user-id"),
+			"password":   []byte("admin-password"),
+			"project-id": []byte("admin-project-id"),
+		},
+	}
+}
+
+func writeOpenstackAuthCatalog(w http.ResponseWriter, endpoint string) {
+	w.Header().Set("X-Subject-Token", "test-token")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	fmt.Fprintf(w, `{"token":{"catalog":[
+		{"type":"identity","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
+		{"type":"compute","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
+		{"type":"image","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
+		{"type":"network","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]}
+		],"expires_at":"2099-01-01T00:00:00.000000Z"}}`,
+		endpoint)
+}
+
+func writeOpenstackVersions(w http.ResponseWriter, endpoint string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w,
+		`{"versions":{"values":[
+			{"id":"v2.1","status":"CURRENT","links":[{"href":%q,"rel":"self"}]},
+			{"id":"v3","status":"current","links":[{"href":%q,"rel":"self"}]}
+			]}}`,
+		endpoint+"/v2.1/", endpoint+"/v3/")
+}
+
+func writeOpenstackFlavors(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, `{"flavors":[{"id":"f1","name":"m1.small","vcpus":1,"ram":1024,"disk":10,"swap":""}]}`)
+}
+
 func newIdentityDeleteOpenStack(t *testing.T, serviceUserID, serviceProjectID string, deletedUser, deletedProject *atomic.Bool) *httptest.Server {
 	t.Helper()
 
@@ -284,29 +360,13 @@ func newIdentityDeleteOpenStack(t *testing.T, serviceUserID, serviceProjectID st
 				return
 			}
 
-			w.Header().Set("X-Subject-Token", "test-token")
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprintf(w, `{"token":{"catalog":[
-				{"type":"identity","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
-				{"type":"compute","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
-				{"type":"image","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
-				{"type":"network","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]}
-				],"expires_at":"2099-01-01T00:00:00.000000Z"}}`,
-				server.URL)
+			writeOpenstackAuthCatalog(w, server.URL)
 
 			return
 		}
 
 		if r.URL.Path == "/" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprintf(w,
-				`{"versions":{"values":[
-					{"id":"v2.1","status":"CURRENT","links":[{"href":%q,"rel":"self"}]},
-					{"id":"v3","status":"current","links":[{"href":%q,"rel":"self"}]}
-					]}}`,
-				server.URL+"/v2.1/", server.URL+"/v3/")
+			writeOpenstackVersions(w, server.URL)
 
 			return
 		}
@@ -325,9 +385,7 @@ func newIdentityDeleteOpenStack(t *testing.T, serviceUserID, serviceProjectID st
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"flavors":[{"id":"f1","name":"m1.small","vcpus":1,"ram":1024,"disk":10,"swap":""}]}`)
+		writeOpenstackFlavors(w)
 	}))
 	t.Cleanup(server.Close)
 
@@ -410,6 +468,13 @@ func securityGroupFixture(rules ...regionv1.SecurityGroupRule) *regionv1.Securit
 			Rules: rules,
 		},
 	}
+}
+
+func securityGroupForDeleteFixture(identity *regionv1.Identity) *regionv1.SecurityGroup {
+	securityGroup := securityGroupFixture()
+	securityGroup.Namespace = identity.Namespace
+
+	return securityGroup
 }
 
 // securityGroupMatcher is used to check mock function call parameters, as the object
@@ -585,6 +650,12 @@ func withPublicIP() func(*regionv1.LoadBalancer) {
 	}
 }
 
+func withLoadBalancerVIPStatus(addr string) func(*regionv1.LoadBalancer) {
+	return func(lb *regionv1.LoadBalancer) {
+		lb.Status.VIPAddress = &corev1.IPv4Address{IP: net.ParseIP(addr).To4()}
+	}
+}
+
 // listenerFixture creates a CRD listener with the given name/protocol/port and
 // applies any per-listener mutators. IdleTimeoutSeconds is preset to 60 for TCP
 // listeners (mirroring the handler default) and left nil for UDP; opts may
@@ -755,6 +826,27 @@ func expectNoFloatingIP(t *testing.T, c *gomock.Controller, vipPortID string) *m
 	return m
 }
 
+func deleteLoadBalancerWithClients(
+	t *testing.T,
+	network *regionv1.Network,
+	lb *regionv1.LoadBalancer,
+	lbClient openstack.LoadBalancingInterface,
+	fipClient openstack.FloatingIPInterface,
+) error {
+	t.Helper()
+
+	p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
+
+	return openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, fipClient, lb)
+}
+
+func requireLoadBalancerIPsCleared(t *testing.T, lb *regionv1.LoadBalancer) {
+	t.Helper()
+
+	require.Nil(t, lb.Status.PublicIP)
+	require.Nil(t, lb.Status.VIPAddress)
+}
+
 // openstackListenerFixture builds an ACTIVE listener live representation. The
 // timeout fields default to the 60s admission default in millis so steady-state
 // tests don't need to repeat them.
@@ -816,6 +908,29 @@ func getClient(t *testing.T, objects []client.Object) client.Client {
 	require.NoError(t, err)
 
 	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func testProviderFixture(t *testing.T, region *regionv1.Region, objects ...client.Object) *openstack.Provider {
+	t.Helper()
+
+	return openstack.NewTestProvider(getClient(t, objects), region)
+}
+
+func deleteLoadBalancerClientSetupFixture(t *testing.T, endpoint string, provisioned bool) (*openstack.Provider, *regionv1.Identity, *regionv1.LoadBalancer) {
+	t.Helper()
+
+	identity := identityFixture()
+	openstackIdentity := openstackIdentityFixture(identity)
+	network := loadBalancerNetworkFixture()
+	lb := loadBalancerFixture(network)
+
+	if provisioned {
+		withLoadBalancerVIPStatus("10.0.0.42")(lb)
+	}
+
+	provider := testProviderFixture(t, regionFixture(withOpenstackEndpoint(endpoint)), openstackIdentity)
+
+	return provider, identity, lb
 }
 
 // TestReconcileNetwork tests a resource is created when one isn't present.
@@ -1807,39 +1922,23 @@ func TestDeleteIdentitySkipsUnauthorizedComputeCleanup(t *testing.T) {
 	openstackIdentity.Spec.SSHKeyName = ptr.To("unikorn-openstack-provider")
 	openstackIdentity.Spec.ServerGroupID = ptr.To("server-group-id")
 
-	var deletedUser atomic.Bool
-	var deletedProject atomic.Bool
+	var (
+		deletedUser    atomic.Bool
+		deletedProject atomic.Bool
+	)
 
 	server := newIdentityDeleteOpenStack(t, *openstackIdentity.Spec.UserID, *openstackIdentity.Spec.ProjectID, &deletedUser, &deletedProject)
 
-	region := &regionv1.Region{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-region",
-			Namespace: "default",
-		},
-		Spec: regionv1.RegionSpec{
-			Openstack: &regionv1.RegionOpenstackSpec{
-				Endpoint: server.URL,
-				ServiceAccountSecret: &regionv1.NamespacedObject{
-					Name:      "test-secret",
-					Namespace: "default",
-				},
-			},
-		},
+	region := regionFixture(
+		withOpenstackEndpoint(server.URL),
+		withOpenstackServiceAccountSecret("test-secret", "default"),
+	)
+	region.ObjectMeta = metav1.ObjectMeta{
+		Name:      "test-region",
+		Namespace: "default",
 	}
 
-	secret := &k8sv1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-secret",
-			Namespace: "default",
-		},
-		Data: map[string][]byte{
-			"domain-id":  []byte("admin-domain-id"),
-			"user-id":    []byte("admin-user-id"),
-			"password":   []byte("admin-password"),
-			"project-id": []byte("admin-project-id"),
-		},
-	}
+	secret := openstackServiceAccountSecretFixture("test-secret", "default")
 
 	kubeClient := newRaceTestClient(t, region, secret, openstackIdentity)
 	provider, err := openstack.New(t.Context(), kubeClient, kubeClient, region, openstack.Options{})
@@ -3300,7 +3399,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 	})
 }
 
-func TestDeleteLoadBalancer(t *testing.T) {
+func TestDeleteLoadBalancerAlreadyGone(t *testing.T) {
 	t.Parallel()
 
 	c := gomock.NewController(t)
@@ -3319,23 +3418,29 @@ func TestDeleteLoadBalancer(t *testing.T) {
 
 		networkClient := mock.NewMockNetworkingInterface(c)
 
-		p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
-
-		err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
+		err := deleteLoadBalancerWithClients(t, network, lb, lbClient, networkClient)
 		require.NoError(t, err)
-		require.Nil(t, lb.Status.PublicIP)
-		require.Nil(t, lb.Status.VIPAddress)
+		requireLoadBalancerIPsCleared(t, lb)
 	})
+}
 
-	pendingStates := []struct {
+func TestDeleteLoadBalancerStatusGuards(t *testing.T) {
+	t.Parallel()
+
+	c := gomock.NewController(t)
+	t.Cleanup(c.Finish)
+
+	tests := []struct {
 		name   string
 		status string
+		err    error
 	}{
-		{"LBPendingCreate_Yields", "PENDING_CREATE"},
-		{"LBPendingUpdate_Yields", "PENDING_UPDATE"},
-		{"LBPendingDelete_Yields", "PENDING_DELETE"},
+		{"LBPendingCreate_Yields", "PENDING_CREATE", provisioners.ErrYield},
+		{"LBPendingUpdate_Yields", "PENDING_UPDATE", provisioners.ErrYield},
+		{"LBPendingDelete_Yields", "PENDING_DELETE", provisioners.ErrYield},
 	}
-	for _, tc := range pendingStates {
+
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -3349,12 +3454,17 @@ func TestDeleteLoadBalancer(t *testing.T) {
 
 			networkClient := mock.NewMockNetworkingInterface(c)
 
-			p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
-
-			err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
-			require.ErrorIs(t, err, provisioners.ErrYield)
+			err := deleteLoadBalancerWithClients(t, network, lb, lbClient, networkClient)
+			require.ErrorIs(t, err, tc.err)
 		})
 	}
+}
+
+func TestDeleteLoadBalancerCascade(t *testing.T) {
+	t.Parallel()
+
+	c := gomock.NewController(t)
+	t.Cleanup(c.Finish)
 
 	t.Run("LBError_StillCascades", func(t *testing.T) {
 		t.Parallel()
@@ -3370,9 +3480,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 
 		networkClient := expectNoFloatingIP(t, c, osLB.VipPortID)
 
-		p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
-
-		err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
+		err := deleteLoadBalancerWithClients(t, network, lb, lbClient, networkClient)
 		require.ErrorIs(t, err, provisioners.ErrYield)
 	})
 
@@ -3396,9 +3504,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 			lbClient.EXPECT().DeleteLoadBalancer(t.Context(), osLB.ID, true).Return(nil),
 		)
 
-		p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
-
-		err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
+		err := deleteLoadBalancerWithClients(t, network, lb, lbClient, networkClient)
 		require.ErrorIs(t, err, provisioners.ErrYield)
 		require.Nil(t, lb.Status.PublicIP)
 	})
@@ -3417,9 +3523,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 
 		networkClient := expectNoFloatingIP(t, c, osLB.VipPortID)
 
-		p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
-
-		err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
+		err := deleteLoadBalancerWithClients(t, network, lb, lbClient, networkClient)
 		require.ErrorIs(t, err, provisioners.ErrYield)
 	})
 
@@ -3437,11 +3541,16 @@ func TestDeleteLoadBalancer(t *testing.T) {
 
 		networkClient := mock.NewMockNetworkingInterface(c)
 
-		p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
-
-		err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
+		err := deleteLoadBalancerWithClients(t, network, lb, lbClient, networkClient)
 		require.ErrorIs(t, err, provisioners.ErrYield)
 	})
+}
+
+func TestDeleteLoadBalancerErrors(t *testing.T) {
+	t.Parallel()
+
+	c := gomock.NewController(t)
+	t.Cleanup(c.Finish)
 
 	t.Run("GetFloatingIPConsistency_Propagates", func(t *testing.T) {
 		t.Parallel()
@@ -3457,9 +3566,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 		networkClient := mock.NewMockNetworkingInterface(c)
 		networkClient.EXPECT().GetFloatingIP(t.Context(), osLB.VipPortID).Return(nil, errors.ErrConsistency)
 
-		p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
-
-		err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
+		err := deleteLoadBalancerWithClients(t, network, lb, lbClient, networkClient)
 		require.ErrorIs(t, err, errors.ErrConsistency)
 	})
 
@@ -3474,9 +3581,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 
 		networkClient := mock.NewMockNetworkingInterface(c)
 
-		p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
-
-		err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
+		err := deleteLoadBalancerWithClients(t, network, lb, lbClient, networkClient)
 		require.ErrorIs(t, err, errors.ErrConsistency)
 	})
 
@@ -3489,7 +3594,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 		osLB := openstackLoadBalancerFixture(lb)
 		openstackFloatingIP := openstackFloatingIPFixture(&ports.Port{ID: osLB.VipPortID})
 
-		// FIP delete failure must short-circuit before cascade — no DeleteLoadBalancer expectation.
+		// FIP delete failure must short-circuit before cascade; no DeleteLoadBalancer expectation.
 		lbClient := mock.NewMockLoadBalancingInterface(c)
 		lbClient.EXPECT().GetLoadBalancer(t.Context(), loadBalancerMatcher(lb)).Return(osLB, nil)
 
@@ -3497,9 +3602,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 		networkClient.EXPECT().GetFloatingIP(t.Context(), osLB.VipPortID).Return(openstackFloatingIP, nil)
 		networkClient.EXPECT().DeleteFloatingIP(t.Context(), openstackFloatingIP.ID).Return(assert.AnError)
 
-		p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
-
-		err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
+		err := deleteLoadBalancerWithClients(t, network, lb, lbClient, networkClient)
 		require.ErrorIs(t, err, assert.AnError)
 	})
 
@@ -3517,9 +3620,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 
 		networkClient := expectNoFloatingIP(t, c, osLB.VipPortID)
 
-		p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
-
-		err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
+		err := deleteLoadBalancerWithClients(t, network, lb, lbClient, networkClient)
 		require.ErrorIs(t, err, assert.AnError)
 	})
 }
@@ -3593,15 +3694,7 @@ func TestDeleteLoadBalancerMissingEndpoint(t *testing.T) {
 		t.Parallel()
 
 		ks := newFakeOpenstack(t)
-		identity := identityFixture()
-		openstackIdentity := openstackIdentityFixture(identity)
-		network := loadBalancerNetworkFixture()
-		lb := loadBalancerFixture(network)
-
-		region := regionFixture()
-		region.Spec.Openstack.Endpoint = ks.ts.URL
-
-		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), region)
+		p, identity, lb := deleteLoadBalancerClientSetupFixture(t, ks.ts.URL, false)
 
 		require.NoError(t, p.DeleteLoadBalancer(t.Context(), identity, lb))
 	})
@@ -3610,21 +3703,13 @@ func TestDeleteLoadBalancerMissingEndpoint(t *testing.T) {
 		t.Parallel()
 
 		ks := newFakeOpenstack(t)
-		identity := identityFixture()
-		openstackIdentity := openstackIdentityFixture(identity)
-		network := loadBalancerNetworkFixture()
-		lb := loadBalancerFixture(network)
-		lb.Status.VIPAddress = &corev1.IPv4Address{IP: net.ParseIP("10.0.0.42").To4()}
-
-		region := regionFixture()
-		region.Spec.Openstack.Endpoint = ks.ts.URL
-
-		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), region)
+		p, identity, lb := deleteLoadBalancerClientSetupFixture(t, ks.ts.URL, true)
 
 		err := p.DeleteLoadBalancer(t.Context(), identity, lb)
 		require.Error(t, err)
 
 		var endpointNotFound *gophercloud.ErrEndpointNotFound
+
 		require.ErrorAs(t, err, &endpointNotFound)
 	})
 }
@@ -3640,15 +3725,7 @@ func TestDeleteLoadBalancerUnauthorized(t *testing.T) {
 	t.Run("UnprovisionedNoOp", func(t *testing.T) {
 		t.Parallel()
 
-		identity := identityFixture()
-		openstackIdentity := openstackIdentityFixture(identity)
-		network := loadBalancerNetworkFixture()
-		lb := loadBalancerFixture(network)
-
-		region := regionFixture()
-		region.Spec.Openstack.Endpoint = server.URL
-
-		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), region)
+		p, identity, lb := deleteLoadBalancerClientSetupFixture(t, server.URL, false)
 
 		require.NoError(t, p.DeleteLoadBalancer(t.Context(), identity, lb))
 	})
@@ -3656,16 +3733,7 @@ func TestDeleteLoadBalancerUnauthorized(t *testing.T) {
 	t.Run("ProvisionedPropagates", func(t *testing.T) {
 		t.Parallel()
 
-		identity := identityFixture()
-		openstackIdentity := openstackIdentityFixture(identity)
-		network := loadBalancerNetworkFixture()
-		lb := loadBalancerFixture(network)
-		lb.Status.VIPAddress = &corev1.IPv4Address{IP: net.ParseIP("10.0.0.42").To4()}
-
-		region := regionFixture()
-		region.Spec.Openstack.Endpoint = server.URL
-
-		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), region)
+		p, identity, lb := deleteLoadBalancerClientSetupFixture(t, server.URL, true)
 
 		err := p.DeleteLoadBalancer(t.Context(), identity, lb)
 		require.Error(t, err)
@@ -3676,68 +3744,82 @@ func TestDeleteLoadBalancerUnauthorized(t *testing.T) {
 func TestDeleteNetworkWithoutProviderState(t *testing.T) {
 	t.Parallel()
 
-	t.Run("ClientSetupErrorNoOp", func(t *testing.T) {
-		t.Parallel()
+	tests := []struct {
+		name    string
+		status  *regionv1.NetworkStatusOpenstack
+		wantErr error
+	}{
+		{
+			name: "ClientSetupErrorNoOp",
+		},
+		{
+			name: "RecordedProviderStatePropagates",
+			status: &regionv1.NetworkStatusOpenstack{
+				NetworkID: ptr.To("network-id"),
+			},
+			wantErr: errors.ErrConsistency,
+		},
+	}
 
-		identity := identityFixture()
-		openstackIdentity := openstackIdentityFixture(identity)
-		openstackIdentity.Spec.ProjectID = nil
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-		network := networkFixture()
-		network.Namespace = identity.Namespace
-		network.Status.Openstack = nil
+			identity := identityFixture()
+			openstackIdentity := openstackIdentityFixture(identity)
+			openstackIdentity.Spec.ProjectID = nil
 
-		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), regionFixture())
+			network := networkForDeleteFixture(identity, test.status)
+			p := testProviderFixture(t, regionFixture(), openstackIdentity)
 
-		require.NoError(t, p.DeleteNetwork(t.Context(), identity, network))
-	})
+			err := p.DeleteNetwork(t.Context(), identity, network)
+			if test.wantErr == nil {
+				require.NoError(t, err)
 
-	t.Run("RecordedProviderStatePropagates", func(t *testing.T) {
-		t.Parallel()
+				return
+			}
 
-		identity := identityFixture()
-		openstackIdentity := openstackIdentityFixture(identity)
-		openstackIdentity.Spec.ProjectID = nil
-
-		network := networkFixture()
-		network.Namespace = identity.Namespace
-		network.Status.Openstack = &regionv1.NetworkStatusOpenstack{
-			NetworkID: ptr.To("network-id"),
-		}
-
-		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), regionFixture())
-
-		err := p.DeleteNetwork(t.Context(), identity, network)
-		require.ErrorIs(t, err, errors.ErrConsistency)
-	})
+			require.ErrorIs(t, err, test.wantErr)
+		})
+	}
 }
 
 func TestDeleteSecurityGroupWithoutProviderState(t *testing.T) {
 	t.Parallel()
 
-	t.Run("MissingOpenstackIdentityNoOp", func(t *testing.T) {
-		t.Parallel()
+	tests := []struct {
+		name    string
+		objects func(*regionv1.Identity) []client.Object
+	}{
+		{
+			name: "MissingOpenstackIdentityNoOp",
+		},
+		{
+			name: "MissingProjectNoOp",
+			objects: func(identity *regionv1.Identity) []client.Object {
+				openstackIdentity := openstackIdentityFixture(identity)
+				openstackIdentity.Spec.ProjectID = nil
 
-		identity := identityFixture()
-		securityGroup := securityGroupFixture()
-		securityGroup.Namespace = identity.Namespace
+				return []client.Object{openstackIdentity}
+			},
+		},
+	}
 
-		p := openstack.NewTestProvider(getClient(t, nil), regionFixture())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-		require.NoError(t, p.DeleteSecurityGroup(t.Context(), identity, securityGroup))
-	})
+			identity := identityFixture()
+			securityGroup := securityGroupForDeleteFixture(identity)
 
-	t.Run("MissingProjectNoOp", func(t *testing.T) {
-		t.Parallel()
+			var objects []client.Object
+			if test.objects != nil {
+				objects = test.objects(identity)
+			}
 
-		identity := identityFixture()
-		openstackIdentity := openstackIdentityFixture(identity)
-		openstackIdentity.Spec.ProjectID = nil
-		securityGroup := securityGroupFixture()
-		securityGroup.Namespace = identity.Namespace
+			p := testProviderFixture(t, regionFixture(), objects...)
 
-		p := openstack.NewTestProvider(getClient(t, []client.Object{openstackIdentity}), regionFixture())
-
-		require.NoError(t, p.DeleteSecurityGroup(t.Context(), identity, securityGroup))
-	})
+			require.NoError(t, p.DeleteSecurityGroup(t.Context(), identity, securityGroup))
+		})
+	}
 }

--- a/pkg/providers/internal/openstack/provider_test.go
+++ b/pkg/providers/internal/openstack/provider_test.go
@@ -3466,6 +3466,57 @@ func TestDeleteLoadBalancerCascade(t *testing.T) {
 	c := gomock.NewController(t)
 	t.Cleanup(c.Finish)
 
+	t.Run("LBDeleted_NoOp", func(t *testing.T) {
+		t.Parallel()
+
+		network := loadBalancerNetworkFixture()
+		lb := loadBalancerFixture(network)
+		lb.Status.PublicIP = &corev1.IPv4Address{IP: net.ParseIP("12.34.56.78").To4()}
+		lb.Status.VIPAddress = &corev1.IPv4Address{IP: net.ParseIP("10.0.0.42").To4()}
+
+		osLB := openstackLoadBalancerFixture(lb, withProvisioningStatus("DELETED"))
+
+		lbClient := mock.NewMockLoadBalancingInterface(c)
+		lbClient.EXPECT().GetLoadBalancer(t.Context(), loadBalancerMatcher(lb)).Return(osLB, nil)
+
+		networkClient := mock.NewMockNetworkingInterface(c)
+
+		p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
+
+		err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
+		require.NoError(t, err)
+		require.Nil(t, lb.Status.PublicIP)
+		require.Nil(t, lb.Status.VIPAddress)
+	})
+
+	unexpectedStates := []struct {
+		name   string
+		status string
+	}{
+		{"LBUnknownStatus_Consistency", "UNKNOWN"},
+		{"LBEmptyStatus_Consistency", ""},
+	}
+	for _, tc := range unexpectedStates {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			network := loadBalancerNetworkFixture()
+			lb := loadBalancerFixture(network)
+
+			osLB := openstackLoadBalancerFixture(lb, withProvisioningStatus(tc.status))
+
+			lbClient := mock.NewMockLoadBalancingInterface(c)
+			lbClient.EXPECT().GetLoadBalancer(t.Context(), loadBalancerMatcher(lb)).Return(osLB, nil)
+
+			networkClient := mock.NewMockNetworkingInterface(c)
+
+			p := openstack.NewTestProvider(getClient(t, []client.Object{network}), regionFixture())
+
+			err := openstack.DeleteLoadBalancerWithClient(t.Context(), p, lbClient, networkClient, lb)
+			require.ErrorIs(t, err, errors.ErrConsistency)
+		})
+	}
+
 	t.Run("LBError_StillCascades", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Failed provisioning can leave Region resources with finalizers, before any recoverable OpenStack state exists. Delete paths should clear those control-plane objects instead of retrying client setup forever, while still propagating errors once provider state has been recorded.
