### PR TITLE
test: uplift handler client-layer unit coverage (region, server, securitygroup)

### DIFF
--- a/pkg/handler/region/region_test.go
+++ b/pkg/handler/region/region_test.go
@@ -18,16 +18,20 @@ package region_test
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	coreerrors "github.com/unikorn-cloud/core/pkg/server/errors"
 	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
 	"github.com/unikorn-cloud/identity/pkg/rbac"
 	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/handler/common"
 	"github.com/unikorn-cloud/region/pkg/handler/region"
+	"github.com/unikorn-cloud/region/pkg/openapi"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -296,4 +300,228 @@ func TestCheckAccessMissingRegion(t *testing.T) {
 	c := regionClientFixture(t)
 
 	require.Error(t, c.CheckAccess(aclFixture(t, organizationID1), "does-not-exist"))
+}
+
+// regionClientWithObjects creates a region.Client backed by a fake Kubernetes client
+// pre-populated with arbitrary objects (e.g. Regions alongside the Secret a Kubernetes
+// region's detail view dereferences). Callers must set each object's namespace.
+func regionClientWithObjects(t *testing.T, objects ...runtime.Object) *region.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, regionv1.AddToScheme(scheme))
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+
+	for _, o := range objects {
+		builder = builder.WithRuntimeObjects(o)
+	}
+
+	return region.NewClient(common.ClientArgs{
+		Client:    builder.Build(),
+		Namespace: testNamespace,
+	})
+}
+
+func simulatedRegion(name string, organizationIDs ...string) regionv1.Region {
+	resource := regionv1.Region{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Spec:       regionv1.RegionSpec{Provider: regionv1.ProviderSimulated},
+	}
+
+	if len(organizationIDs) > 0 {
+		orgs := make([]regionv1.RegionSecurityOrganizationSpec, len(organizationIDs))
+		for i, id := range organizationIDs {
+			orgs[i] = regionv1.RegionSecurityOrganizationSpec{ID: id}
+		}
+
+		resource.Spec.Security = &regionv1.RegionSecuritySpec{Organizations: orgs}
+	}
+
+	return resource
+}
+
+// regionIDs collects the resource IDs from a list of region reads so assertions can
+// be order-independent (List does not impose an ordering guarantee).
+func regionIDs(in openapi.Regions) []string {
+	out := make([]string, len(in))
+	for i := range in {
+		out[i] = in[i].Metadata.Id
+	}
+
+	return out
+}
+
+// TestListIncludesAccessibleprivate verifies List returns public regions plus the
+// private regions the caller's organization is permitted to see.
+func TestListIncludesAccessiblePrivate(t *testing.T) {
+	t.Parallel()
+
+	c := regionClientFixture(t,
+		simulatedRegion(globalRegionName),
+		simulatedRegion(privateRegionName1, organizationID1, organizationID2),
+		simulatedRegion(privateRegionName3, organizationID3),
+	)
+
+	result, err := c.List(aclFixture(t, organizationID1))
+
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	require.ElementsMatch(t, []string{globalRegionName, privateRegionName1}, regionIDs(result))
+}
+
+// TestListExcludesInaccessiblePrivate verifies a caller whose organization matches no
+// private region sees only the public ones.
+func TestListExcludesInaccessiblePrivate(t *testing.T) {
+	t.Parallel()
+
+	c := regionClientFixture(t,
+		simulatedRegion(globalRegionName),
+		simulatedRegion(privateRegionName1, organizationID1),
+	)
+
+	result, err := c.List(aclFixture(t, organizationID4))
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, globalRegionName, result[0].Metadata.Id)
+	require.Equal(t, openapi.RegionTypeSimulated, result[0].Spec.Type)
+}
+
+// TestListGlobalScope verifies a platform admin or service with global scope sees
+// every region regardless of its security constraints.
+func TestListGlobalScope(t *testing.T) {
+	t.Parallel()
+
+	c := regionClientFixture(t,
+		simulatedRegion(globalRegionName),
+		simulatedRegion(privateRegionName1, organizationID1),
+		simulatedRegion(privateRegionName2, organizationID2),
+	)
+
+	result, err := c.List(globalACLFixture(t))
+
+	require.NoError(t, err)
+	require.Len(t, result, 3)
+}
+
+// TestGetDetailSimulated verifies GetDetail returns the region detail for an
+// accessible region without provider-specific configuration.
+func TestGetDetailSimulated(t *testing.T) {
+	t.Parallel()
+
+	c := regionClientFixture(t, simulatedRegion(globalRegionName))
+
+	result, err := c.GetDetail(aclFixture(t, organizationID1), globalRegionName)
+
+	require.NoError(t, err)
+	require.Equal(t, globalRegionName, result.Metadata.Id)
+	require.Equal(t, openapi.RegionTypeSimulated, result.Spec.Type)
+	require.Nil(t, result.Spec.Kubernetes)
+}
+
+// TestGetDetailKubernetesEmbedsKubeconfig verifies GetDetail resolves the referenced
+// kubeconfig secret and returns its contents base64 encoded.
+func TestGetDetailKubernetesEmbedsKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	const (
+		regionName    = "k8s-region"
+		kubeconfigRef = "k8s-region-kubeconfig"
+	)
+
+	kubeconfig := []byte("apiVersion: v1\nkind: Config\n")
+
+	resource := regionv1.Region{
+		ObjectMeta: metav1.ObjectMeta{Name: regionName, Namespace: testNamespace},
+		Spec: regionv1.RegionSpec{
+			Provider: regionv1.ProviderKubernetes,
+			Kubernetes: &regionv1.RegionKubernetesSpec{
+				KubeconfigSecret: &regionv1.NamespacedObject{
+					Namespace: testNamespace,
+					Name:      kubeconfigRef,
+				},
+				DomainName: "example.com",
+			},
+		},
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: kubeconfigRef, Namespace: testNamespace},
+		Data:       map[string][]byte{"kubeconfig": kubeconfig},
+	}
+
+	c := regionClientWithObjects(t, &resource, secret)
+
+	result, err := c.GetDetail(aclFixture(t, organizationID1), regionName)
+
+	require.NoError(t, err)
+	require.Equal(t, openapi.RegionTypeKubernetes, result.Spec.Type)
+	require.NotNil(t, result.Spec.Kubernetes)
+	require.Equal(t, base64.RawURLEncoding.EncodeToString(kubeconfig), result.Spec.Kubernetes.Kubeconfig)
+	require.NotNil(t, result.Spec.Kubernetes.DomainName)
+	require.Equal(t, "example.com", *result.Spec.Kubernetes.DomainName)
+}
+
+// TestGetDetailKubernetesMissingKubeconfigKey verifies GetDetail surfaces an error
+// when the referenced secret exists but lacks the kubeconfig key.
+func TestGetDetailKubernetesMissingKubeconfigKey(t *testing.T) {
+	t.Parallel()
+
+	const (
+		regionName    = "k8s-region"
+		kubeconfigRef = "k8s-region-kubeconfig"
+	)
+
+	resource := regionv1.Region{
+		ObjectMeta: metav1.ObjectMeta{Name: regionName, Namespace: testNamespace},
+		Spec: regionv1.RegionSpec{
+			Provider: regionv1.ProviderKubernetes,
+			Kubernetes: &regionv1.RegionKubernetesSpec{
+				KubeconfigSecret: &regionv1.NamespacedObject{
+					Namespace: testNamespace,
+					Name:      kubeconfigRef,
+				},
+			},
+		},
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: kubeconfigRef, Namespace: testNamespace},
+		Data:       map[string][]byte{"not-kubeconfig": []byte("data")},
+	}
+
+	c := regionClientWithObjects(t, &resource, secret)
+
+	_, err := c.GetDetail(aclFixture(t, organizationID1), regionName)
+
+	require.Error(t, err)
+}
+
+// TestGetDetailNotFound verifies GetDetail returns a not-found error for a region
+// that does not exist.
+func TestGetDetailNotFound(t *testing.T) {
+	t.Parallel()
+
+	c := regionClientFixture(t)
+
+	_, err := c.GetDetail(aclFixture(t, organizationID1), "does-not-exist")
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+// TestGetDetailAccessDenied verifies GetDetail returns a not-found error (not a
+// forbidden error) when the caller's organization cannot see a restricted region,
+// so existence is not leaked.
+func TestGetDetailAccessDenied(t *testing.T) {
+	t.Parallel()
+
+	c := regionClientFixture(t, simulatedRegion(privateRegionName1, organizationID1))
+
+	_, err := c.GetDetail(aclFixture(t, organizationID4), privateRegionName1)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
 }

--- a/pkg/handler/securitygroup/rbac_test.go
+++ b/pkg/handler/securitygroup/rbac_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package securitygroup_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -26,8 +28,10 @@ import (
 	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
 	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
 	coreerrors "github.com/unikorn-cloud/core/pkg/server/errors"
+	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
 	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
 	identitymock "github.com/unikorn-cloud/identity/pkg/openapi/mock"
+	"github.com/unikorn-cloud/identity/pkg/principal"
 	"github.com/unikorn-cloud/identity/pkg/rbac"
 	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/constants"
@@ -188,4 +192,395 @@ func TestSGCreateV2RBACNoCreatePermission(t *testing.T) {
 
 	require.Error(t, err)
 	require.True(t, coreerrors.IsForbidden(err), "expected forbidden, got: %v", err)
+}
+
+// sgProjectACL grants region:networks:v2 read (so network lookups succeed) plus the
+// given region:securitygroups:v2 operations, all at project scope. ListV2/GetV2Raw
+// use AllowProjectScope, so a project-scoped grant is what authorizes them.
+func sgProjectACL(securityGroupOps ...identityapi.AclOperation) *identityapi.Acl {
+	endpoints := identityapi.AclEndpoints{
+		{Name: "region:networks:v2", Operations: identityapi.AclOperations{identityapi.Read}},
+	}
+
+	if len(securityGroupOps) != 0 {
+		endpoints = append(endpoints, identityapi.AclEndpoint{
+			Name:       "region:securitygroups:v2",
+			Operations: securityGroupOps,
+		})
+	}
+
+	return &identityapi.Acl{
+		Organizations: &identityapi.AclOrganizationList{
+			{
+				Id: sgOrganizationID,
+				Projects: &identityapi.AclProjectList{
+					{Id: sgProjectID, Endpoints: endpoints},
+				},
+			},
+		},
+	}
+}
+
+// withSGPrincipal attaches the authorization and principal information that the
+// generate path (InjectUserPrincipal, SetIdentityMetadata) requires on a write.
+func withSGPrincipal(ctx context.Context) context.Context {
+	ctx = authorization.NewContext(ctx, &authorization.Info{
+		Userinfo: &identityapi.Userinfo{Sub: "token-actor"},
+	})
+
+	return principal.NewContext(ctx, &principal.Principal{Actor: "test@example.com"})
+}
+
+// testSecurityGroupV2 returns a v2 SecurityGroup owned by the test org/project and
+// labelled so GetV2Raw's API-version guard passes.
+func testSecurityGroupV2(name string) *regionv1.SecurityGroup {
+	return &regionv1.SecurityGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: sgNamespace,
+			Labels: map[string]string{
+				coreconstants.OrganizationLabel:   sgOrganizationID,
+				coreconstants.ProjectLabel:        sgProjectID,
+				coreconstants.NameLabel:           name,
+				constants.RegionLabel:             "test-region",
+				constants.NetworkLabel:            sgNetworkID,
+				constants.ResourceAPIVersionLabel: constants.MarshalAPIVersion(2),
+			},
+		},
+	}
+}
+
+func newSGClient(t *testing.T, objects ...runtime.Object) *securitygroup.Client {
+	t.Helper()
+
+	return securitygroup.New(common.ClientArgs{
+		Client:    newSGFakeClient(t, objects...).Build(),
+		Namespace: sgNamespace,
+	})
+}
+
+// TestSGGetV2 verifies GetV2 returns a security group's converted view, including the
+// region and network identifiers carried on its labels.
+func TestSGGetV2(t *testing.T) {
+	t.Parallel()
+
+	resource := testSecurityGroupV2("sg-1")
+
+	c := newSGClient(t, resource)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read))
+
+	result, err := c.GetV2(ctx, "sg-1")
+
+	require.NoError(t, err)
+	require.Equal(t, "sg-1", result.Metadata.Id)
+	require.Equal(t, "test-region", result.Status.RegionId)
+	require.Equal(t, sgNetworkID, result.Status.NetworkId)
+}
+
+// TestSGGetV2RawNotFound verifies a missing security group returns 404.
+func TestSGGetV2RawNotFound(t *testing.T) {
+	t.Parallel()
+
+	c := newSGClient(t)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read))
+
+	_, err := c.GetV2Raw(ctx, "does-not-exist")
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+// TestSGGetV2RawNoReadPermission verifies a caller without securitygroup read access
+// is refused even when the resource exists.
+func TestSGGetV2RawNoReadPermission(t *testing.T) {
+	t.Parallel()
+
+	resource := testSecurityGroupV2("sg-1")
+
+	c := newSGClient(t, resource)
+
+	// network read only, no securitygroup read.
+	ctx := rbac.NewContext(t.Context(), sgProjectACL())
+
+	_, err := c.GetV2Raw(ctx, "sg-1")
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsForbidden(err), "expected forbidden, got: %v", err)
+}
+
+// TestSGGetV2RawMissingAPIVersion verifies a resource without the API-version label is
+// hidden behind a 404 rather than being returned by the v2 client.
+func TestSGGetV2RawMissingAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	resource := testSecurityGroupV2("sg-1")
+	delete(resource.Labels, constants.ResourceAPIVersionLabel)
+
+	c := newSGClient(t, resource)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read))
+
+	_, err := c.GetV2Raw(ctx, "sg-1")
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+// TestSGGetV2RawWrongAPIVersion verifies a v1 resource is not reachable through the v2
+// client.
+func TestSGGetV2RawWrongAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	resource := testSecurityGroupV2("sg-1")
+	resource.Labels[constants.ResourceAPIVersionLabel] = constants.MarshalAPIVersion(1)
+
+	c := newSGClient(t, resource)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read))
+
+	_, err := c.GetV2Raw(ctx, "sg-1")
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+// TestSGListV2 verifies ListV2 returns the project's security groups, name-sorted.
+func TestSGListV2(t *testing.T) {
+	t.Parallel()
+
+	c := newSGClient(t, testSecurityGroupV2("sg-b"), testSecurityGroupV2("sg-a"))
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read))
+
+	result, err := c.ListV2(ctx, openapi.GetApiV2SecuritygroupsParams{})
+
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	require.Equal(t, "sg-a", result[0].Metadata.Id)
+	require.Equal(t, "sg-b", result[1].Metadata.Id)
+}
+
+// TestSGListV2ExcludesUnauthorizedProject verifies a security group in a project the
+// caller cannot see is omitted from the listing.
+func TestSGListV2ExcludesUnauthorizedProject(t *testing.T) {
+	t.Parallel()
+
+	visible := testSecurityGroupV2("sg-visible")
+
+	hidden := testSecurityGroupV2("sg-hidden")
+	hidden.Labels[coreconstants.ProjectLabel] = "other-project"
+
+	c := newSGClient(t, visible, hidden)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read))
+
+	result, err := c.ListV2(ctx, openapi.GetApiV2SecuritygroupsParams{})
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, "sg-visible", result[0].Metadata.Id)
+}
+
+// TestSGListV2Empty verifies ListV2 returns nothing when the project has no security
+// groups.
+func TestSGListV2Empty(t *testing.T) {
+	t.Parallel()
+
+	c := newSGClient(t)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read))
+
+	result, err := c.ListV2(ctx, openapi.GetApiV2SecuritygroupsParams{})
+
+	require.NoError(t, err)
+	require.Empty(t, result)
+}
+
+// TestSGDeleteV2 verifies a delete removes the resource and a subsequent read fails.
+func TestSGDeleteV2(t *testing.T) {
+	t.Parallel()
+
+	resource := testSecurityGroupV2("sg-1")
+
+	c := newSGClient(t, resource)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read, identityapi.Delete))
+
+	require.NoError(t, c.DeleteV2(ctx, "sg-1"))
+
+	_, err := c.GetV2Raw(ctx, "sg-1")
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found after delete, got: %v", err)
+}
+
+// TestSGDeleteV2NotFound verifies deleting a missing security group returns 404.
+func TestSGDeleteV2NotFound(t *testing.T) {
+	t.Parallel()
+
+	c := newSGClient(t)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read, identityapi.Delete))
+
+	err := c.DeleteV2(ctx, "does-not-exist")
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+// TestSGDeleteV2NoDeletePermission verifies a read-only caller cannot delete.
+func TestSGDeleteV2NoDeletePermission(t *testing.T) {
+	t.Parallel()
+
+	resource := testSecurityGroupV2("sg-1")
+
+	c := newSGClient(t, resource)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read))
+
+	err := c.DeleteV2(ctx, "sg-1")
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsForbidden(err), "expected forbidden, got: %v", err)
+}
+
+// TestSGDeleteV2InUse verifies a security group still referenced by another resource
+// (an extra finalizer) cannot be deleted and reports a forbidden error.
+func TestSGDeleteV2InUse(t *testing.T) {
+	t.Parallel()
+
+	resource := testSecurityGroupV2("sg-1")
+	resource.Finalizers = []string{"servers.region.unikorn-cloud.org/ref-1"}
+
+	c := newSGClient(t, resource)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read, identityapi.Delete))
+
+	err := c.DeleteV2(ctx, "sg-1")
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsForbidden(err), "expected forbidden (in use), got: %v", err)
+}
+
+// TestSGDeleteV2AlreadyDeleting verifies deleting a resource that is already being
+// deleted is a no-op rather than an error.
+func TestSGDeleteV2AlreadyDeleting(t *testing.T) {
+	t.Parallel()
+
+	resource := testSecurityGroupV2("sg-1")
+	now := metav1.NewTime(time.Now())
+	resource.DeletionTimestamp = &now
+	resource.Finalizers = []string{"securitygroups.region.unikorn-cloud.org/test"}
+
+	c := newSGClient(t, resource)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read, identityapi.Delete))
+
+	require.NoError(t, c.DeleteV2(ctx, "sg-1"))
+}
+
+// TestSGUpdateV2 verifies a successful update applies the requested rules and returns
+// the converted resource.
+//
+// NOTE: UpdateV2 currently authorizes against the Delete operation (see client_v2.go),
+// so a superset grant (Read+Update+Delete) is used here to stay correct regardless of
+// whether that permission check is later corrected to Update.
+func TestSGUpdateV2(t *testing.T) {
+	t.Parallel()
+
+	network := testNetworkWithProject(sgOrganizationID, sgProjectID)
+	resource := testSecurityGroupV2("sg-1")
+
+	c := newSGClient(t, network, resource)
+
+	ctx := withSGPrincipal(rbac.NewContext(t.Context(),
+		sgProjectACL(identityapi.Read, identityapi.Update, identityapi.Delete)))
+
+	request := &openapi.SecurityGroupV2Update{
+		Metadata: coreapi.ResourceWriteMetadata{Name: "sg-1"},
+		Spec: openapi.SecurityGroupV2Spec{
+			Rules: openapi.SecurityGroupRuleV2List{
+				{
+					Direction: openapi.NetworkDirectionIngress,
+					Protocol:  openapi.NetworkProtocolAny,
+				},
+			},
+		},
+	}
+
+	result, err := c.UpdateV2(ctx, "sg-1", request)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Spec.Rules, 1)
+	require.Equal(t, openapi.NetworkDirectionIngress, result.Spec.Rules[0].Direction)
+	require.Equal(t, sgNetworkID, result.Status.NetworkId)
+}
+
+// TestSGUpdateV2NotFound verifies updating a missing security group returns 404.
+func TestSGUpdateV2NotFound(t *testing.T) {
+	t.Parallel()
+
+	c := newSGClient(t)
+
+	ctx := rbac.NewContext(t.Context(),
+		sgProjectACL(identityapi.Read, identityapi.Update, identityapi.Delete))
+
+	request := &openapi.SecurityGroupV2Update{
+		Metadata: coreapi.ResourceWriteMetadata{Name: "does-not-exist"},
+		Spec:     openapi.SecurityGroupV2Spec{Rules: openapi.SecurityGroupRuleV2List{}},
+	}
+
+	_, err := c.UpdateV2(ctx, "does-not-exist", request)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+// TestSGUpdateV2NoPermission verifies a read-only caller cannot update.
+func TestSGUpdateV2NoPermission(t *testing.T) {
+	t.Parallel()
+
+	resource := testSecurityGroupV2("sg-1")
+
+	c := newSGClient(t, resource)
+
+	ctx := rbac.NewContext(t.Context(), sgProjectACL(identityapi.Read))
+
+	request := &openapi.SecurityGroupV2Update{
+		Metadata: coreapi.ResourceWriteMetadata{Name: "sg-1"},
+		Spec:     openapi.SecurityGroupV2Spec{Rules: openapi.SecurityGroupRuleV2List{}},
+	}
+
+	_, err := c.UpdateV2(ctx, "sg-1", request)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsForbidden(err), "expected forbidden, got: %v", err)
+}
+
+// TestSGUpdateV2BeingDeleted verifies updating a resource already marked for deletion
+// is rejected as a bad request.
+func TestSGUpdateV2BeingDeleted(t *testing.T) {
+	t.Parallel()
+
+	resource := testSecurityGroupV2("sg-1")
+	now := metav1.NewTime(time.Now())
+	resource.DeletionTimestamp = &now
+	resource.Finalizers = []string{"securitygroups.region.unikorn-cloud.org/test"}
+
+	c := newSGClient(t, resource)
+
+	ctx := rbac.NewContext(t.Context(),
+		sgProjectACL(identityapi.Read, identityapi.Update, identityapi.Delete))
+
+	request := &openapi.SecurityGroupV2Update{
+		Metadata: coreapi.ResourceWriteMetadata{Name: "sg-1"},
+		Spec:     openapi.SecurityGroupV2Spec{Rules: openapi.SecurityGroupRuleV2List{}},
+	}
+
+	_, err := c.UpdateV2(ctx, "sg-1", request)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsBadRequest(err), "expected bad request (being deleted), got: %v", err)
 }

