### PR TITLE
Make provider deletes idempotent and identity-tolerant

### DIFF
--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -58,6 +58,19 @@ packages are the concrete provider implementations.
     the real backing resources
   - mirrored provider-state records are not the preferred answer unless the
     state cannot be reconstructed safely enough by other means
+- Provider `Delete*` methods must be idempotent and must tolerate an unrealized
+  identity as a no-op. Callers delegate unconditionally; the provider
+  self-gates on realized identity rather than the caller gating on readiness or
+  status:
+  - rediscover backing resources by name rather than trusting recorded status,
+    and treat already-absent resources as success
+  - when the backing service-principal identity has not been realized (the
+    `OpenstackIdentity` is absent, or has no project allocated yet) nothing
+    could have been created, so the delete returns cleanly instead of erroring
+  - this is safe because finalizer ordering keeps the identity alive until its
+    consumers are gone: at delete time it is either realized-and-complete or
+    never realized. Callers must therefore never gate a delete on identity
+    readiness or recorded status — that belongs to this layer.
 - Providers must tolerate changing backing credentials and region state rather
   than assuming client material is static for process lifetime.
   Credential rotation, secret refresh, and region configuration refresh are part

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -1697,8 +1697,44 @@ func (p *Provider) CreateNetwork(ctx context.Context, identity *unikornv1.Identi
 	return nil
 }
 
