### PR TITLE
chore: version v1.16.7

### DIFF
--- a/charts/region/Chart.yaml
+++ b/charts/region/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn's Region Controller
 
 type: application
 
-version: 1.16.6
-appVersion: 1.16.6
+version: 1.16.7
+appVersion: 1.16.7
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
Release v1.16.7.

Cuts a new release tag so the identity v1.17.1 bump (already merged to main) can be built into a deployable image + Helm chart and pinned in k8s-deploy-unikorn.

Chart-only change: bumps `version` + `appVersion` to 1.16.7. Tag v1.16.7 will be pushed on the merge commit once this lands.