--- a/pkg/handler/server/client_v2_test.go
+++ b/pkg/handler/server/client_v2_test.go
@@ -880,6 +880,123 @@ func TestServerDeleteV2_NoDeletePermission(t *testing.T) {
 	require.True(t, coreerrors.IsForbidden(err), "expected forbidden, got: %v", err)
 }
 
+// srvProjectACL grants the given region:servers operations at project scope, which
+// is what ListV2 uses to both build its label selector and filter each result.
+func srvProjectACL(ops ...identityapi.AclOperation) *identityapi.Acl {
+	return &identityapi.Acl{
+		Organizations: &identityapi.AclOrganizationList{
+			{
+				Id: srvOrganizationID,
+				Projects: &identityapi.AclProjectList{
+					{
+						Id: srvProjectID,
+						Endpoints: identityapi.AclEndpoints{
+							{Name: "region:servers", Operations: ops},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestServerListV2 verifies ListV2 returns the project's servers, name-sorted, with
+// their status fields populated from the underlying resources.
+func TestServerListV2(t *testing.T) {
+	t.Parallel()
+
+	serverB := testServerV2("server-b")
+	serverA := testServerV2("server-a")
+
+	k8sClient := newSrvFakeClient(t, serverB, serverA).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+	})
+
+	ctx := rbac.NewContext(t.Context(), srvProjectACL(identityapi.Read))
+
+	result, err := c.ListV2(ctx, openapi.GetApiV2ServersParams{})
+
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	require.Equal(t, "server-a", result[0].Metadata.Id)
+	require.Equal(t, "server-b", result[1].Metadata.Id)
+	require.Equal(t, "test-region", result[0].Status.RegionId)
+	require.Equal(t, srvNetworkID, result[0].Status.NetworkId)
+}
+
+// TestServerListV2ExcludesUnauthorizedProject verifies a server in a project the
+// caller cannot see is omitted from the listing.
+func TestServerListV2ExcludesUnauthorizedProject(t *testing.T) {
+	t.Parallel()
+
+	visible := testServerV2("server-visible")
+
+	hidden := testServerV2("server-hidden")
+	hidden.Labels[coreconstants.ProjectLabel] = "other-project"
+
+	k8sClient := newSrvFakeClient(t, visible, hidden).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+	})
+
+	ctx := rbac.NewContext(t.Context(), srvProjectACL(identityapi.Read))
+
+	result, err := c.ListV2(ctx, openapi.GetApiV2ServersParams{})
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, "server-visible", result[0].Metadata.Id)
+}
+
+// TestServerListV2FilterByRegion verifies the regionID query parameter restricts the
+// listing to servers labelled with that region.
+func TestServerListV2FilterByRegion(t *testing.T) {
+	t.Parallel()
+
+	resource := testServerV2("server-1")
+
+	k8sClient := newSrvFakeClient(t, resource).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+	})
+
+	ctx := rbac.NewContext(t.Context(), srvProjectACL(identityapi.Read))
+
+	result, err := c.ListV2(ctx, openapi.GetApiV2ServersParams{
+		RegionID: &openapi.RegionIDQueryParameter{"different-region"},
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, result)
+}
+
+// TestServerListV2Empty verifies ListV2 returns no servers when none exist for the
+// caller's scope.
+func TestServerListV2Empty(t *testing.T) {
+	t.Parallel()
+
+	k8sClient := newSrvFakeClient(t).Build()
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+	})
+
+	ctx := rbac.NewContext(t.Context(), srvProjectACL(identityapi.Read))
+
+	result, err := c.ListV2(ctx, openapi.GetApiV2ServersParams{})
+
+	require.NoError(t, err)
+	require.Empty(t, result)
+}
+
 func TestServerStartV2_NotFound(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes INST-951.

Adds unit coverage for the previously untested read/CRUD paths in the
`region`, `server`, and `securitygroup` handler client layer. All tests use
`fake.NewClientBuilder()` with the region scheme, `gomock` for provider/identity
mocks, `t.Parallel()`, and `t.Context()`.

## What's covered
- **region** — `List` (visibility filtering: accessible-private, excluded-private, global scope) and `GetDetail` (simulated, Kubernetes kubeconfig-secret resolution, missing-key error, not-found, access-denied returns 404 not 403)
- **server** — `ListV2` (name-sorted results, unauthorized-project exclusion, `regionID` filter, empty scope). `GetV2`/write paths were already covered.
- **securitygroup** — `ListV2`, `GetV2`/`GetV2Raw` (not-found, no-read-permission, missing/wrong API-version guard), `DeleteV2` (happy, not-found, no-permission, in-use finalizer, already-deleting no-op), `UpdateV2` (happy, not-found, no-permission, being-deleted)

## Coverage delta
| package | before | after |
|---|---|---|
| handler/region | 19.1% | 55.1% |
| handler/server | 27.8% | 32.3% |
| handler/securitygroup | 14.5% | 45.1% |

## Note
`TestSGUpdateV2` is written with a Read+Update+Delete superset grant because `securitygroup.UpdateV2` currently authorizes against the `Delete` operation rather than `Update` (likely a copy-paste from `DeleteV2`). Tracked separately as a correctness follow-up; this PR keeps the test robust to either behaviour. 
Tracked here: https://linear.app/nscale-workspace/issue/INST-962/uni-region-securitygroup-updatev2-authorizes-against-delete-instead-of