### PR TITLE
test: tolerate load balancer update cache lag

### DIFF
--- a/test/api/suites/loadbalancers_test.go
+++ b/test/api/suites/loadbalancers_test.go
@@ -166,11 +166,15 @@ var _ = Describe("LoadBalancer", func() {
 				Expect(*putResp.Spec.Listeners[0].AllowedCidrs).To(Equal(allowedCidrs))
 				Expect(putResp.Spec.Listeners[0].Pool.Members).To(Equal(updatedMembers))
 
-				roundTrip, err := regionClient.GetLoadBalancer(ctx, lbID)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(roundTrip.Spec.Listeners[0].AllowedCidrs).NotTo(BeNil())
-				Expect(*roundTrip.Spec.Listeners[0].AllowedCidrs).To(Equal(allowedCidrs))
-				Expect(roundTrip.Spec.Listeners[0].Pool.Members).To(Equal(updatedMembers))
+				// The API server reads single-resource GETs through the controller-runtime cache,
+				// so an immediate GET after PUT can briefly observe the pre-update object.
+				Eventually(func(g Gomega) {
+					roundTrip, err := regionClient.GetLoadBalancer(ctx, lbID)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(roundTrip.Spec.Listeners[0].AllowedCidrs).NotTo(BeNil())
+					g.Expect(*roundTrip.Spec.Listeners[0].AllowedCidrs).To(Equal(allowedCidrs))
+					g.Expect(roundTrip.Spec.Listeners[0].Pool.Members).To(Equal(updatedMembers))
+				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
 			})
 
 			It("accepts an update toggling publicIP to false", func() {


### PR DESCRIPTION
## Summary
- make the load balancer update round-trip assertion poll the follow-up GET until the cached API read observes the persisted spec
- keep the immediate PUT response assertions unchanged so handler response behavior is still validated directly

## Investigation
Run `27554846090`, job `81450925857`, failed only on the `LoadBalancer / accepts updates to allowed CIDRs and pool members` spec. The PUT update response contained the requested `allowedCidrs` and pool members, but the immediately following GET returned `allowedCidrs == nil` at `test/api/suites/loadbalancers_test.go:171`.

The test client is not caching. It sends a normal HTTP GET through `test/api/api_client.go`. The cache sits on the server side: the region controller creates its Kubernetes client with `core/pkg/client.New`, which constructs a controller-runtime cache and wires it as the client reader. The load balancer GET handler then reads through `c.Client.Get`, so an immediate read after the PUT patch can observe stale informer state briefly.

There is no fixed cache TTL here; controller-runtime informer cache updates via watch events. In KinD this should normally converge quickly, so the test now uses a tight 5 second timeout with 250ms polling rather than a broad infrastructure-style wait. The same workflow was rerun on the same commit and passed, which points to a read-after-write timing flake rather than a deterministic load balancer update bug or an external provisioning issue.

## Fix
The post-update GET assertion now uses `Eventually`. This still fails if the update never persists, but avoids failing when the API cache has not caught up to the write yet.

## Validation
- `go test -tags=integration ./test/api/suites -run '^$' -count=1`
