### PR TITLE
Bump unikorn-identity to v1.17.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spjmurray/go-util v0.1.3
 	github.com/stretchr/testify v1.11.1
 	github.com/unikorn-cloud/core v1.17.1
-	github.com/unikorn-cloud/identity v1.17.7
+	github.com/unikorn-cloud/identity v1.17.8
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/unikorn-cloud/core v1.17.1 h1:HTdh055cAyqROqFUTGRQE4zJW9J5Xzm/6Naa/YGYY3M=
 github.com/unikorn-cloud/core v1.17.1/go.mod h1:t91+Hw7YbNt5nOtp93Ij826iQfYDcz6Og0KAi2xq+B8=
-github.com/unikorn-cloud/identity v1.17.7 h1:TShYCMuv+5TRtJM/S2RfiOHsDHanYU4FJcb8UbJPzy8=
-github.com/unikorn-cloud/identity v1.17.7/go.mod h1:hNcesH3wRepz3jsnb9GZYf8eAIiGKSMVYZu8zcydBzU=
+github.com/unikorn-cloud/identity v1.17.8 h1:ZP1n9j/wB+l2JHsHWjFkG5zIx5dfr9tUPvc7P0WTY5A=
+github.com/unikorn-cloud/identity v1.17.8/go.mod h1:zdd93lbGvx90cduY/EAj5Mo9Irq/u5B75kIET0/Ql1w=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Pull in the identity CI infrastructure fix: v1.17.8 pins cloud-provider-kind
to v0.10.0 in the shared hack/ci/setup-infra script. v1.17.7 installed it via
@latest, which floated to v0.11.0 (Go >= 1.26) and broke the Integration job's
infrastructure setup on Go 1.25 runners. region delegates to that script, so
the bump restores green Integration CI.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
