### PR TITLE
fix(server): attach serverID context to missing API version label 404

### DIFF
--- a/pkg/handler/server/client_v2.go
+++ b/pkg/handler/server/client_v2.go
@@ -464,7 +464,7 @@ func (c *ClientV2) GetV2Raw(ctx context.Context, serverID string) (*regionv1.Ser
 	// Only allow access to resources created by this API (temporarily).
 	v, ok := result.Labels[constants.ResourceAPIVersionLabel]
 	if !ok {
-		return nil, errors.HTTPNotFound()
+		return nil, errors.HTTPNotFound().WithValues("serverID", serverID)
 	}
 
 	version, err := constants.UnmarshalAPIVersion(v)

--- a/pkg/handler/server/client_v2_test.go
+++ b/pkg/handler/server/client_v2_test.go
@@ -616,6 +616,7 @@ func TestServerGetV2Raw_MissingAPIVersionLabel(t *testing.T) {
 
 	require.Error(t, err)
 	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+	require.NotEmpty(t, err.Error(), "expected non-empty error description in response body")
 }
 
 func TestServerGetV2Raw_WrongAPIVersion(t *testing.T) {


### PR DESCRIPTION
## Summary

- `GetV2Raw` returned a bare `HTTPNotFound()` (no log context) when a server existed but lacked `ResourceAPIVersionLabel`
- Add `.WithValues("serverID", serverID)` so the server ID is emitted to logs on this path, consistent with the k8s-not-found path at line 454
- Extend `TestServerGetV2Raw_MissingAPIVersionLabel` to assert the error description is non-empty, explicitly covering the response body check

Closes INST-936