### PR TITLE
Validate service version as semver in integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.3.1 // indirect
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/brunoga/deep v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,6 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/unikorn-cloud/core v1.17.1 h1:HTdh055cAyqROqFUTGRQE4zJW9J5Xzm/6Naa/YGYY3M=
 github.com/unikorn-cloud/core v1.17.1/go.mod h1:t91+Hw7YbNt5nOtp93Ij826iQfYDcz6Og0KAi2xq+B8=
-github.com/unikorn-cloud/identity v1.17.7-0.20260618074532-d586263f3dcf h1:TemAgoQfftz/+GOt4hmtUFi+BkUunOGe3XkK1OlfvBA=
-github.com/unikorn-cloud/identity v1.17.7-0.20260618074532-d586263f3dcf/go.mod h1:hNcesH3wRepz3jsnb9GZYf8eAIiGKSMVYZu8zcydBzU=
 github.com/unikorn-cloud/identity v1.17.7 h1:TShYCMuv+5TRtJM/S2RfiOHsDHanYU4FJcb8UbJPzy8=
 github.com/unikorn-cloud/identity v1.17.7/go.mod h1:hNcesH3wRepz3jsnb9GZYf8eAIiGKSMVYZu8zcydBzU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/test/api/suites/version_test.go
+++ b/test/api/suites/version_test.go
@@ -23,6 +23,8 @@ package suites
 import (
 	"net/http"
 
+	"github.com/Masterminds/semver/v3"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -37,10 +39,11 @@ var _ = Describe("Service Version", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(version.Name).To(HavePrefix("unikorn-region-"))
-				Expect(version.Version).To(SatisfyAny(
-					Equal("0.0.0"),
-					MatchRegexp(`^v\d+\.\d+\.\d+$`),
-				))
+				// Releases are stamped with a semver tag, dev builds with a Go
+				// pseudo-version (e.g. v0.0.0-20260624115013-59dc5a97ce0b), and
+				// unstamped local builds default to 0.0.0; all are valid semver.
+				_, semverErr := semver.NewVersion(version.Version)
+				Expect(semverErr).NotTo(HaveOccurred(), "service version %q is not valid semver", version.Version)
 
 				GinkgoWriter.Printf("Region service version: %s %s\n", version.Name, version.Version)
 			})


### PR DESCRIPTION
The version assertion only accepted "0.0.0" or a strict "vX.Y.Z" tag, so
nightly builds stamped with a Go pseudo-version
(e.g. v0.0.0-20260624115013-59dc5a97ce0b) failed the check even though a
pseudo-version is valid semver.

Parse the reported version with the Masterminds semver library instead of
matching a narrow regex. This accepts release tags, pseudo-versions and the
0.0.0 local-build default while still rejecting genuinely malformed strings.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
