### PR TITLE
Fix stale VLAN allocation cleanup by network ID

### DIFF
--- a/pkg/providers/allocation/vlan/README.md
+++ b/pkg/providers/allocation/vlan/README.md
@@ -38,8 +38,10 @@ and the `Region` VLAN/provider-network configuration that this allocator uses.
 - `Allocate()` is idempotent by `networkID`; repeated allocation for the same
   network returns the existing VLAN ID.
 - At most one VLAN ID may be allocated to a given `networkID`. `Allocate()`
-  returns an error if duplicate allocations are detected for the same network,
-  while `FreeByNetworkID()` removes all matching entries to heal corruption.
+  prevents new duplicate ownership by returning an error if duplicates are
+  detected for the same network. `FreeByNetworkID()` deliberately removes all
+  matching entries when cleaning up a network so existing duplicate ownership is
+  healed during deletion.
 - `Free()` and `FreeByNetworkID()` are idempotent.
 - If the allocation table contains the same VLAN ID more than once, the package
   treats that as corruption and returns an allocation error rather than trying

--- a/pkg/providers/allocation/vlan/README.md
+++ b/pkg/providers/allocation/vlan/README.md
@@ -35,7 +35,12 @@ and the `Region` VLAN/provider-network configuration that this allocator uses.
   topology-aware.
 - Persistence and concurrency coordination rely on the backing Kubernetes
   `VLANAllocation` object rather than in-memory state.
-- `Free()` is idempotent.
+- `Allocate()` is idempotent by `networkID`; repeated allocation for the same
+  network returns the existing VLAN ID.
+- At most one VLAN ID may be allocated to a given `networkID`. `Allocate()`
+  returns an error if duplicate allocations are detected for the same network,
+  while `FreeByNetworkID()` removes all matching entries to heal corruption.
+- `Free()` and `FreeByNetworkID()` are idempotent.
 - If the allocation table contains the same VLAN ID more than once, the package
   treats that as corruption and returns an allocation error rather than trying
   to guess how to repair it.
@@ -46,9 +51,12 @@ and the `Region` VLAN/provider-network configuration that this allocator uses.
   for a general platform-wide network allocation abstraction.
 - Allocation is currently an exhaustive search with an admitted `O(n^2)`
   worst-case shape, though the problem space is bounded.
-- Ownership is only recorded as `networkID` in the allocation table, but
-  deallocation is keyed by VLAN ID alone. Correctness therefore depends on
-  higher layers calling `Free()` with the right VLAN ID.
+- Ownership is recorded as `networkID` in the allocation table. Callers can
+  deallocate by VLAN ID using `Free()` or by network ID using
+  `FreeByNetworkID()`.
+- `FreeByNetworkID()` is the preferred cleanup path when a network resource is
+  being deleted because it does not depend on the VLAN ID being present in
+  network status or the OpenStack provider network still existing.
 - If an operator manually corrupts the `VLANAllocation` object, this package can
   detect some bad states but does not provide a repair or reconciliation model.
 - Falling back to the full VLAN range when no explicit segments are configured

--- a/pkg/providers/allocation/vlan/vlan.go
+++ b/pkg/providers/allocation/vlan/vlan.go
@@ -139,6 +139,12 @@ func (a *Allocator) Allocate(ctx context.Context, networkID string) (int, error)
 		return -1, err
 	}
 
+	if id, ok, err := vlanIDByNetworkID(allocation, networkID); err != nil {
+		return -1, err
+	} else if ok {
+		return id, nil
+	}
+
 	allocatable := a.allocatable()
 
 	// Do an exhaustive search through all allocatable VLAN IDs...
@@ -181,6 +187,32 @@ func (a *Allocator) Allocate(ctx context.Context, networkID string) (int, error)
 	return -1, fmt.Errorf("%w: vlan ids exhausted", ErrAllocation)
 }
 