+// openstackIdentityProvisioned reports whether the service principal has been
+// realized far enough to build a project-scoped client. Finalizer ordering
+// keeps the identity alive until its consumers are gone, so on delete paths a
+// not-yet-provisioned identity (absent, or no project allocated) means nothing
+// provider-side was ever created and the delete is a no-op. Never use this to
+// gate create paths: there the missing project must surface as an error so the
+// manager requeues.
+//
+// The project is the deliberate watermark: it is allocated before any provider
+// resource (a VLAN, Neutron or Octavia object) can be created, so its absence
+// is sufficient to prove nothing exists to delete. Later identity fields (user,
+// password) gate specific clients and still surface their own errors past this
+// point, which is correct: those deletes are idempotent and the manager
+// requeues.
+func (p *Provider) openstackIdentityProvisioned(ctx context.Context, identity *unikornv1.Identity) (bool, error) {
+	openstackIdentity, err := p.GetOpenstackIdentity(ctx, identity)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return openstackIdentity.Spec.ProjectID != nil, nil
+}
+
 // DeleteNetwork deletes a physical network.
 func (p *Provider) DeleteNetwork(ctx context.Context, identity *unikornv1.Identity, network *unikornv1.Network) error {
+	provisioned, err := p.openstackIdentityProvisioned(ctx, identity)
+	if err != nil {
+		return err
+	}
+
+	if !provisioned {
+		return nil
+	}
+
 	// NOTE: this is a privileged network client as it needs permissions
 	// from the manager policy in order to see provider networks for VLAN
 	// deallocation.
@@ -2026,6 +2062,15 @@ func (p *Provider) CreateSecurityGroup(ctx context.Context, identity *unikornv1.
 // DeleteSecurityGroup deletes a security group.
 func (p *Provider) DeleteSecurityGroup(ctx context.Context, identity *unikornv1.Identity, securityGroup *unikornv1.SecurityGroup) error {
 	log := log.FromContext(ctx)
+
+	provisioned, err := p.openstackIdentityProvisioned(ctx, identity)
+	if err != nil {
+		return err
+	}
+
+	if !provisioned {
+		return nil
+	}
 
 	openstackIdentity, err := p.GetOpenstackIdentity(ctx, identity)
 	if err != nil {
@@ -2451,6 +2496,15 @@ func resolveServerKeyName(server *unikornv1.Server, identity *unikornv1.Openstac
 //nolint:cyclop
 func (p *Provider) DeleteServer(ctx context.Context, identity *unikornv1.Identity, server *unikornv1.Server) error {
 	log := log.FromContext(ctx)
+
+	provisioned, err := p.openstackIdentityProvisioned(ctx, identity)
+	if err != nil {
+		return err
+	}
+
+	if !provisioned {
+		return nil
+	}
 
 	compute, err := p.computeFromServicePrincipal(ctx, identity)
 	if err != nil {
@@ -3481,6 +3535,15 @@ func (p *Provider) createLoadBalancer(ctx context.Context, lbClient LoadBalancin
 // IP idempotently. It yields while Octavia is in any PENDING_* state and
 // after issuing a cascade delete so the next reconcile can confirm completion.
 func (p *Provider) DeleteLoadBalancer(ctx context.Context, identity *unikornv1.Identity, loadBalancer *unikornv1.LoadBalancer) error {
+	provisioned, err := p.openstackIdentityProvisioned(ctx, identity)
+	if err != nil {
+		return err
+	}
+
+	if !provisioned {
+		return nil
+	}
+
 	lbClient, err := p.loadBalancerFromServicePrincipal(ctx, identity)
 	if err != nil {
 		return err

--- a/pkg/providers/internal/openstack/provider_test.go
+++ b/pkg/providers/internal/openstack/provider_test.go
@@ -539,6 +539,106 @@ func TestDeleteNetworkSkipsVLANFreeWithoutProviderNetworks(t *testing.T) {
 	assert.Equal(t, network.Name, result.Spec.Allocations[0].NetworkID)
 }
 
+// identityFixture builds an abstract identity whose namespace/name key the
+// lookup of the backing OpenstackIdentity.
+func identityFixture() *regionv1.Identity {
+	return &regionv1.Identity{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-identity",
+		},
+	}
+}
+
+// unrealizedOpenstackIdentityFixture builds a backing OpenstackIdentity for the
+// given identity that has no project allocated yet, modelling a service
+// principal that has not finished provisioning.
+func unrealizedOpenstackIdentityFixture(identity *regionv1.Identity) *regionv1.OpenstackIdentity {
+	return &regionv1.OpenstackIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: identity.Namespace,
+			Name:      identity.Name,
+		},
+	}
+}
+
+// TestDeleteNetworkNoopsWhenIdentityAbsent verifies the delete is a clean no-op
+// when the backing OpenstackIdentity does not exist: nothing could have been
+// created provider-side, so cleanup must not error or block.
+func TestDeleteNetworkNoopsWhenIdentityAbsent(t *testing.T) {
+	t.Parallel()
+
+	region := providerNetworkRegionFixture()
+	identity := identityFixture()
+	network := networkFixture()
+
+	p := openstack.NewTestProvider(getClient(t, nil), region)
+
+	require.NoError(t, p.DeleteNetwork(t.Context(), identity, network))
+}
+
+// TestDeleteNetworkNoopsWhenIdentityUnrealized verifies the delete is a clean
+// no-op when the backing OpenstackIdentity exists but has no project allocated
+// yet (still provisioning).
+func TestDeleteNetworkNoopsWhenIdentityUnrealized(t *testing.T) {
+	t.Parallel()
+
+	region := providerNetworkRegionFixture()
+	identity := identityFixture()
+	network := networkFixture()
+
+	k8sClient := getClient(t, []client.Object{unrealizedOpenstackIdentityFixture(identity)})
+	p := openstack.NewTestProvider(k8sClient, region)
+
+	require.NoError(t, p.DeleteNetwork(t.Context(), identity, network))
+}
+
+// TestDeleteSecurityGroupNoopsWhenIdentityUnrealized is a regression guard: the
+// delete previously dereferenced a nil project ID and panicked. An unrealized
+// identity must be a clean no-op.
+func TestDeleteSecurityGroupNoopsWhenIdentityUnrealized(t *testing.T) {
+	t.Parallel()
+
+	region := providerNetworkRegionFixture()
+	identity := identityFixture()
+	securityGroup := securityGroupFixture()
+
+	k8sClient := getClient(t, []client.Object{unrealizedOpenstackIdentityFixture(identity)})
+	p := openstack.NewTestProvider(k8sClient, region)
+
+	require.NoError(t, p.DeleteSecurityGroup(t.Context(), identity, securityGroup))
+}
+
+// TestDeleteServerNoopsWhenIdentityUnrealized verifies the delete is a clean
+// no-op when the backing identity has no project allocated yet.
+func TestDeleteServerNoopsWhenIdentityUnrealized(t *testing.T) {
+	t.Parallel()
+
+	region := providerNetworkRegionFixture()
+	identity := identityFixture()
+	server := serverFixture()
+
+	k8sClient := getClient(t, []client.Object{unrealizedOpenstackIdentityFixture(identity)})
+	p := openstack.NewTestProvider(k8sClient, region)
+
+	require.NoError(t, p.DeleteServer(t.Context(), identity, server))
+}
+
+// TestDeleteLoadBalancerNoopsWhenIdentityUnrealized verifies the delete is a
+// clean no-op when the backing identity has no project allocated yet.
+func TestDeleteLoadBalancerNoopsWhenIdentityUnrealized(t *testing.T) {
+	t.Parallel()
+
+	region := providerNetworkRegionFixture()
+	identity := identityFixture()
+	loadBalancer := loadBalancerFixture(loadBalancerNetworkFixture())
+
+	k8sClient := getClient(t, []client.Object{unrealizedOpenstackIdentityFixture(identity)})
+	p := openstack.NewTestProvider(k8sClient, region)
+
+	require.NoError(t, p.DeleteLoadBalancer(t.Context(), identity, loadBalancer))
+}
+
 // TestReconcileNetworkSkipsVLANBookkeepingWhenCreateFailsWithoutProviderNetworks
 // verifies that when no VLAN was allocated (region does not use provider
 // networks), a CreateNetwork failure does not trigger any extra VLAN-related

--- a/pkg/provisioners/README.md
+++ b/pkg/provisioners/README.md
@@ -31,16 +31,24 @@ The main deviations from a trivial “call provider create/delete” model are:
 
 Provisioners must handle deletion from any state a handler or earlier reconcile
 step can leave behind. Teardown should split provider cleanup, reference
-cleanup, and quota/accounting cleanup into separate idempotent steps. Gate each
-step on the minimum recorded state it needs rather than on a broad prerequisite
-such as parent identity readiness.
+cleanup, and quota/accounting cleanup into separate idempotent steps that each
+run unconditionally.
+
+Crucially, a delete step must never be gated on a readiness condition or on
+best-effort recorded status (for example provider resource IDs written to
+`Status`). Status is non-authoritative and can lag or be lost, so gating on it
+skips a cleanup that is genuinely required and leaks the resource. Instead, make
+each step idempotent and push tolerance for partial state down to where the
+authoritative truth lives: the provider rediscovers its resources by name and
+no-ops when the parent identity was never realized (see
+[providers](../providers/README.md)). Finalizer ordering guarantees the parent
+identity outlives its consumers, so at delete time it is either
+realized-and-complete or never realized — in both cases an unconditional,
+idempotent delete is correct.
 
 This matters for partially created resources: an allocation or reference may
-already exist even when the provider resource was never created. Waiting for
-provider prerequisites in that window can block cleanup of the side effects that
-do exist. When a lifecycle edge is subtle, keep the predicate named after the
-state it actually observes and document the partial-state window next to that
-predicate.
+already exist even when the provider resource was never created. The provider
+delete simply finds nothing to do; the allocation/reference cleanup still runs.
 
 ## Cross-Package Context
 

--- a/pkg/provisioners/managers/network/README.md
+++ b/pkg/provisioners/managers/network/README.md
@@ -6,8 +6,9 @@ identity/service-principal context is ready.
 Distinctive behaviour:
 
 - blocks on parent identity readiness before provider create
-- skips provider delete when identity is not ready and no provider resource IDs
-  have been recorded, because there is nothing provider-side to remove yet
+- always delegates provider delete unconditionally on deprovision; the provider
+  no-ops idempotently when the identity was never realized, so cleanup is never
+  gated on readiness or best-effort recorded status
 - deletes identity-side quota allocation on deprovision for `v2` networks only
 - carries explicit `v1` compatibility debt in that allocation cleanup path
 

--- a/pkg/provisioners/managers/network/provisioner.go
+++ b/pkg/provisioners/managers/network/provisioner.go
@@ -88,34 +88,6 @@ func (p *Provisioner) Object() unikornv1core.ManagableResourceInterface {
 	return p.network
 }
 
-func identityReady(identity *unikornv1.Identity) bool {
-	condition, err := identity.StatusConditionRead(unikornv1core.ConditionAvailable)
-	if err != nil {
-		return false
-	}
-
-	return condition.Reason == unikornv1core.ConditionReasonProvisioned
-}
-
-func providerResourceIDsRecorded(network *unikornv1.Network) bool {
-	if network.Status.Openstack == nil {
-		return false
-	}
-
-	return network.Status.Openstack.NetworkID != nil ||
-		network.Status.Openstack.SubnetID != nil ||
-		network.Status.Openstack.VlanID != nil
-}
-
-func needsProviderDelete(identity *unikornv1.Identity, network *unikornv1.Network) bool {
-	// A v2 network can be deleted after the API has created its identity-side
-	// allocation but before provisioning has waited for Identity readiness and
-	// recorded provider resource IDs. In that window there is nothing for the
-	// provider to delete, and waiting for Identity readiness would leak the
-	// allocation.
-	return identityReady(identity) || providerResourceIDsRecorded(network)
-}
-
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	provider, identity, err := p.ProviderAndIdentity(ctx, p.network)
@@ -143,10 +115,12 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 		return err
 	}
 
-	if needsProviderDelete(identity, p.network) {
-		if err := provider.DeleteNetwork(ctx, identity, p.network); err != nil {
-			return err
-		}
+	// Provider deletion is unconditional and idempotent: it rediscovers
+	// provider resources by name and frees the VLAN by network name, and no-ops
+	// when the identity was never realized. Never gate it on readiness or
+	// best-effort recorded status, or a lost status write leaks resources.
+	if err := provider.DeleteNetwork(ctx, identity, p.network); err != nil {
+		return err
 	}
 
 	// Temporary hack, V1 networks don't have a discrete network allocation,

--- a/pkg/provisioners/managers/network/provisioner_test.go
+++ b/pkg/provisioners/managers/network/provisioner_test.go
@@ -186,6 +186,9 @@ func TestDeprovision_UnreadyIdentityDeletesAllocation(t *testing.T) {
 	region := testRegion()
 	provider := mocktypes.NewMockProvider(ctrl)
 	provider.EXPECT().Region(gomock.Any()).Return(region, nil)
+	// Deprovision now always delegates to the provider; the provider is
+	// responsible for no-opping when the identity was never realized.
+	provider.EXPECT().DeleteNetwork(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	providers := mockproviders.NewMockProviders(ctrl)
 	providers.EXPECT().LookupCloud(testRegionID).Return(provider, nil).Times(2)


### PR DESCRIPTION
Commit a618471 ("Fix network allocation leak") fixed a real symptom the
wrong way. A v2 network can be deleted while its hidden service-principal
identity is still provisioning (OpenstackIdentity has no ProjectID yet).
DeleteNetwork then failed building its project-scoped client, the error
propagated out of Deprovision, and the downstream identity-side allocation
cleanup never ran, leaking quota.

That commit gated the provider delete behind

    needsProviderDelete = identityReady(identity) ||
                          providerResourceIDsRecorded(network)

where providerResourceIDsRecorded reads Status.Openstack.*. This went wrong
on two counts:

- It made a delete decision depend on best-effort, non-authoritative status
  (CreateNetwork even resets Status.Openstack to empty on every reconcile).
  A lost status write skips a delete that is genuinely required and re-leaks
  the resource. This contradicts the provider contract in
  pkg/providers/README.md: re-find backing resources rather than trusting
  mirrored provider-state records.
- It gated the delete on parent identity readiness, the exact "broad
  prerequisite" the commit's own new Deprovisioning Partial State note in
  pkg/provisioners/README.md said not to gate on.

The delete path was already designed to not trust status: it rediscovers
Neutron resources by name and frees the VLAN by network name, and is fully
idempotent. Gating it added risk and no benefit. The only real precondition
is being able to build a project-scoped client, which needs the identity to
be realized.

Fix it at the layer that owns the truth, and apply it everywhere, since the
same fragility existed unguarded in the other identity-consuming deletes
(DeleteSecurityGroup even dereferenced a nil ProjectID and panicked):

- Add openstackIdentityProvisioned and have DeleteNetwork, DeleteSecurityGroup,
  DeleteServer and DeleteLoadBalancer no-op when the identity was never
  realized (OpenstackIdentity absent or no ProjectID). Finalizer ordering
  guarantees the identity outlives its consumers, so at delete time it is
  either realized-and-complete or never realized; in both cases an
  unconditional idempotent delete is correct.
- Remove needsProviderDelete from the network provisioner; Deprovision now
  delegates unconditionally. The create-side ResourceReady requeue gate stays.
- Correct the docs that encoded the flawed assumption (provisioners and
  network READMEs) and add the idempotent/identity-tolerant delete invariant
  to the providers README.
- Cover the no-op paths for all four deletes, including the security group
  panic regression, and update the network provisioner test to expect the
  unconditional delete.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
