### PR TITLE
[codex] Pass deployed version to API test Slack reports

### DIFF
--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -163,13 +163,13 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@codex/slack-deployed-version
       if: ${{ !cancelled() }}
       with:
         test-results-path: test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: dev
         deployed-version: ${{ needs.find-dev-deployed-version.outputs.version || needs.find-dev-deployed-version.outputs.ref }}
@@ -279,13 +279,13 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@codex/slack-deployed-version
       if: ${{ !cancelled() }}
       with:
         test-results-path: test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
         deployed-version: ${{ needs.find-uat-deployed-version.outputs.version || needs.find-uat-deployed-version.outputs.ref }}

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -163,13 +163,13 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@codex/slack-deployed-version
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
       if: ${{ !cancelled() }}
       with:
         test-results-path: test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: dev
         deployed-version: ${{ needs.find-dev-deployed-version.outputs.version || needs.find-dev-deployed-version.outputs.ref }}
@@ -279,13 +279,13 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@codex/slack-deployed-version
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
       if: ${{ !cancelled() }}
       with:
         test-results-path: test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
         deployed-version: ${{ needs.find-uat-deployed-version.outputs.version || needs.find-uat-deployed-version.outputs.ref }}

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -74,6 +74,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event.inputs.run_dev == 'true'
     outputs:
       ref: ${{ steps.find.outputs.ref }}
+      version: ${{ steps.find.outputs.version }}
     steps:
     - name: Resolve Dev checkout ref
       uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@main
@@ -171,6 +172,7 @@ jobs:
         slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: dev
+        deployed-version: ${{ needs.find-dev-deployed-version.outputs.version || needs.find-dev-deployed-version.outputs.ref }}
         title: 'Region API Test Results'
         test-history-suite: uni-region-api
         enable-ai-analysis: 'true'
@@ -187,6 +189,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true'
     outputs:
       ref: ${{ steps.find.outputs.ref }}
+      version: ${{ steps.find.outputs.version }}
     steps:
     - name: Resolve UAT checkout ref
       uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@main
@@ -285,6 +288,7 @@ jobs:
         slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
+        deployed-version: ${{ needs.find-uat-deployed-version.outputs.version || needs.find-uat-deployed-version.outputs.ref }}
         title: 'Region API Test Results'
         test-history-suite: uni-region-api
         enable-ai-analysis: 'true'


### PR DESCRIPTION
## Summary

Wires the deployed version resolved by `uni-find-staging-constellation` into `test-results-report` for Dev and UAT API tests.

- exposes `steps.find.outputs.version` from both resolver jobs
- passes `deployed-version` to the report action
- falls back to the resolved checkout ref if the version output is empty

## Why

The Slack report already shows totals, duration, environment, branch, and actor. Passing the deployed version lets the message also show the exact component tag/ref being tested, for example `v1.18.0-rc1` from the UAT `/api/version` resolver.

## Dependency

The required shared action input was merged in nscaledev/quality-tooling#20 and is now available through `quality-tooling@main`.

## Validation

- `git diff --check`
- YAML parse check for `.github/workflows/test-api.yaml`
- Focused UAT `Region Discovery` workflow run using `SLACK_API_TESTING_TMP_WEBHOOK_URL`: https://github.com/nscaledev/uni-region/actions/runs/28180887316