+func vlanIDByNetworkID(allocation *unikornv1.VLANAllocation, networkID string) (int, bool, error) {
+	var (
+		count int
+		id    int
+	)
+
+	for _, entry := range allocation.Spec.Allocations {
+		if entry.NetworkID != networkID {
+			continue
+		}
+
+		count++
+		id = entry.ID
+	}
+
+	if count == 0 {
+		return -1, false, nil
+	}
+
+	if count > 1 {
+		return -1, false, fmt.Errorf("%w: network id %s allocated more than once", ErrAllocation, networkID)
+	}
+
+	return id, true, nil
+}
+
 func (a *Allocator) Free(ctx context.Context, id int) error {
 	if !vlanIDValid(id) {
 		return fmt.Errorf("%w: vlan id %d is invalid", ErrAllocation, id)
@@ -210,6 +242,36 @@ func (a *Allocator) Free(ctx context.Context, id int) error {
 	// manually corrupted the allocations table.
 	if delta > 1 {
 		return fmt.Errorf("%w: vlan id %d not allocated exactly once", ErrAllocation, id)
+	}
+
+	if err := a.client.Update(ctx, allocation); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *Allocator) FreeByNetworkID(ctx context.Context, networkID string) error {
+	allocation, err := a.getVLANAllocation(ctx)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	allocationsLength := len(allocation.Spec.Allocations)
+
+	callback := func(allocation unikornv1.VLANAllocationEntry) bool {
+		return allocation.NetworkID == networkID
+	}
+
+	allocation.Spec.Allocations = slices.DeleteFunc(allocation.Spec.Allocations, callback)
+
+	delta := allocationsLength - len(allocation.Spec.Allocations)
+	if delta == 0 {
+		return nil
 	}
 
 	if err := a.client.Update(ctx, allocation); err != nil {

--- a/pkg/providers/allocation/vlan/vlan_test.go
+++ b/pkg/providers/allocation/vlan/vlan_test.go
@@ -104,6 +104,26 @@ func TestVLANAllocationCreate(t *testing.T) {
 	require.ErrorIs(t, err, vlan.ErrAllocation)
 }
 
+func TestVLANAllocationCreateIsIdempotentByNetworkID(t *testing.T) {
+	t.Parallel()
+
+	client := newClient(t)
+	region := regionFixture(regionID1, defaultSegmentFixture())
+	allocator := vlan.New(client, region)
+
+	id1, err := allocator.Allocate(t.Context(), networkID1)
+	require.NoError(t, err)
+	require.Equal(t, segmentStart, id1)
+
+	id2, err := allocator.Allocate(t.Context(), networkID1)
+	require.NoError(t, err)
+	require.Equal(t, id1, id2)
+
+	id3, err := allocator.Allocate(t.Context(), networkID2)
+	require.NoError(t, err)
+	require.Equal(t, segmentStart+1, id3)
+}
+
 // TestVLANAllocationCreateMultiSegment tests multi segment allocation works.
 func TestVLANAllocationCreateMultiSegment(t *testing.T) {
 	t.Parallel()
@@ -191,6 +211,77 @@ func TestVLANFree(t *testing.T) {
 
 	require.NoError(t, allocator.Free(t.Context(), id))
 	require.NoError(t, allocator.Free(t.Context(), id))
+}
+
+func TestVLANFreeByNetworkID(t *testing.T) {
+	t.Parallel()
+
+	client := newClient(t)
+	region := regionFixture(regionID1, defaultSegmentFixture())
+	allocator := vlan.New(client, region)
+
+	id, err := allocator.Allocate(t.Context(), networkID1)
+	require.NoError(t, err)
+	require.Equal(t, segmentStart, id)
+
+	require.NoError(t, allocator.FreeByNetworkID(t.Context(), networkID1))
+	require.NoError(t, allocator.FreeByNetworkID(t.Context(), networkID1))
+
+	id, err = allocator.Allocate(t.Context(), networkID2)
+	require.NoError(t, err)
+	require.Equal(t, segmentStart, id)
+}
+
+func TestVLANFreeByNetworkIDMissingAllocation(t *testing.T) {
+	t.Parallel()
+
+	client := newClient(t)
+	region := regionFixture(regionID1, defaultSegmentFixture())
+	allocator := vlan.New(client, region)
+
+	require.NoError(t, allocator.FreeByNetworkID(t.Context(), networkID1))
+}
+
+func TestVLANDuplicateNetworkIDRejectedAndFreed(t *testing.T) {
+	t.Parallel()
+
+	k8sClient := newClient(t)
+	region := regionFixture(regionID1, defaultSegmentFixture())
+
+	allocation := &regionv1.VLANAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: region.Namespace,
+			Name:      region.StaticName(),
+		},
+		Spec: regionv1.VLANAllocationSpec{
+			Allocations: []regionv1.VLANAllocationEntry{
+				{
+					ID:        segmentStart,
+					NetworkID: networkID1,
+				},
+				{
+					ID:        segmentStart + 1,
+					NetworkID: networkID1,
+				},
+			},
+		},
+	}
+
+	require.NoError(t, k8sClient.Create(t.Context(), allocation))
+
+	allocator := vlan.New(k8sClient, region)
+
+	_, err := allocator.Allocate(t.Context(), networkID1)
+	require.ErrorIs(t, err, vlan.ErrAllocation)
+
+	require.NoError(t, allocator.FreeByNetworkID(t.Context(), networkID1))
+
+	result := &regionv1.VLANAllocation{}
+	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKey{
+		Namespace: region.Namespace,
+		Name:      region.StaticName(),
+	}, result))
+	require.Empty(t, result.Spec.Allocations)
 }
 
 // TestVLANFreeIllegalID tests illegaly VLAN IDs are caught.

--- a/pkg/providers/internal/openstack/export_test.go
+++ b/pkg/providers/internal/openstack/export_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/unikorn-cloud/core/pkg/util/cache"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/providers/allocation/vlan"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -107,6 +108,7 @@ func NewTestProvider(client client.Client, region *unikornv1.Region) *Provider {
 			client:  client,
 			_region: region,
 		},
+		vlanAllocator: vlan.New(client, region),
 	}
 }
 
