### PR TITLE
Wait for network update reads in API tests

### DIFF
--- a/test/api/suites/networks_test.go
+++ b/test/api/suites/networks_test.go
@@ -142,12 +142,18 @@ var _ = Describe("Network Management", func() {
 				Expect(putResp.Metadata.Description).NotTo(BeNil())
 				Expect(*putResp.Metadata.Description).To(Equal("updated description"))
 
-				roundTrip, err := regionClient.GetNetwork(ctx, networkID)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(roundTrip.Metadata.Name).To(Equal(updatedName))
-				Expect(roundTrip.Metadata.Description).NotTo(BeNil())
-				Expect(*roundTrip.Metadata.Description).To(Equal("updated description"))
-				Expect(roundTrip.Status.Prefix).To(Equal(networkPrefix))
+				// Single-resource GETs can briefly observe the pre-update object through
+				// the API server's controller-runtime cache.
+				Eventually(func(g Gomega) {
+					roundTrip, err := regionClient.GetNetwork(ctx, networkID)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(roundTrip.Metadata.Name).To(Equal(updatedName))
+					g.Expect(roundTrip.Metadata.Description).NotTo(BeNil())
+					g.Expect(*roundTrip.Metadata.Description).To(Equal("updated description"))
+					g.Expect(roundTrip.Status.Prefix).To(Equal(networkPrefix))
+				}).WithTimeout(30 * time.Second).
+					WithPolling(1 * time.Second).
+					Should(Succeed())
 
 				networkName = updatedName
 			})


### PR DESCRIPTION
## Summary

Stabilize the Network Management API test by polling the post-update GET until the API read path reflects the successful network update response.

## Context

Run https://github.com/nscaledev/uni-region/actions/runs/28159309905 failed because `UpdateNetwork` returned the updated name, but the immediate follow-up `GetNetwork` still observed the pre-update name. The network handler patches the CR and returns the patched object, while single-resource GETs can briefly observe stale state through the API server's controller-runtime cache.

## Changes

- Wrap the post-update network GET assertions in `Eventually`.
- Keep the existing assertions for updated name, updated description, and preserved prefix.
- Match the existing read-after-write polling pattern used by the load balancer and security group API tests.

## Validation

- `go test -tags integration ./test/api/suites -run '^$'`
- `go test ./test/api/...`
- `git diff --check`
