### PR TITLE
Use canonical header key in placement microversion test

### DIFF
--- a/pkg/providers/internal/openstack/placement_test.go
+++ b/pkg/providers/internal/openstack/placement_test.go
@@ -278,7 +278,7 @@ func TestPlacementClientResourceProviderAvailable(t *testing.T) {
 			t.Errorf("required query = %q, want %q", got, want)
 		}
 
-		if got, want := r.Header.Get("OpenStack-API-Version"), "placement 1.18"; got != want {
+		if got, want := r.Header.Get("Openstack-Api-Version"), "placement 1.18"; got != want {
 			t.Errorf("microversion header = %q, want %q", got, want)
 		}
 


### PR DESCRIPTION
The canonicalheader linter (now enforced after a golangci-lint dependency
bump) flags the non-canonical "OpenStack-API-Version" literal in the
placement test, failing `make lint` on every PR. http.Header.Get
canonicalizes its key, so "Openstack-Api-Version" reads the identical value
— behaviour is unchanged; this only satisfies the linter.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