@@ -124,6 +126,10 @@ func ReconcileRouter(ctx context.Context, p *Provider, client RouterInterface, n
 
 func ReconcileRouterInterface(ctx context.Context, p *Provider, client NetworkingInterface, router *routers.Router, subnet *subnets.Subnet) error {
 	return p.reconcileRouterInterface(ctx, client, router, subnet)
+}
+
+func DeleteNetworkWithClient(ctx context.Context, p *Provider, client NetworkingInterface, network *unikornv1.Network) error {
+	return p.deleteNetwork(ctx, client, network)
 }
 
 func ReconcileSecurityGroup(ctx context.Context, p *Provider, client SecurityGroupInterface, securityGroup *unikornv1.SecurityGroup) (*groups.SecGroup, error) {

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -1491,6 +1491,8 @@ func (p *Provider) reconcileNetwork(ctx context.Context, client NetworkInterface
 	if region.Spec.Openstack.Network.UseProviderNetworks() {
 		v, err := p.vlanAllocator.Allocate(ctx, network.Name)
 		if err != nil {
+			log.Error(err, "failed to allocate VLAN", "networkID", network.Name, "allocation", region.StaticName())
+
 			return nil, err
 		}
 

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -1503,6 +1503,8 @@ func (p *Provider) reconcileNetwork(ctx context.Context, client NetworkInterface
 
 	result, err = client.CreateNetwork(ctx, network, vlanID)
 	if err != nil {
+		log.Error(err, "failed to create OpenStack network", "networkID", network.Name, "vlanID", vlanID)
+
 		if vlanID != nil {
 			if rerr := p.vlanAllocator.Free(ctx, *vlanID); rerr != nil {
 				log.Error(rerr, "failed to free vlan", "id", *vlanID)

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -1670,11 +1670,7 @@ func (p *Provider) CreateNetwork(ctx context.Context, identity *unikornv1.Identi
 }
 
 // DeleteNetwork deletes a physical network.
-//
-//nolint:gocognit,cyclop
 func (p *Provider) DeleteNetwork(ctx context.Context, identity *unikornv1.Identity, network *unikornv1.Network) error {
-	log := log.FromContext(ctx)
-
 	// NOTE: this is a privileged network client as it needs permissions
 	// from the manager policy in order to see provider networks for VLAN
 	// deallocation.
@@ -1682,6 +1678,13 @@ func (p *Provider) DeleteNetwork(ctx context.Context, identity *unikornv1.Identi
 	if err != nil {
 		return err
 	}
+
+	return p.deleteNetwork(ctx, networking, network)
+}
+
+//nolint:gocognit,cyclop
+func (p *Provider) deleteNetwork(ctx context.Context, networking NetworkingInterface, network *unikornv1.Network) error {
+	log := log.FromContext(ctx)
 
 	openstackNetwork, err := networking.GetNetwork(ctx, network)
 	if err != nil && !errors.Is(err, coreerrors.ErrResourceNotFound) {
@@ -1728,26 +1731,27 @@ func (p *Provider) DeleteNetwork(ctx context.Context, identity *unikornv1.Identi
 		}
 	}
 
-	//nolint:nestif
-	if openstackNetwork != nil {
-		log.V(1).Info("deleting network")
+	region, _ := p.openstack.regionSnapshot()
+	// VLAN deallocation is idempotent. Prefer the VLAN ID recorded in
+	// status because the OpenStack network may already be gone; fall back
+	// to the segmentation ID for older Network statuses.
+	if region.Spec.Openstack != nil && region.Spec.Openstack.Network.UseProviderNetworks() {
+		vlanID, ok, err := networkVLANID(network, openstackNetwork)
+		if err != nil {
+			return err
+		}
 
-		region, _ := p.openstack.regionSnapshot()
-		// VLAN deallocation is idempotent, but requires the network to
-		// exist so we can lookup the segmentation ID, so this has to
-		// occur first.
-		if region.Spec.Openstack.Network.UseProviderNetworks() {
-			log.V(1).Info("freeing vlan", "id", openstackNetwork.SegmentationID)
+		if ok {
+			log.V(1).Info("freeing vlan", "id", vlanID)
 
-			vlanID, err := strconv.Atoi(openstackNetwork.SegmentationID)
-			if err != nil {
-				return fmt.Errorf("%w: segmentation ID not parsable", err)
-			}
-
-			if err := p.vlanAllocator.Free(ctx, vlanID); err != nil {
+			if err := p.vlanAllocator.Free(ctx, vlanID); err != nil && !kerrors.IsNotFound(err) {
 				return fmt.Errorf("%w: failed to free vlan", err)
 			}
 		}
+	}
+
+	if openstackNetwork != nil {
+		log.V(1).Info("deleting network")
 
 		if err := networking.DeleteNetwork(ctx, openstackNetwork.ID); err != nil {
 			return err
@@ -1755,6 +1759,23 @@ func (p *Provider) DeleteNetwork(ctx context.Context, identity *unikornv1.Identi
 	}
 
 	return nil
+}
+
+func networkVLANID(network *unikornv1.Network, openstackNetwork *NetworkExt) (int, bool, error) {
+	if network.Status.Openstack != nil && network.Status.Openstack.VlanID != nil {
+		return *network.Status.Openstack.VlanID, true, nil
+	}
+
+	if openstackNetwork == nil {
+		return 0, false, nil
+	}
+
+	parsedVLANID, err := strconv.Atoi(openstackNetwork.SegmentationID)
+	if err != nil {
+		return 0, false, fmt.Errorf("%w: segmentation ID not parsable", err)
+	}
+
+	return parsedVLANID, true, nil
 }
 
 // securityGroupRulePortRange expands a security group port into a start-end range as

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -1505,12 +1505,6 @@ func (p *Provider) reconcileNetwork(ctx context.Context, client NetworkInterface
 	if err != nil {
 		log.Error(err, "failed to create OpenStack network", "networkID", network.Name, "vlanID", vlanID)
 
-		if vlanID != nil {
-			if rerr := p.vlanAllocator.Free(ctx, *vlanID); rerr != nil {
-				log.Error(rerr, "failed to free vlan", "id", *vlanID)
-			}
-		}
-
 		return nil, err
 	}
 
@@ -1686,7 +1680,7 @@ func (p *Provider) DeleteNetwork(ctx context.Context, identity *unikornv1.Identi
 	return p.deleteNetwork(ctx, networking, network)
 }
 
-//nolint:gocognit,cyclop
+//nolint:cyclop
 func (p *Provider) deleteNetwork(ctx context.Context, networking NetworkingInterface, network *unikornv1.Network) error {
 	log := log.FromContext(ctx)
 
@@ -1736,21 +1730,13 @@ func (p *Provider) deleteNetwork(ctx context.Context, networking NetworkingInter
 	}
 
 	region, _ := p.openstack.regionSnapshot()
-	// VLAN deallocation is idempotent. Prefer the VLAN ID recorded in
-	// status because the OpenStack network may already be gone; fall back
-	// to the segmentation ID for older Network statuses.
 	if region.Spec.Openstack != nil && region.Spec.Openstack.Network.UseProviderNetworks() {
-		vlanID, ok, err := networkVLANID(network, openstackNetwork)
-		if err != nil {
-			return err
-		}
+		// NetworkID is the allocator source of truth; status and OpenStack
+		// resources can both be missing during delete.
+		log.V(1).Info("freeing vlan", "networkID", network.Name)
 
-		if ok {
-			log.V(1).Info("freeing vlan", "id", vlanID)
-
-			if err := p.vlanAllocator.Free(ctx, vlanID); err != nil && !kerrors.IsNotFound(err) {
-				return fmt.Errorf("%w: failed to free vlan", err)
-			}
+		if err := p.vlanAllocator.FreeByNetworkID(ctx, network.Name); err != nil {
+			return fmt.Errorf("%w: failed to free vlan", err)
 		}
 	}
 
@@ -1763,23 +1749,6 @@ func (p *Provider) deleteNetwork(ctx context.Context, networking NetworkingInter
 	}
 
 	return nil
-}
-
-func networkVLANID(network *unikornv1.Network, openstackNetwork *NetworkExt) (int, bool, error) {
-	if network.Status.Openstack != nil && network.Status.Openstack.VlanID != nil {
-		return *network.Status.Openstack.VlanID, true, nil
-	}
-
-	if openstackNetwork == nil {
-		return 0, false, nil
-	}
-
-	parsedVLANID, err := strconv.Atoi(openstackNetwork.SegmentationID)
-	if err != nil {
-		return 0, false, fmt.Errorf("%w: segmentation ID not parsable", err)
-	}
-
-	return parsedVLANID, true, nil
 }
 
 // securityGroupRulePortRange expands a security group port into a start-end range as

--- a/pkg/providers/internal/openstack/provider_test.go
+++ b/pkg/providers/internal/openstack/provider_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/ptr"
 
@@ -226,6 +227,20 @@ func regionFixture() *regionv1.Region {
 	}
 }
 
+func providerNetworkRegionFixture() *regionv1.Region {
+	region := regionFixture()
+	region.Name = "region"
+	region.Namespace = "default"
+	region.Spec.Provider = regionv1.ProviderOpenstack
+	region.Spec.Openstack.Network = &regionv1.RegionOpenstackNetworkSpec{
+		ProviderNetworks: &regionv1.ProviderNetworks{
+			Network: ptr.To("physnet1"),
+		},
+	}
+
+	return region
+}
+
 // networkFixture creates a basic network definition.
 func networkFixture() *regionv1.Network {
 	return &regionv1.Network{
@@ -249,6 +264,76 @@ func networkFixture() *regionv1.Network {
 			Openstack: &regionv1.NetworkStatusOpenstack{},
 		},
 	}
+}
+
+func TestDeleteNetworkFreesRecordedVLANWhenOpenStackNetworkMissing(t *testing.T) {
+	t.Parallel()
+
+	const vlanID = 607
+
+	region := providerNetworkRegionFixture()
+	network := networkFixture()
+	network.Status.Openstack.VlanID = ptr.To(vlanID)
+
+	allocation := &regionv1.VLANAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: region.Namespace,
+			Name:      region.StaticName(),
+		},
+		Spec: regionv1.VLANAllocationSpec{
+			Allocations: []regionv1.VLANAllocationEntry{
+				{
+					ID:        vlanID,
+					NetworkID: network.Name,
+				},
+			},
+		},
+	}
+
+	client := getClient(t, []client.Object{allocation})
+
+	c := gomock.NewController(t)
+	t.Cleanup(c.Finish)
+
+	networking := mock.NewMockNetworkingInterface(c)
+	networking.EXPECT().GetNetwork(t.Context(), network).Return(nil, errors.ErrResourceNotFound)
+	networking.EXPECT().GetSubnet(t.Context(), network).Return(nil, errors.ErrResourceNotFound)
+	networking.EXPECT().GetRouter(t.Context(), network).Return(nil, errors.ErrResourceNotFound)
+
+	p := openstack.NewTestProvider(client, region)
+
+	require.NoError(t, openstack.DeleteNetworkWithClient(t.Context(), p, networking, network))
+
+	result := &regionv1.VLANAllocation{}
+	require.NoError(t, client.Get(t.Context(), k8stypes.NamespacedName{
+		Namespace: region.Namespace,
+		Name:      region.StaticName(),
+	}, result))
+	require.Empty(t, result.Spec.Allocations)
+}
+
+func TestDeleteNetworkIgnoresMissingVLANAllocation(t *testing.T) {
+	t.Parallel()
+
+	const vlanID = 607
+
+	region := providerNetworkRegionFixture()
+	network := networkFixture()
+	network.Status.Openstack.VlanID = ptr.To(vlanID)
+
+	client := getClient(t, nil)
+
+	c := gomock.NewController(t)
+	t.Cleanup(c.Finish)
+
+	networking := mock.NewMockNetworkingInterface(c)
+	networking.EXPECT().GetNetwork(t.Context(), network).Return(nil, errors.ErrResourceNotFound)
+	networking.EXPECT().GetSubnet(t.Context(), network).Return(nil, errors.ErrResourceNotFound)
+	networking.EXPECT().GetRouter(t.Context(), network).Return(nil, errors.ErrResourceNotFound)
+
+	p := openstack.NewTestProvider(client, region)
+
+	require.NoError(t, openstack.DeleteNetworkWithClient(t.Context(), p, networking, network))
 }
 
 // networkMatcher is used to check mock function call parameters, as the object

--- a/pkg/providers/internal/openstack/provider_test.go
+++ b/pkg/providers/internal/openstack/provider_test.go
@@ -266,14 +266,13 @@ func networkFixture() *regionv1.Network {
 	}
 }
 
-func TestDeleteNetworkFreesRecordedVLANWhenOpenStackNetworkMissing(t *testing.T) {
+func TestDeleteNetworkFreesVLANByNetworkIDWhenOpenStackNetworkMissing(t *testing.T) {
 	t.Parallel()
 
 	const vlanID = 607
 
 	region := providerNetworkRegionFixture()
 	network := networkFixture()
-	network.Status.Openstack.VlanID = ptr.To(vlanID)
 
 	allocation := &regionv1.VLANAllocation{
 		ObjectMeta: metav1.ObjectMeta{
@@ -315,11 +314,8 @@ func TestDeleteNetworkFreesRecordedVLANWhenOpenStackNetworkMissing(t *testing.T)
 func TestDeleteNetworkIgnoresMissingVLANAllocation(t *testing.T) {
 	t.Parallel()
 
-	const vlanID = 607
-
 	region := providerNetworkRegionFixture()
 	network := networkFixture()
-	network.Status.Openstack.VlanID = ptr.To(vlanID)
 
 	client := getClient(t, nil)
 


### PR DESCRIPTION
## Context

Stage UAT found stale VLAN allocation rows where the Region `Network` CR had already been deleted, but `VLANAllocation` still held the VLAN entry. Confirmed examples from the investigation:

- `607 / def703a8-e37c-4264-a503-69532663149b`
- `608 / cc69f439-1afc-43a3-80f7-301ee64ef0de`
- `605 / c3a541a0-6938-4c6f-b4b8-00b3afd73344` remains unmapped but has the same stale allocator shape

Investigation doc: https://www.notion.so/nscalecloud/VLAN-605-607-608-Stale-Allocation-Investigation-uni-region-LoadBalancer-UAT-2026-06-03-374caf6bfadc8174b03afda2de7e0ae3

## Problem

The allocator records ownership as `VLANAllocationEntry.NetworkID`, but network delete previously freed VLANs by VLAN ID derived from the live OpenStack provider network or observed Network status. That can miss cleanup when:

- the OpenStack provider network is already gone, and
- Network status did not record the VLAN ID or is otherwise stale.

That leaves allocator state stale and can later surface as:

```text
allocation failure: vlan ids exhausted
```

## Changes

- Make VLAN allocation idempotent by `networkID`; repeated allocation for the same network returns the existing VLAN.
- Guard against duplicate existing allocations for the same `networkID`.
- Add `FreeByNetworkID`, which frees allocator entries by `NetworkID` and absorbs missing `VLANAllocation` objects/missing entries.
- Use `FreeByNetworkID(ctx, network.Name)` during OpenStack network delete, so cleanup does not depend on Network status or a live OpenStack network.
- Stop rolling back VLAN allocation after OpenStack network creation failure.
- Keep searchable logs for VLAN allocation failure and OpenStack network creation failure.
- Keep the testable delete helper and initialize the test provider's VLAN allocator consistently with the real provider.

## Verification

```text
go test ./pkg/providers/allocation/vlan
go test ./pkg/providers/internal/openstack
make lint
```

Passed locally.
