### PR TITLE
Retry server creation on error

### DIFF
--- a/charts/region/crds/region.unikorn-cloud.org_servers.yaml
+++ b/charts/region/crds/region.unikorn-cloud.org_servers.yaml
@@ -241,6 +241,17 @@ spec:
               privateIP:
                 description: PrivateIP is the private IP address of the server.
                 type: string
+              providerCreateFailures:
+                description: |-
+                  ProviderCreateFailures records how many provider-accepted create attempts
+                  later landed in a provider error state before the server launched.
+                format: int32
+                type: integer
+              providerCreateRetrying:
+                description: |-
+                  ProviderCreateRetrying is true while the controller is deleting a failed
+                  provider server before making another create attempt.
+                type: boolean
               publicIP:
                 description: PublicIP is the public IP address of the server.
                 type: string

--- a/charts/region/templates/server-controller/deployment.yaml
+++ b/charts/region/templates/server-controller/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         args:
         {{- include "unikorn.core.flags" . | nindent 8 }}
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
+        {{- range $i, $arg := .Values.serverController.extraFlags }}
+        - {{ $arg }}
+        {{- end }}
         env:
         - name: OTEL_SERVICE_NAME
           value: {{ .Release.Name }}-server-controller

--- a/charts/region/values.yaml
+++ b/charts/region/values.yaml
@@ -170,6 +170,8 @@ securityGroupRuleController:
 serverController:
   # Allow override of the controller image.
   image: ~
+  # An array of extra flags to append to the server controller configuration.
+  extraFlags: ~
   # Allows resource limits to be set.
   resources:
     limits:

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -973,6 +973,12 @@ type ServerStatus struct {
 	// ScheduledAt is the time the provider accepted and processed the creation request.
 	// Nil until the server has been observed in the provider at least once.
 	ScheduledAt *metav1.Time `json:"scheduledAt,omitempty"`
+	// ProviderCreateFailures records how many provider-accepted create attempts
+	// later landed in a provider error state before the server launched.
+	ProviderCreateFailures int32 `json:"providerCreateFailures,omitempty"`
+	// ProviderCreateRetrying is true while the controller is deleting a failed
+	// provider server before making another create attempt.
+	ProviderCreateRetrying bool `json:"providerCreateRetrying,omitempty"`
 }
 
 // OpenstackServerList is a typed list of servers.

--- a/pkg/managers/server/README.md
+++ b/pkg/managers/server/README.md
@@ -6,3 +6,8 @@ It is structurally standard, but it fronts the richest provisioner in the tree:
 [`pkg/provisioners/managers/server`](../../provisioners/managers/server/README.md),
 which maintains explicit resource-reference edges and SSH CA cloud-init
 augmentation.
+
+The watch is slightly broader than the other resource managers: besides server
+spec generation changes, it also wakes the controller when the monitor first
+observes a pre-launch provider server in `Healthy/Errored`. That status edge is
+the trigger for bounded delete-and-retry handling in the server provisioner.

