### PR TITLE
Poll read-after-write assertions against the informer cache

### DIFF
--- a/test/api/suites/filestorage_test.go
+++ b/test/api/suites/filestorage_test.go
@@ -88,34 +88,38 @@ var _ = Describe("File Storage Management", func() {
 
 				GinkgoWriter.Printf("Created test storage for list: %s (%s)\n", testStorageName, testStorageID)
 
-				storageList, err := regionClient.ListFileStorage(ctx, config.OrgID, config.ProjectID, config.RegionID)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(len(storageList)).To(BeNumerically(">=", 1), "Should have at least one storage resource")
+				// List GETs are served from the controller-runtime cache, so a
+				// just-created resource can briefly be absent from the list.
+				Eventually(func(g Gomega) {
+					storageList, err := regionClient.ListFileStorage(ctx, config.OrgID, config.ProjectID, config.RegionID)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(len(storageList)).To(BeNumerically(">=", 1), "Should have at least one storage resource")
 
-				found := false
-				for _, storage := range storageList {
-					// Validate ALL items in collection have required fields
-					Expect(storage.Metadata).NotTo(BeNil())
-					Expect(storage.Metadata.Id).NotTo(BeEmpty())
-					Expect(storage.Metadata.Name).NotTo(BeEmpty())
-					Expect(storage.Spec.SizeGiB).To(BeNumerically(">", 0))
-					Expect(storage.Status.StorageClassId).NotTo(BeEmpty())
-					Expect(storage.Status.RegionId).NotTo(BeEmpty())
+					found := false
+					for _, storage := range storageList {
+						// Validate ALL items in collection have required fields
+						g.Expect(storage.Metadata).NotTo(BeNil())
+						g.Expect(storage.Metadata.Id).NotTo(BeEmpty())
+						g.Expect(storage.Metadata.Name).NotTo(BeEmpty())
+						g.Expect(storage.Spec.SizeGiB).To(BeNumerically(">", 0))
+						g.Expect(storage.Status.StorageClassId).NotTo(BeEmpty())
+						g.Expect(storage.Status.RegionId).NotTo(BeEmpty())
 
-					if storage.Metadata.Id == testStorageID {
-						found = true
-						Expect(storage.Metadata.Name).To(Equal(testStorageName))
-						Expect(storage.Metadata.OrganizationId).To(Equal(config.OrgID))
-						Expect(storage.Metadata.ProjectId).To(Equal(config.ProjectID))
-						GinkgoWriter.Printf("  Found our test storage: %s (%s) - %dGiB\n",
-							storage.Metadata.Name,
-							storage.Metadata.Id,
-							storage.Spec.SizeGiB)
+						if storage.Metadata.Id == testStorageID {
+							found = true
+							g.Expect(storage.Metadata.Name).To(Equal(testStorageName))
+							g.Expect(storage.Metadata.OrganizationId).To(Equal(config.OrgID))
+							g.Expect(storage.Metadata.ProjectId).To(Equal(config.ProjectID))
+							GinkgoWriter.Printf("  Found our test storage: %s (%s) - %dGiB\n",
+								storage.Metadata.Name,
+								storage.Metadata.Id,
+								storage.Spec.SizeGiB)
+						}
 					}
-				}
 
-				Expect(found).To(BeTrue(), "Created storage should be in the list")
-				GinkgoWriter.Printf("Found %d total file storage resources\n", len(storageList))
+					g.Expect(found).To(BeTrue(), "Created storage should be in the list")
+					GinkgoWriter.Printf("Found %d total file storage resources\n", len(storageList))
+				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
 			})
 
 			AfterEach(func() {

--- a/test/api/suites/loadbalancers_test.go
+++ b/test/api/suites/loadbalancers_test.go
@@ -110,25 +110,33 @@ var _ = Describe("LoadBalancer", func() {
 			})
 
 			It("appears in the load balancer list", func() {
-				list, err := regionClient.ListLoadBalancers(ctx, config.OrgID, config.ProjectID, config.RegionID)
-				Expect(err).NotTo(HaveOccurred())
+				// List GETs are served from the controller-runtime cache, so a
+				// just-created load balancer can briefly be absent from the list.
+				Eventually(func(g Gomega) {
+					list, err := regionClient.ListLoadBalancers(ctx, config.OrgID, config.ProjectID, config.RegionID)
+					g.Expect(err).NotTo(HaveOccurred())
 
-				var found *regionopenapi.LoadBalancerV2Read
-				for i := range list {
-					if list[i].Metadata.Id == lbID {
-						found = &list[i]
-						break
+					var found *regionopenapi.LoadBalancerV2Read
+					for i := range list {
+						if list[i].Metadata.Id == lbID {
+							found = &list[i]
+							break
+						}
 					}
-				}
-				Expect(found).NotTo(BeNil(), "created load balancer not found in list")
-				Expect(found.Metadata.Name).To(Equal(createReq.Metadata.Name))
+					g.Expect(found).NotTo(BeNil(), "created load balancer not found in list")
+					g.Expect(found.Metadata.Name).To(Equal(createReq.Metadata.Name))
+				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
 			})
 
 			It("can be retrieved by id", func() {
-				got, err := regionClient.GetLoadBalancer(ctx, lbID)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(got.Metadata.Id).To(Equal(lbID))
-				Expect(got.Status.NetworkId).To(Equal(networkID))
+				// Single-resource GETs are served from the controller-runtime cache,
+				// so an immediate GET after create can briefly miss the new object.
+				Eventually(func(g Gomega) {
+					got, err := regionClient.GetLoadBalancer(ctx, lbID)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(got.Metadata.Id).To(Equal(lbID))
+					g.Expect(got.Status.NetworkId).To(Equal(networkID))
+				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
 			})
 
 			It("eventually reports Provisioned with status.vipAddress and status.publicIP populated", func() {

--- a/test/api/suites/networks_test.go
+++ b/test/api/suites/networks_test.go
@@ -74,21 +74,25 @@ var _ = Describe("Network Management", func() {
 					Skip("No network ID available - create step may have been skipped or failed")
 				}
 
-				list, err := regionClient.ListNetworks(ctx, config.OrgID, config.ProjectID, config.RegionID)
-				Expect(err).NotTo(HaveOccurred())
+				// List GETs are served from the controller-runtime cache, so a
+				// just-created network can briefly be absent from the list.
+				Eventually(func(g Gomega) {
+					list, err := regionClient.ListNetworks(ctx, config.OrgID, config.ProjectID, config.RegionID)
+					g.Expect(err).NotTo(HaveOccurred())
 
-				var found *regionopenapi.NetworkV2Read
-				for i := range list {
-					if list[i].Metadata.Id == networkID {
-						found = &list[i]
-						break
+					var found *regionopenapi.NetworkV2Read
+					for i := range list {
+						if list[i].Metadata.Id == networkID {
+							found = &list[i]
+							break
+						}
 					}
-				}
 
-				Expect(found).NotTo(BeNil(), "created network not found in list")
-				Expect(found.Metadata.Name).To(Equal(networkName))
-				Expect(found.Metadata.OrganizationId).To(Equal(config.OrgID))
-				Expect(found.Metadata.ProjectId).To(Equal(config.ProjectID))
+					g.Expect(found).NotTo(BeNil(), "created network not found in list")
+					g.Expect(found.Metadata.Name).To(Equal(networkName))
+					g.Expect(found.Metadata.OrganizationId).To(Equal(config.OrgID))
+					g.Expect(found.Metadata.ProjectId).To(Equal(config.ProjectID))
+				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
 			})
 
 			It("should reach provisioned state and be retrievable by ID", func() {
@@ -142,12 +146,16 @@ var _ = Describe("Network Management", func() {
 				Expect(putResp.Metadata.Description).NotTo(BeNil())
 				Expect(*putResp.Metadata.Description).To(Equal("updated description"))
 
-				roundTrip, err := regionClient.GetNetwork(ctx, networkID)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(roundTrip.Metadata.Name).To(Equal(updatedName))
-				Expect(roundTrip.Metadata.Description).NotTo(BeNil())
-				Expect(*roundTrip.Metadata.Description).To(Equal("updated description"))
-				Expect(roundTrip.Status.Prefix).To(Equal(networkPrefix))
+				// The API server reads single-resource GETs through the controller-runtime
+				// cache, so an immediate GET after PUT can briefly observe the pre-update object.
+				Eventually(func(g Gomega) {
+					roundTrip, err := regionClient.GetNetwork(ctx, networkID)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(roundTrip.Metadata.Name).To(Equal(updatedName))
+					g.Expect(roundTrip.Metadata.Description).NotTo(BeNil())
+					g.Expect(*roundTrip.Metadata.Description).To(Equal("updated description"))
+					g.Expect(roundTrip.Status.Prefix).To(Equal(networkPrefix))
+				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
 
 				networkName = updatedName
 			})

--- a/test/api/suites/securitygroups_test.go
+++ b/test/api/suites/securitygroups_test.go
@@ -78,36 +78,44 @@ var _ = Describe("SecurityGroup", func() {
 				Expect(sgID).NotTo(BeEmpty())
 				Expect(createReq.Metadata.Name).NotTo(BeEmpty())
 
-				got, err := regionClient.GetSecurityGroup(ctx, sgID)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(got.Metadata.Id).To(Equal(sgID))
-				Expect(got.Metadata.Name).To(Equal(createReq.Metadata.Name))
-				Expect(got.Metadata.OrganizationId).To(Equal(config.OrgID))
-				Expect(got.Metadata.ProjectId).To(Equal(config.ProjectID))
-				Expect(got.Status.RegionId).To(Equal(config.RegionID))
-				Expect(got.Status.NetworkId).To(Equal(networkID))
-				Expect(got.Spec.Rules).To(HaveLen(1))
-				Expect(got.Spec.Rules[0].Direction).To(Equal(regionopenapi.NetworkDirectionIngress))
-				Expect(got.Spec.Rules[0].Protocol).To(Equal(regionopenapi.NetworkProtocolTcp))
-				Expect(got.Spec.Rules[0].Port).To(Equal(ptr.To(22)))
+				// Single-resource GETs are served from the controller-runtime cache,
+				// so an immediate GET after create can briefly miss the new object.
+				Eventually(func(g Gomega) {
+					got, err := regionClient.GetSecurityGroup(ctx, sgID)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(got.Metadata.Id).To(Equal(sgID))
+					g.Expect(got.Metadata.Name).To(Equal(createReq.Metadata.Name))
+					g.Expect(got.Metadata.OrganizationId).To(Equal(config.OrgID))
+					g.Expect(got.Metadata.ProjectId).To(Equal(config.ProjectID))
+					g.Expect(got.Status.RegionId).To(Equal(config.RegionID))
+					g.Expect(got.Status.NetworkId).To(Equal(networkID))
+					g.Expect(got.Spec.Rules).To(HaveLen(1))
+					g.Expect(got.Spec.Rules[0].Direction).To(Equal(regionopenapi.NetworkDirectionIngress))
+					g.Expect(got.Spec.Rules[0].Protocol).To(Equal(regionopenapi.NetworkProtocolTcp))
+					g.Expect(got.Spec.Rules[0].Port).To(Equal(ptr.To(22)))
+				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
 			})
 
 			It("should appear in the list filtered by org, project and region", func() {
-				list, err := regionClient.ListSecurityGroups(ctx, config.OrgID, config.ProjectID, config.RegionID)
-				Expect(err).NotTo(HaveOccurred())
+				// List GETs are served from the controller-runtime cache, so a
+				// just-created security group can briefly be absent from the list.
+				Eventually(func(g Gomega) {
+					list, err := regionClient.ListSecurityGroups(ctx, config.OrgID, config.ProjectID, config.RegionID)
+					g.Expect(err).NotTo(HaveOccurred())
 
-				var found *regionopenapi.SecurityGroupV2Read
-				for i := range list {
-					if list[i].Metadata.Id == sgID {
-						found = &list[i]
-						break
+					var found *regionopenapi.SecurityGroupV2Read
+					for i := range list {
+						if list[i].Metadata.Id == sgID {
+							found = &list[i]
+							break
+						}
 					}
-				}
 
-				Expect(found).NotTo(BeNil(), "created security group %s not found in list", sgID)
-				Expect(found.Metadata.Name).To(Equal(createReq.Metadata.Name))
-				Expect(found.Status.NetworkId).To(Equal(networkID))
-				GinkgoWriter.Printf("Found security group in list: %s\n", sgID)
+					g.Expect(found).NotTo(BeNil(), "created security group %s not found in list", sgID)
+					g.Expect(found.Metadata.Name).To(Equal(createReq.Metadata.Name))
+					g.Expect(found.Status.NetworkId).To(Equal(networkID))
+					GinkgoWriter.Printf("Found security group in list: %s\n", sgID)
+				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
 			})
 
 			It("should update rules and verify the change persists on re-GET", func() {

--- a/test/api/suites/servers_test.go
+++ b/test/api/suites/servers_test.go
@@ -166,26 +166,30 @@ var _ = Describe("Server Management", func() {
 				Expect(created.Status.RegionId).To(Equal(config.RegionID))
 				Expect(created.Status.NetworkId).To(Equal(networkID))
 
-				list, err := regionClient.ListServers(ctx, config.OrgID, config.ProjectID, config.RegionID, networkID)
-				Expect(err).NotTo(HaveOccurred())
+				// List and single-resource GETs are served from the controller-runtime
+				// cache, so a just-created server can briefly be absent or stale.
+				Eventually(func(g Gomega) {
+					list, err := regionClient.ListServers(ctx, config.OrgID, config.ProjectID, config.RegionID, networkID)
+					g.Expect(err).NotTo(HaveOccurred())
 
-				var found *regionopenapi.ServerV2Read
-				for i := range list {
-					if list[i].Metadata.Id == serverID {
-						found = &list[i]
-						break
+					var found *regionopenapi.ServerV2Read
+					for i := range list {
+						if list[i].Metadata.Id == serverID {
+							found = &list[i]
+							break
+						}
 					}
-				}
 
-				Expect(found).NotTo(BeNil(), "created server not found in list")
-				Expect(found.Metadata.Name).To(Equal(createReq.Metadata.Name))
+					g.Expect(found).NotTo(BeNil(), "created server not found in list")
+					g.Expect(found.Metadata.Name).To(Equal(createReq.Metadata.Name))
 
-				got, err := regionClient.GetServer(ctx, serverID)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(got.Metadata.Id).To(Equal(serverID))
-				Expect(got.Spec.FlavorId).To(Equal(createReq.Spec.FlavorId))
-				Expect(got.Spec.ImageId).To(Equal(createReq.Spec.ImageId))
-				Expect(got.Status.NetworkId).To(Equal(networkID))
+					got, err := regionClient.GetServer(ctx, serverID)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(got.Metadata.Id).To(Equal(serverID))
+					g.Expect(got.Spec.FlavorId).To(Equal(createReq.Spec.FlavorId))
+					g.Expect(got.Spec.ImageId).To(Equal(createReq.Spec.ImageId))
+					g.Expect(got.Status.NetworkId).To(Equal(networkID))
+				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
The region API server serves single-resource GETs and Lists from the
controller-runtime cache, which is repopulated asynchronously by a watch.
Writes are synchronous to the apiserver, so an immediate read-back after a
create or update races the cache and can observe the pre-write object (a
stale name/spec, or a resource not yet present in a list).

This caused the networks "should reflect updated name and description"
spec to flake: the PUT response correctly echoed the updated name, but the
immediate round-trip GET returned the pre-update name.

Wrap every immediate read-back of a just-written resource in a bounded
Eventually (5s timeout, 250ms polling), matching the existing convention in
the load balancer and security group suites. The PUT/POST response
assertions remain immediate and authoritative; only the cache-backed
re-reads tolerate convergence.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