--- a/pkg/managers/server/manager.go
+++ b/pkg/managers/server/manager.go
@@ -18,6 +18,7 @@ limitations under the License.
 package server
 
 import (
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
 	coremanager "github.com/unikorn-cloud/core/pkg/manager"
 	"github.com/unikorn-cloud/core/pkg/manager/options"
@@ -27,7 +28,10 @@ import (
 	"github.com/unikorn-cloud/region/pkg/managers"
 	"github.com/unikorn-cloud/region/pkg/provisioners/managers/server"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -52,7 +56,7 @@ func (*Factory) Metadata() util.ServiceDescriptor {
 
 // Options returns any options to be added to the CLI flags and passed to the reconciler.
 func (*Factory) Options() coremanager.ControllerOptions {
-	return nil
+	return server.NewOptions()
 }
 
 // Reconciler returns a new reconciler instance.
@@ -60,10 +64,50 @@ func (f *Factory) Reconciler(options *options.Options, controllerOptions coreman
 	return coremanager.NewReconciler(options, controllerOptions, manager, f.ProvisionerCreate(server.New))
 }
 
+func providerCreateFailure(server *unikornv1.Server) bool {
+	if server.Status.LaunchedAt != nil {
+		return false
+	}
+
+	switch server.Status.Phase {
+	case unikornv1.InstanceLifecyclePhaseRunning,
+		unikornv1.InstanceLifecyclePhaseStopping,
+		unikornv1.InstanceLifecyclePhaseStopped:
+		return false
+	case unikornv1.InstanceLifecyclePhasePending,
+		unikornv1.InstanceLifecyclePhaseQueued,
+		unikornv1.InstanceLifecyclePhaseBuilding,
+		"":
+	}
+
+	condition, err := server.StatusConditionRead(unikornv1core.ConditionHealthy)
+	if err != nil {
+		return false
+	}
+
+	return condition.Status == corev1.ConditionFalse &&
+		condition.Reason == unikornv1core.ConditionReasonErrored
+}
+
+func providerCreateFailureUpdate(e event.TypedUpdateEvent[*unikornv1.Server]) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+
+	return !providerCreateFailure(e.ObjectOld) && providerCreateFailure(e.ObjectNew)
+}
+
 // RegisterWatches adds any watches that would trigger a reconcile.
 func (*Factory) RegisterWatches(manager manager.Manager, controller controller.Controller) error {
 	// Any changes to the server spec, trigger a reconcile.
-	if err := controller.Watch(source.Kind(manager.GetCache(), &unikornv1.Server{}, &handler.TypedEnqueueRequestForObject[*unikornv1.Server]{}, &predicate.TypedGenerationChangedPredicate[*unikornv1.Server]{})); err != nil {
+	serverPredicate := predicate.Or(
+		predicate.TypedGenerationChangedPredicate[*unikornv1.Server]{},
+		predicate.TypedFuncs[*unikornv1.Server]{
+			UpdateFunc: providerCreateFailureUpdate,
+		},
+	)
+
+	if err := controller.Watch(source.Kind(manager.GetCache(), &unikornv1.Server{}, &handler.TypedEnqueueRequestForObject[*unikornv1.Server]{}, serverPredicate)); err != nil {
 		return err
 	}
 

--- a/pkg/managers/server/manager_test.go
+++ b/pkg/managers/server/manager_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:testpackage // Tests cover the unexported watch predicate directly.
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func serverWithProviderCreateFailure() *unikornv1.Server {
+	server := &unikornv1.Server{}
+	server.StatusConditionWrite(unikornv1core.ConditionHealthy, corev1.ConditionFalse, unikornv1core.ConditionReasonErrored, "")
+
+	return server
+}
+
+func TestProviderCreateFailureUpdate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PreLaunchHealthError", func(t *testing.T) {
+		t.Parallel()
+
+		require.True(t, providerCreateFailureUpdate(event.TypedUpdateEvent[*unikornv1.Server]{
+			ObjectOld: &unikornv1.Server{},
+			ObjectNew: serverWithProviderCreateFailure(),
+		}))
+	})
+
+	t.Run("AlreadyErrored", func(t *testing.T) {
+		t.Parallel()
+
+		server := serverWithProviderCreateFailure()
+
+		require.False(t, providerCreateFailureUpdate(event.TypedUpdateEvent[*unikornv1.Server]{
+			ObjectOld: server,
+			ObjectNew: server.DeepCopy(),
+		}))
+	})
+
+	t.Run("AlreadyLaunched", func(t *testing.T) {
+		t.Parallel()
+
+		server := serverWithProviderCreateFailure()
+		launchedAt := metav1.NewTime(time.Now())
+		server.Status.LaunchedAt = &launchedAt
+
+		require.False(t, providerCreateFailureUpdate(event.TypedUpdateEvent[*unikornv1.Server]{
+			ObjectOld: &unikornv1.Server{},
+			ObjectNew: server,
+		}))
+	})
+
+	t.Run("RunningWithoutLaunchTimestamp", func(t *testing.T) {
+		t.Parallel()
+
+		server := serverWithProviderCreateFailure()
+		server.Status.Phase = unikornv1.InstanceLifecyclePhaseRunning
+
+		require.False(t, providerCreateFailureUpdate(event.TypedUpdateEvent[*unikornv1.Server]{
+			ObjectOld: &unikornv1.Server{},
+			ObjectNew: server,
+		}))
+	})
+}

--- a/pkg/provisioners/managers/server/README.md
+++ b/pkg/provisioners/managers/server/README.md
@@ -26,6 +26,9 @@ This is the clearest controller-side expression of the lifecycle DAG model:
 - Provider create retry state is stored on `Server.status`; changing retry
   behaviour must preserve the invariant that transient provider create failures
   return `ErrYield` until the configured attempt limit is reached.
+- Provider create retries also emit Kubernetes events and structured logs on
+  retry start, retry readiness after delete, and retry exhaustion; avoid
+  per-reconcile emissions while deletion is still converging.
 - The provisioner currently trusts the API not to supply repeated network or
   security-group IDs, even though the code still carries explicit TODOs to
   reject duplicates.

--- a/pkg/provisioners/managers/server/README.md
+++ b/pkg/provisioners/managers/server/README.md
@@ -8,6 +8,8 @@ Distinctive behaviour:
   security groups, and optional SSH certificate authority
 - blocks on identity readiness before provider create/delete
 - augments provider create options with managed cloud-init parts for SSH CA use
+- retries provider-accepted create attempts that later land in provider error,
+  deleting the failed provider server before a bounded re-attempt
 - clears or updates consumed-resource references during reprovision and teardown
 
 This is the clearest controller-side expression of the lifecycle DAG model:
@@ -21,6 +23,9 @@ This is the clearest controller-side expression of the lifecycle DAG model:
 
 - Reference maintenance here is easy to underappreciate, but it is central to
   keeping server deletion and dependent-resource blocking semantics correct.
+- Provider create retry state is stored on `Server.status`; changing retry
+  behaviour must preserve the invariant that transient provider create failures
+  return `ErrYield` until the configured attempt limit is reached.
 - The provisioner currently trusts the API not to supply repeated network or
   security-group IDs, even though the code still carries explicit TODOs to
   reject duplicates.

--- a/pkg/provisioners/managers/server/export_test.go
+++ b/pkg/provisioners/managers/server/export_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 	"github.com/unikorn-cloud/region/pkg/provisioners/internal/base"
 
+	"k8s.io/client-go/tools/record"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,16 +37,22 @@ func ServerCreateOptionsForTest(ctx context.Context, server *unikornv1.Server, c
 	return provisioner.serverCreateOptions(ctx, cli)
 }
 
-func NewForTest(server *unikornv1.Server, providers providers.Providers, options *Options) *Provisioner {
+func NewForTest(server *unikornv1.Server, providers providers.Providers, options *Options, recorders ...record.EventRecorder) *Provisioner {
 	if options == nil {
 		options = NewOptions()
 	}
 
-	return &Provisioner{
+	provisioner := &Provisioner{
 		server:  server,
 		options: options,
 		Base: base.Base{
 			Providers: providers,
 		},
 	}
+
+	if len(recorders) > 0 {
+		provisioner.recorder = recorders[0]
+	}
+
+	return provisioner
 }

--- a/pkg/provisioners/managers/server/export_test.go
+++ b/pkg/provisioners/managers/server/export_test.go
@@ -20,7 +20,9 @@ import (
 	"context"
 
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/providers"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
+	"github.com/unikorn-cloud/region/pkg/provisioners/internal/base"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -31,4 +33,18 @@ func ServerCreateOptionsForTest(ctx context.Context, server *unikornv1.Server, c
 	}
 
 	return provisioner.serverCreateOptions(ctx, cli)
+}
+
+func NewForTest(server *unikornv1.Server, providers providers.Providers, options *Options) *Provisioner {
+	if options == nil {
+		options = NewOptions()
+	}
+
+	return &Provisioner{
+		server:  server,
+		options: options,
+		Base: base.Base{
+			Providers: providers,
+		},
+	}
 }

--- a/pkg/provisioners/managers/server/provisioner.go
+++ b/pkg/provisioners/managers/server/provisioner.go
@@ -19,36 +19,76 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
+	"github.com/spf13/pflag"
 
 	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
 	"github.com/unikorn-cloud/core/pkg/manager"
 	"github.com/unikorn-cloud/core/pkg/provisioners"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/providers"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
 	"github.com/unikorn-cloud/region/pkg/provisioners/internal/base"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const defaultProviderCreateMaxAttempts = 3
+
+var errProviderServerCreateFailed = errors.New("provider server create failed")
+
+// Options allows access to CLI options in the provisioner.
+type Options struct {
+	// ProviderCreateMaxAttempts bounds provider server create attempts before
+	// surfacing an error on the Server.
+	ProviderCreateMaxAttempts int32
+}
+
+// NewOptions returns server controller options with production defaults.
+func NewOptions() *Options {
+	return &Options{
+		ProviderCreateMaxAttempts: defaultProviderCreateMaxAttempts,
+	}
+}
+
+func (o *Options) AddFlags(f *pflag.FlagSet) {
+	if o.ProviderCreateMaxAttempts == 0 {
+		o.ProviderCreateMaxAttempts = defaultProviderCreateMaxAttempts
+	}
+
+	f.Int32Var(&o.ProviderCreateMaxAttempts, "provider-create-max-attempts", o.ProviderCreateMaxAttempts, "Maximum provider server create attempts before surfacing an error")
+}
 
 // Provisioner encapsulates control plane provisioning.
 type Provisioner struct {
 	provisioners.Metadata
 	// server is the server we're provisioning.
 	server *unikornv1.Server
+	// options are documented for the type.
+	options *Options
 
 	// Base gives this methods for getting identities and providers.
 	base.Base
 }
 
 // New returns a new initialized provisioner object.
-func New(_ manager.ControllerOptions, providers providers.Providers) provisioners.ManagerProvisioner {
+func New(options manager.ControllerOptions, providers providers.Providers) provisioners.ManagerProvisioner {
+	o, _ := options.(*Options)
+	if o == nil {
+		o = NewOptions()
+	}
+
 	return &Provisioner{
-		server: &unikornv1.Server{},
+		server:  &unikornv1.Server{},
+		options: o,
 		Base: base.Base{
 			Providers: providers,
 		},
@@ -173,6 +213,98 @@ func (p *Provisioner) identityListOptions() *client.ListOptions {
 	}
 }
 
+func (p *Provisioner) providerCreateMaxAttempts() int32 {
+	if p.options == nil {
+		return defaultProviderCreateMaxAttempts
+	}
+
+	if p.options.ProviderCreateMaxAttempts < 1 {
+		return 1
+	}
+
+	return p.options.ProviderCreateMaxAttempts
+}
+
+func (p *Provisioner) providerCreateFailure() bool {
+	if p.server.Status.LaunchedAt != nil {
+		return false
+	}
+
+	switch p.server.Status.Phase {
+	case unikornv1.InstanceLifecyclePhaseRunning,
+		unikornv1.InstanceLifecyclePhaseStopping,
+		unikornv1.InstanceLifecyclePhaseStopped:
+		return false
+	case unikornv1.InstanceLifecyclePhasePending,
+		unikornv1.InstanceLifecyclePhaseQueued,
+		unikornv1.InstanceLifecyclePhaseBuilding,
+		"":
+	}
+
+	condition, err := p.server.StatusConditionRead(unikornv1core.ConditionHealthy)
+	if err != nil {
+		return false
+	}
+
+	return condition.Status == corev1.ConditionFalse &&
+		condition.Reason == unikornv1core.ConditionReasonErrored
+}
+
+func (p *Provisioner) resetProviderCreateRuntimeStatus(message string) {
+	p.server.Status.Phase = unikornv1.InstanceLifecyclePhasePending
+	p.server.Status.PrivateIP = nil
+	p.server.Status.PublicIP = nil
+	p.server.Status.MACAddress = nil
+	p.server.Status.LaunchedAt = nil
+	p.server.Status.ScheduledAt = nil
+	p.server.StatusConditionWrite(unikornv1core.ConditionHealthy, corev1.ConditionUnknown, unikornv1core.ConditionReasonProvisioning, message)
+}
+
+func (p *Provisioner) deleteFailedProviderServer(ctx context.Context, provider types.Provider, identity *unikornv1.Identity) error {
+	if err := provider.DeleteServer(ctx, identity, p.server); err != nil {
+		return err
+	}
+
+	if err := provider.UpdateServerState(ctx, identity, p.server); err != nil {
+		if !errors.Is(err, coreerrors.ErrResourceNotFound) {
+			return err
+		}
+
+		p.server.Status.ProviderCreateRetrying = false
+		p.resetProviderCreateRuntimeStatus("Retrying provider server create")
+
+		return provisioners.ErrYield
+	}
+
+	p.server.Status.ProviderCreateRetrying = true
+	p.resetProviderCreateRuntimeStatus("Deleting failed provider server before retrying create")
+
+	return provisioners.ErrYield
+}
+
+func (p *Provisioner) handleProviderCreateRetry(ctx context.Context, provider types.Provider, identity *unikornv1.Identity) (bool, error) {
+	if p.server.Status.ProviderCreateRetrying {
+		return true, p.deleteFailedProviderServer(ctx, provider, identity)
+	}
+
+	if !p.providerCreateFailure() {
+		return false, nil
+	}
+
+	attempt := p.server.Status.ProviderCreateFailures + 1
+	p.server.Status.ProviderCreateFailures = attempt
+
+	if attempt >= p.providerCreateMaxAttempts() {
+		p.server.Status.ProviderCreateRetrying = false
+
+		return true, fmt.Errorf("%w after %d attempts", errProviderServerCreateFailed, attempt)
+	}
+
+	p.server.Status.ProviderCreateRetrying = true
+
+	return true, p.deleteFailedProviderServer(ctx, provider, identity)
+}
+
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	cli, err := coreclient.FromContext(ctx)
@@ -196,6 +328,10 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 	}
 
 	if err := manager.ResourceReady(ctx, identity); err != nil {
+		return err
+	}
+
+	if handled, err := p.handleProviderCreateRetry(ctx, provider, identity); handled {
 		return err
 	}
 

--- a/pkg/provisioners/managers/server/provisioner.go
+++ b/pkg/provisioners/managers/server/provisioner.go
@@ -37,11 +37,19 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const defaultProviderCreateMaxAttempts = 3
+const (
+	defaultProviderCreateMaxAttempts = 3
+
+	eventReasonProviderCreateRetrying   = "ProviderCreateRetrying"
+	eventReasonProviderCreateRetryReady = "ProviderCreateRetryReady"
+	eventReasonProviderCreateFailed     = "ProviderCreateFailed"
+)
 
 var errProviderServerCreateFailed = errors.New("provider server create failed")
 
@@ -74,6 +82,8 @@ type Provisioner struct {
 	server *unikornv1.Server
 	// options are documented for the type.
 	options *Options
+	// recorder is used to emit provider create retry events.
+	recorder record.EventRecorder
 
 	// Base gives this methods for getting identities and providers.
 	base.Base
@@ -225,6 +235,19 @@ func (p *Provisioner) providerCreateMaxAttempts() int32 {
 	return p.options.ProviderCreateMaxAttempts
 }
 
+func (p *Provisioner) eventRecorder(ctx context.Context) record.EventRecorder {
+	if p.recorder != nil {
+		return p.recorder
+	}
+
+	return manager.FromContext(ctx).GetEventRecorderFor("server-controller")
+}
+
+func (p *Provisioner) recordProviderCreateRetryEvent(ctx context.Context, eventType, reason, logMessage, eventMessage string, attempt, maxAttempts int32) {
+	log.FromContext(ctx).Info(logMessage, "eventType", eventType, "reason", reason, "attempt", attempt, "maxAttempts", maxAttempts)
+	p.eventRecorder(ctx).Event(p.server, eventType, reason, eventMessage)
+}
+
 func (p *Provisioner) providerCreateFailure() bool {
 	if p.server.Status.LaunchedAt != nil {
 		return false
@@ -260,7 +283,7 @@ func (p *Provisioner) resetProviderCreateRuntimeStatus(message string) {
 	p.server.StatusConditionWrite(unikornv1core.ConditionHealthy, corev1.ConditionUnknown, unikornv1core.ConditionReasonProvisioning, message)
 }
 
-func (p *Provisioner) deleteFailedProviderServer(ctx context.Context, provider types.Provider, identity *unikornv1.Identity) error {
+func (p *Provisioner) deleteFailedProviderServer(ctx context.Context, provider types.Provider, identity *unikornv1.Identity, attempt, maxAttempts int32) error {
 	if err := provider.DeleteServer(ctx, identity, p.server); err != nil {
 		return err
 	}
@@ -272,6 +295,15 @@ func (p *Provisioner) deleteFailedProviderServer(ctx context.Context, provider t
 
 		p.server.Status.ProviderCreateRetrying = false
 		p.resetProviderCreateRuntimeStatus("Retrying provider server create")
+		p.recordProviderCreateRetryEvent(
+			ctx,
+			corev1.EventTypeNormal,
+			eventReasonProviderCreateRetryReady,
+			"retrying provider server create",
+			fmt.Sprintf("Failed provider server deleted; retrying provider server create (attempt %d/%d)", attempt, maxAttempts),
+			attempt,
+			maxAttempts,
+		)
 
 		return provisioners.ErrYield
 	}
@@ -283,8 +315,10 @@ func (p *Provisioner) deleteFailedProviderServer(ctx context.Context, provider t
 }
 
 func (p *Provisioner) handleProviderCreateRetry(ctx context.Context, provider types.Provider, identity *unikornv1.Identity) (bool, error) {
+	maxAttempts := p.providerCreateMaxAttempts()
+
 	if p.server.Status.ProviderCreateRetrying {
-		return true, p.deleteFailedProviderServer(ctx, provider, identity)
+		return true, p.deleteFailedProviderServer(ctx, provider, identity, p.server.Status.ProviderCreateFailures, maxAttempts)
 	}
 
 	if !p.providerCreateFailure() {
@@ -294,15 +328,33 @@ func (p *Provisioner) handleProviderCreateRetry(ctx context.Context, provider ty
 	attempt := p.server.Status.ProviderCreateFailures + 1
 	p.server.Status.ProviderCreateFailures = attempt
 
-	if attempt >= p.providerCreateMaxAttempts() {
+	if attempt >= maxAttempts {
 		p.server.Status.ProviderCreateRetrying = false
+		p.recordProviderCreateRetryEvent(
+			ctx,
+			corev1.EventTypeWarning,
+			eventReasonProviderCreateFailed,
+			"provider server create failed after all retry attempts",
+			fmt.Sprintf("Provider server create failed after %d attempts", attempt),
+			attempt,
+			maxAttempts,
+		)
 
 		return true, fmt.Errorf("%w after %d attempts", errProviderServerCreateFailed, attempt)
 	}
 
 	p.server.Status.ProviderCreateRetrying = true
+	p.recordProviderCreateRetryEvent(
+		ctx,
+		corev1.EventTypeNormal,
+		eventReasonProviderCreateRetrying,
+		"deleting failed provider server before retrying create",
+		fmt.Sprintf("Deleting failed provider server before retrying create (attempt %d/%d)", attempt, maxAttempts),
+		attempt,
+		maxAttempts,
+	)
 
-	return true, p.deleteFailedProviderServer(ctx, provider, identity)
+	return true, p.deleteFailedProviderServer(ctx, provider, identity, attempt, maxAttempts)
 }
 
 // Provision implements the Provision interface.

--- a/pkg/provisioners/managers/server/provisioner_retry_test.go
+++ b/pkg/provisioners/managers/server/provisioner_retry_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -114,13 +115,36 @@ func withRuntimeStatus(server *regionv1.Server) {
 	server.Status.ScheduledAt = &scheduledAt
 }
 
-func retryProvisioner(t *testing.T, server *regionv1.Server, options *serverprovisioner.Options, provider *mocktypes.MockProvider) *serverprovisioner.Provisioner {
+func retryProvisioner(t *testing.T, server *regionv1.Server, options *serverprovisioner.Options, provider *mocktypes.MockProvider, recorders ...record.EventRecorder) *serverprovisioner.Provisioner {
 	t.Helper()
 
 	providers := mockproviders.NewMockProviders(gomock.NewController(t))
 	providers.EXPECT().LookupCloud(retryRegionID).Return(provider, nil)
 
-	return serverprovisioner.NewForTest(server, providers, options)
+	return serverprovisioner.NewForTest(server, providers, options, recorders...)
+}
+
+func requireEvent(t *testing.T, recorder *record.FakeRecorder, values ...string) {
+	t.Helper()
+
+	select {
+	case event := <-recorder.Events:
+		for _, value := range values {
+			require.Contains(t, event, value)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func requireNoEvent(t *testing.T, recorder *record.FakeRecorder) {
+	t.Helper()
+
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected event: %s", event)
+	default:
+	}
 }
 
 func TestProvision_ProviderCreateFailureDeletesAndYields(t *testing.T) {
@@ -135,7 +159,8 @@ func TestProvision_ProviderCreateFailureDeletesAndYields(t *testing.T) {
 	provider.EXPECT().UpdateServerState(gomock.Any(), gomock.Any(), server).Return(coreerrors.ErrResourceNotFound)
 
 	cli := retryClient(t, retryIdentity(), server)
-	prov := retryProvisioner(t, server, nil, provider)
+	recorder := record.NewFakeRecorder(2)
+	prov := retryProvisioner(t, server, nil, provider, recorder)
 
 	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
 	require.ErrorIs(t, err, provisioners.ErrYield)
@@ -151,6 +176,9 @@ func TestProvision_ProviderCreateFailureDeletesAndYields(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, corev1.ConditionUnknown, condition.Status)
 	require.Equal(t, unikornv1core.ConditionReasonProvisioning, condition.Reason)
+
+	requireEvent(t, recorder, corev1.EventTypeNormal, "ProviderCreateRetrying", "attempt 1/3")
+	requireEvent(t, recorder, corev1.EventTypeNormal, "ProviderCreateRetryReady", "attempt 1/3")
 }
 
 func TestProvision_ProviderCreateRetryKeepsDeleting(t *testing.T) {
@@ -171,7 +199,8 @@ func TestProvision_ProviderCreateRetryKeepsDeleting(t *testing.T) {
 		})
 
 	cli := retryClient(t, retryIdentity(), server)
-	prov := retryProvisioner(t, server, nil, provider)
+	recorder := record.NewFakeRecorder(1)
+	prov := retryProvisioner(t, server, nil, provider, recorder)
 
 	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
 	require.ErrorIs(t, err, provisioners.ErrYield)
@@ -182,6 +211,7 @@ func TestProvision_ProviderCreateRetryKeepsDeleting(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, corev1.ConditionUnknown, condition.Status)
 	require.Equal(t, unikornv1core.ConditionReasonProvisioning, condition.Reason)
+	requireNoEvent(t, recorder)
 }
 
 func TestProvision_ProviderCreateFailureStopsAtAttemptLimit(t *testing.T) {
@@ -195,12 +225,14 @@ func TestProvision_ProviderCreateFailureStopsAtAttemptLimit(t *testing.T) {
 	provider := mocktypes.NewMockProvider(ctrl)
 
 	cli := retryClient(t, retryIdentity(), server)
-	prov := retryProvisioner(t, server, &serverprovisioner.Options{ProviderCreateMaxAttempts: 3}, provider)
+	recorder := record.NewFakeRecorder(1)
+	prov := retryProvisioner(t, server, &serverprovisioner.Options{ProviderCreateMaxAttempts: 3}, provider, recorder)
 
 	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
 	require.ErrorContains(t, err, "provider server create failed after 3 attempts")
 	require.Equal(t, int32(3), server.Status.ProviderCreateFailures)
 	require.False(t, server.Status.ProviderCreateRetrying)
+	requireEvent(t, recorder, corev1.EventTypeWarning, "ProviderCreateFailed", "after 3 attempts")
 }
 
 func TestProvision_LaunchedServerHealthErrorDoesNotRetryCreate(t *testing.T) {

--- a/pkg/provisioners/managers/server/provisioner_retry_test.go
+++ b/pkg/provisioners/managers/server/provisioner_retry_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	coreclient "github.com/unikorn-cloud/core/pkg/client"
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	"github.com/unikorn-cloud/core/pkg/provisioners"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	mockproviders "github.com/unikorn-cloud/region/pkg/providers/mock"
+	mocktypes "github.com/unikorn-cloud/region/pkg/providers/types/mock"
+	serverprovisioner "github.com/unikorn-cloud/region/pkg/provisioners/managers/server"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	retryRegionID   = "region-1"
+	retryIdentityID = "identity-1"
+)
+
+func retryServer(opts ...func(*regionv1.Server)) *regionv1.Server {
+	opts = append([]func(*regionv1.Server){
+		func(server *regionv1.Server) {
+			server.Labels = map[string]string{
+				coreconstants.NameLabel: "server-1",
+				constants.RegionLabel:   retryRegionID,
+				constants.IdentityLabel: retryIdentityID,
+			}
+		},
+	}, opts...)
+
+	return testServer(opts...)
+}
+
+func retryIdentity() *regionv1.Identity {
+	identity := &regionv1.Identity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      retryIdentityID,
+			Namespace: "default",
+		},
+	}
+
+	identity.StatusConditionWrite(unikornv1core.ConditionAvailable, corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "")
+
+	return identity
+}
+
+func retryClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	scheme, err := coreclient.NewScheme(regionv1.AddToScheme)
+	require.NoError(t, err)
+
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{regionv1.SchemeGroupVersion})
+	mapper.Add(regionv1.SchemeGroupVersion.WithKind("Server"), meta.RESTScopeNamespace)
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(mapper).
+		WithObjects(objects...).
+		Build()
+}
+
+func withProviderCreateFailure(server *regionv1.Server) {
+	server.StatusConditionWrite(unikornv1core.ConditionHealthy, corev1.ConditionFalse, unikornv1core.ConditionReasonErrored, "server is in an error state")
+}
+
+func withProviderCreateRetrying(server *regionv1.Server) {
+	server.Status.ProviderCreateFailures = 1
+	server.Status.ProviderCreateRetrying = true
+}
+
+func withRuntimeStatus(server *regionv1.Server) {
+	privateIP := "10.0.0.10"
+	publicIP := "203.0.113.10"
+	macAddress := "00:11:22:33:44:55"
+	scheduledAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+
+	server.Status.Phase = regionv1.InstanceLifecyclePhaseBuilding
+	server.Status.PrivateIP = &privateIP
+	server.Status.PublicIP = &publicIP
+	server.Status.MACAddress = &macAddress
+	server.Status.ScheduledAt = &scheduledAt
+}
+
+func retryProvisioner(t *testing.T, server *regionv1.Server, options *serverprovisioner.Options, provider *mocktypes.MockProvider) *serverprovisioner.Provisioner {
+	t.Helper()
+
+	providers := mockproviders.NewMockProviders(gomock.NewController(t))
+	providers.EXPECT().LookupCloud(retryRegionID).Return(provider, nil)
+
+	return serverprovisioner.NewForTest(server, providers, options)
+}
+
+func TestProvision_ProviderCreateFailureDeletesAndYields(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	server := retryServer(withProviderCreateFailure, withRuntimeStatus)
+
+	provider := mocktypes.NewMockProvider(ctrl)
+	provider.EXPECT().DeleteServer(gomock.Any(), gomock.Any(), server).Return(nil)
+	provider.EXPECT().UpdateServerState(gomock.Any(), gomock.Any(), server).Return(coreerrors.ErrResourceNotFound)
+
+	cli := retryClient(t, retryIdentity(), server)
+	prov := retryProvisioner(t, server, nil, provider)
+
+	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
+	require.ErrorIs(t, err, provisioners.ErrYield)
+	require.Equal(t, int32(1), server.Status.ProviderCreateFailures)
+	require.False(t, server.Status.ProviderCreateRetrying)
+	require.Equal(t, regionv1.InstanceLifecyclePhasePending, server.Status.Phase)
+	require.Nil(t, server.Status.PrivateIP)
+	require.Nil(t, server.Status.PublicIP)
+	require.Nil(t, server.Status.MACAddress)
+	require.Nil(t, server.Status.ScheduledAt)
+
+	condition, err := server.StatusConditionRead(unikornv1core.ConditionHealthy)
+	require.NoError(t, err)
+	require.Equal(t, corev1.ConditionUnknown, condition.Status)
+	require.Equal(t, unikornv1core.ConditionReasonProvisioning, condition.Reason)
+}
+
+func TestProvision_ProviderCreateRetryKeepsDeleting(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	server := retryServer(withProviderCreateRetrying, withRuntimeStatus)
+
+	provider := mocktypes.NewMockProvider(ctrl)
+	provider.EXPECT().DeleteServer(gomock.Any(), gomock.Any(), server).Return(nil)
+	provider.EXPECT().
+		UpdateServerState(gomock.Any(), gomock.Any(), server).
+		DoAndReturn(func(_ context.Context, _ *regionv1.Identity, s *regionv1.Server) error {
+			withProviderCreateFailure(s)
+
+			return nil
+		})
+
+	cli := retryClient(t, retryIdentity(), server)
+	prov := retryProvisioner(t, server, nil, provider)
+
+	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
+	require.ErrorIs(t, err, provisioners.ErrYield)
+	require.Equal(t, int32(1), server.Status.ProviderCreateFailures)
+	require.True(t, server.Status.ProviderCreateRetrying)
+
+	condition, err := server.StatusConditionRead(unikornv1core.ConditionHealthy)
+	require.NoError(t, err)
+	require.Equal(t, corev1.ConditionUnknown, condition.Status)
+	require.Equal(t, unikornv1core.ConditionReasonProvisioning, condition.Reason)
+}
+
+func TestProvision_ProviderCreateFailureStopsAtAttemptLimit(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	server := retryServer(withProviderCreateFailure)
+	server.Status.ProviderCreateFailures = 2
+
+	provider := mocktypes.NewMockProvider(ctrl)
+
+	cli := retryClient(t, retryIdentity(), server)
+	prov := retryProvisioner(t, server, &serverprovisioner.Options{ProviderCreateMaxAttempts: 3}, provider)
+
+	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
+	require.ErrorContains(t, err, "provider server create failed after 3 attempts")
+	require.Equal(t, int32(3), server.Status.ProviderCreateFailures)
+	require.False(t, server.Status.ProviderCreateRetrying)
+}
+
+func TestProvision_LaunchedServerHealthErrorDoesNotRetryCreate(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	server := retryServer(withProviderCreateFailure)
+	launchedAt := metav1.NewTime(time.Now().Add(-time.Minute))
+	server.Status.LaunchedAt = &launchedAt
+
+	provider := mocktypes.NewMockProvider(ctrl)
+	provider.EXPECT().CreateServer(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil)
+
+	cli := retryClient(t, retryIdentity(), server)
+	prov := retryProvisioner(t, server, nil, provider)
+
+	require.NoError(t, prov.Provision(coreclient.NewContext(t.Context(), cli)))
+	require.Zero(t, server.Status.ProviderCreateFailures)
+	require.False(t, server.Status.ProviderCreateRetrying)
+}


### PR DESCRIPTION
Related to #568, another mitigation for transient conditions. In this case, experience shows that when a (Nova) server is in an error state, deleting it and creating again will often get past problems. Unlike #568, this applies to VMs, baremetal, and pinned baremetal -- though the latter two categories are more likely to end up in error states.

Also unlike #568, which does a pre-flight check specific to OpenStack, this can be implemented generically in the controller, rather than behind the provider abstraction. "Error" is kept as a terminal state: the controller will only mark a Server as being in error state once it's used up the retries. And, since there's no external signal otherwise, an event is recorded (and a log line logged) on each retry.
