### PR TITLE
Remove unnecessary snapshot policy integration tests

### DIFF
--- a/pkg/openapi/provisioning_status_enum_test.go
+++ b/pkg/openapi/provisioning_status_enum_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package openapi_test
 
 import (
+	"bytes"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/getkin/kin-openapi/routers/legacy"
 	"github.com/stretchr/testify/require"
 
 	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
@@ -109,6 +113,71 @@ func TestStorageDefaultSnapshotProtectionRejectsNullInput(t *testing.T) {
 	defaultProtectionProperty := schemaProperty(t, storageSpec, "defaultSnapshotProtectionEnabled")
 
 	require.Error(t, defaultProtectionProperty.VisitJSON(nil))
+}
+
+func TestStorageV2UpdateRequestRejectsExplicitNulls(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name: "omitted nullable-looking fields is valid",
+			body: `{"metadata":{"name":"storage-name"},"spec":{"sizeGiB":10,"storageType":{"NFS":{"rootSquash":true}}}}`,
+		},
+		{
+			name:    "snapshot policies null is invalid",
+			body:    `{"metadata":{"name":"storage-name"},"spec":{"sizeGiB":10,"storageType":{"NFS":{"rootSquash":true}},"snapshotPolicies":null}}`,
+			wantErr: true,
+		},
+		{
+			name:    "default snapshot protection null is invalid",
+			body:    `{"metadata":{"name":"storage-name"},"spec":{"sizeGiB":10,"storageType":{"NFS":{"rootSquash":true}},"defaultSnapshotProtectionEnabled":null}}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateStorageV2UpdateRequest(t, tt.body)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func validateStorageV2UpdateRequest(t *testing.T, body string) error {
+	t.Helper()
+
+	swagger, err := openapi.GetSwagger()
+	require.NoError(t, err)
+
+	router, err := legacy.NewRouter(swagger)
+	require.NoError(t, err)
+
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPut, "/api/v2/filestorage/00000000-0000-0000-0000-000000000000", bytes.NewBufferString(body))
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+
+	route, pathParams, err := router.FindRoute(request)
+	require.NoError(t, err)
+
+	return openapi3filter.ValidateRequest(t.Context(), &openapi3filter.RequestValidationInput{
+		Request:    request,
+		PathParams: pathParams,
+		Route:      route,
+		Options: &openapi3filter.Options{
+			AuthenticationFunc: openapi3filter.NoopAuthenticationFunc,
+		},
+	})
 }
 
 func componentSchema(t *testing.T, swagger *openapi3.T, name string) *openapi3.Schema {

--- a/test/api/suites/filestorage_test.go
+++ b/test/api/suites/filestorage_test.go
@@ -22,11 +22,7 @@ limitations under the License.
 package suites
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -45,22 +41,6 @@ const defaultProtectionUpdateStorageSizeGiB = int64(10)
 
 func dailyFileStorageSnapshotPolicies() regionopenapi.StorageSnapshotPolicyListV2Spec {
 	return namedDailyFileStorageSnapshotPolicies("daily")
-}
-
-func defaultNamedFileStorageSnapshotPolicies() regionopenapi.StorageSnapshotPolicyListV2Spec {
-	return namedDailyFileStorageSnapshotPolicies("default")
-}
-
-func systemDefaultFileStorageSnapshotPolicies() regionopenapi.StorageSnapshotPolicyListV2Spec {
-	return regionopenapi.StorageSnapshotPolicyListV2Spec{
-		{
-			Name: "system-default",
-			Schedule: regionopenapi.StorageSnapshotScheduleV2Spec{
-				Interval: regionopenapi.StorageSnapshotScheduleIntervalV2Hourly,
-			},
-			Retention: regionopenapi.StorageSnapshotRetentionV2Spec{Keep: 24},
-		},
-	}
 }
 
 func namedDailyFileStorageSnapshotPolicies(name string) regionopenapi.StorageSnapshotPolicyListV2Spec {
@@ -150,16 +130,6 @@ func createDefaultProtectionUpdateTestStorage(storageClassID string, defaultProt
 	return created
 }
 
-func createFileStorageWithRawBody(storageClassID string, defaultProtectionEnabled *bool, snapshotPolicies *regionopenapi.StorageSnapshotPolicyListV2Spec, expectedStatus int) (*http.Response, []byte, error) {
-	request := defaultProtectionCreateRequest(storageClassID, defaultProtectionEnabled, snapshotPolicies)
-	reqBody, err := json.Marshal(request)
-	Expect(err).NotTo(HaveOccurred())
-
-	path := regionClient.GetEndpoints().CreateFileStorage()
-
-	return regionClient.DoRegionRequest(ctx, http.MethodPost, path, bytes.NewReader(reqBody), expectedStatus)
-}
-
 func defaultProtectionUpdateRequest(name string, defaultProtectionEnabled *bool, snapshotPolicies *regionopenapi.StorageSnapshotPolicyListV2Spec) regionopenapi.StorageV2UpdateRequest {
 	return regionopenapi.StorageV2UpdateRequest{
 		Metadata: coreapi.ResourceWriteMetadata{
@@ -173,88 +143,6 @@ func defaultProtectionUpdateRequest(name string, defaultProtectionEnabled *bool,
 			StorageType:                      nfsFileStorageType(),
 		},
 	}
-}
-
-func updateFileStorageWithRawBody(filestorageID string, body any, expectedStatus int) (*http.Response, []byte, error) {
-	reqBody, err := json.Marshal(body)
-	Expect(err).NotTo(HaveOccurred())
-
-	path := regionClient.GetEndpoints().UpdateFileStorage(filestorageID)
-
-	return regionClient.DoRegionRequest(ctx, http.MethodPut, path, bytes.NewReader(reqBody), expectedStatus)
-}
-
-func updateFileStorageWithOmittedSnapshotPolicies(filestorageID string, name string, defaultProtectionEnabled *bool) *regionopenapi.StorageV2Read {
-	body := struct {
-		Metadata coreapi.ResourceWriteMetadata `json:"metadata"`
-		Spec     struct {
-			DefaultSnapshotProtectionEnabled *bool                           `json:"defaultSnapshotProtectionEnabled,omitempty"`
-			SizeGiB                          int64                           `json:"sizeGiB"`
-			StorageType                      regionopenapi.StorageTypeV2Spec `json:"storageType"`
-		} `json:"spec"`
-	}{
-		Metadata: coreapi.ResourceWriteMetadata{
-			Name:        name,
-			Description: ptr.To("Updated with omitted snapshot policies"),
-		},
-	}
-	body.Spec.DefaultSnapshotProtectionEnabled = defaultProtectionEnabled
-	body.Spec.SizeGiB = defaultProtectionUpdateStorageSizeGiB
-	body.Spec.StorageType = nfsFileStorageType()
-
-	_, respBody, err := updateFileStorageWithRawBody(filestorageID, body, http.StatusAccepted)
-	Expect(err).NotTo(HaveOccurred())
-
-	var storage regionopenapi.StorageV2Read
-	Expect(json.Unmarshal(respBody, &storage)).To(Succeed())
-
-	return &storage
-}
-
-func updateFileStorageWithNullDefaultProtection(filestorageID string, name string) (*http.Response, error) {
-	body := struct {
-		Metadata coreapi.ResourceWriteMetadata `json:"metadata"`
-		Spec     struct {
-			DefaultSnapshotProtectionEnabled *bool                           `json:"defaultSnapshotProtectionEnabled"`
-			SizeGiB                          int64                           `json:"sizeGiB"`
-			StorageType                      regionopenapi.StorageTypeV2Spec `json:"storageType"`
-		} `json:"spec"`
-	}{
-		Metadata: coreapi.ResourceWriteMetadata{
-			Name:        name,
-			Description: ptr.To("Invalid null default snapshot protection"),
-		},
-	}
-	body.Spec.SizeGiB = defaultProtectionUpdateStorageSizeGiB
-	body.Spec.StorageType = nfsFileStorageType()
-
-	resp, _, err := updateFileStorageWithRawBody(filestorageID, body, 0)
-
-	return resp, err
-}
-
-func updateFileStorageWithNullSnapshotPolicies(filestorageID string, name string, defaultProtectionEnabled *bool) (*http.Response, error) {
-	body := struct {
-		Metadata coreapi.ResourceWriteMetadata `json:"metadata"`
-		Spec     struct {
-			DefaultSnapshotProtectionEnabled *bool                                          `json:"defaultSnapshotProtectionEnabled,omitempty"`
-			SizeGiB                          int64                                          `json:"sizeGiB"`
-			SnapshotPolicies                 *regionopenapi.StorageSnapshotPolicyListV2Spec `json:"snapshotPolicies"`
-			StorageType                      regionopenapi.StorageTypeV2Spec                `json:"storageType"`
-		} `json:"spec"`
-	}{
-		Metadata: coreapi.ResourceWriteMetadata{
-			Name:        name,
-			Description: ptr.To("Invalid null snapshot policies"),
-		},
-	}
-	body.Spec.DefaultSnapshotProtectionEnabled = defaultProtectionEnabled
-	body.Spec.SizeGiB = defaultProtectionUpdateStorageSizeGiB
-	body.Spec.StorageType = nfsFileStorageType()
-
-	resp, _, err := updateFileStorageWithRawBody(filestorageID, body, 0)
-
-	return resp, err
 }
 
 func expectDefaultProtectionUpdateState(storage *regionopenapi.StorageV2Read, defaultProtectionEnabled bool, snapshotPolicies regionopenapi.StorageSnapshotPolicyListV2Spec) {
@@ -360,19 +248,6 @@ var _ = Describe("File Storage Management", func() {
 				}
 			})
 		})
-
-		Describe("Given invalid parameters", func() {
-			It("should reject requests with invalid organization ID format", func() {
-				// TODO INST-457: API currently returns 502 instead of a structured 400/403; tighten assertions once fixed.
-				invalidOrgID := "not-a-valid-uuid"
-				path := regionClient.GetEndpoints().ListFileStorage(invalidOrgID, config.ProjectID, config.RegionID)
-				_, _, err := regionClient.DoRegionRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
-
-				Expect(err).To(HaveOccurred())
-				Expect(errors.Is(err, coreclient.ErrUnexpectedStatusCode)).To(BeTrue())
-				GinkgoWriter.Printf("Expected error for invalid organization ID: %v\n", err)
-			})
-		})
 	})
 
 	Context("When managing file storage lifecycle", Ordered, func() {
@@ -436,12 +311,7 @@ var _ = Describe("File Storage Management", func() {
 				Expect(created.Metadata.Id).NotTo(BeEmpty())
 				Expect(created.Metadata.Name).To(Equal(request.Metadata.Name))
 				Expect(created.Spec.SizeGiB).To(Equal(request.Spec.SizeGiB))
-				// Generated as a pointer; reads always populate it, so guard against
-				// nil then assert the dereferenced value.
-				Expect(created.Spec.DefaultSnapshotProtectionEnabled).NotTo(BeNil())
-				Expect(*created.Spec.DefaultSnapshotProtectionEnabled).To(BeTrue())
-				Expect(created.Spec.SnapshotPolicies).NotTo(BeNil())
-				Expect(*created.Spec.SnapshotPolicies).To(BeEmpty())
+				expectDefaultProtectionUpdateState(created, true, regionopenapi.StorageSnapshotPolicyListV2Spec{})
 				Expect(created.Status.SnapshotPolicies).To(BeEmpty())
 
 				// Validate resource is correctly scoped and wired up
@@ -488,10 +358,7 @@ var _ = Describe("File Storage Management", func() {
 				Expect(retrieved.Status.RegionId).To(Equal(config.RegionID))
 				Expect(retrieved.Status.StorageClassId).To(Equal(storageClassID))
 				Expect(retrieved.Spec.SizeGiB).To(Equal(initialStorageSizeGiB))
-				Expect(retrieved.Spec.DefaultSnapshotProtectionEnabled).NotTo(BeNil())
-				Expect(*retrieved.Spec.DefaultSnapshotProtectionEnabled).To(BeTrue())
-				Expect(retrieved.Spec.SnapshotPolicies).NotTo(BeNil())
-				Expect(*retrieved.Spec.SnapshotPolicies).To(BeEmpty())
+				expectDefaultProtectionUpdateState(retrieved, true, regionopenapi.StorageSnapshotPolicyListV2Spec{})
 				Expect(retrieved.Status.SnapshotPolicies).To(BeEmpty())
 				Expect(retrieved.Metadata.ProvisioningStatus).To(Equal(coreapi.ResourceProvisioningStatusProvisioned))
 
@@ -529,10 +396,7 @@ var _ = Describe("File Storage Management", func() {
 					Expect(*updated.Metadata.Description).To(Equal("Updated test file storage"))
 				}
 				Expect(updated.Spec.SizeGiB).To(Equal(updatedStorageSizeGiB))
-				Expect(updated.Spec.DefaultSnapshotProtectionEnabled).NotTo(BeNil())
-				Expect(*updated.Spec.DefaultSnapshotProtectionEnabled).To(BeTrue())
-				Expect(updated.Spec.SnapshotPolicies).NotTo(BeNil())
-				Expect(*updated.Spec.SnapshotPolicies).To(BeEmpty())
+				expectDefaultProtectionUpdateState(updated, true, regionopenapi.StorageSnapshotPolicyListV2Spec{})
 
 				GinkgoWriter.Printf("Updated file storage: %s (%s) - now %dGiB\n",
 					updated.Metadata.Name,
@@ -564,10 +428,7 @@ var _ = Describe("File Storage Management", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updated).NotTo(BeNil())
-				Expect(updated.Spec.DefaultSnapshotProtectionEnabled).NotTo(BeNil())
-				Expect(*updated.Spec.DefaultSnapshotProtectionEnabled).To(BeTrue())
-				Expect(updated.Spec.SnapshotPolicies).NotTo(BeNil())
-				Expect(*updated.Spec.SnapshotPolicies).To(BeEmpty())
+				expectDefaultProtectionUpdateState(updated, true, regionopenapi.StorageSnapshotPolicyListV2Spec{})
 				Expect(updated.Status.SnapshotPolicies).To(BeEmpty())
 			})
 
@@ -583,22 +444,6 @@ var _ = Describe("File Storage Management", func() {
 				GinkgoWriter.Printf("Deleted file storage: %s\n", filestorageID)
 				filestorageDeleted = true
 			})
-
-			It("should not find the deleted file storage resource", func() {
-				if !filestorageDeleted {
-					Skip("No filestorage ID available - create test may have been skipped or failed")
-				}
-
-				Eventually(func() error {
-					_, err := regionClient.GetFileStorage(ctx, filestorageID)
-					return err
-				}).WithTimeout(30*time.Second).
-					WithPolling(2*time.Second).
-					Should(And(HaveOccurred(), MatchError(coreclient.ErrUnexpectedStatusCode)),
-						"Resource should eventually return 404")
-
-				GinkgoWriter.Printf("Confirmed file storage deleted: %s\n", filestorageID)
-			})
 		})
 
 		AfterAll(func() {
@@ -611,77 +456,6 @@ var _ = Describe("File Storage Management", func() {
 
 	Context("When updating default snapshot protection", func() {
 		Describe("Given a File Storage resource", func() {
-			It("preserves the current default snapshot protection setting when the flag is omitted", func() {
-				storageClassID := requireFileStorageClassID()
-				created := createDefaultProtectionUpdateTestStorage(storageClassID, ptr.To(false), nil)
-
-				update := defaultProtectionUpdateRequest(created.Metadata.Name, nil, nil)
-				updated, err := regionClient.UpdateFileStorage(ctx, created.Metadata.Id, update)
-				Expect(err).NotTo(HaveOccurred())
-				expectDefaultProtectionUpdateState(updated, false, regionopenapi.StorageSnapshotPolicyListV2Spec{})
-
-				retrieved, err := regionClient.GetFileStorage(ctx, created.Metadata.Id)
-				Expect(err).NotTo(HaveOccurred())
-				expectDefaultProtectionUpdateState(retrieved, false, regionopenapi.StorageSnapshotPolicyListV2Spec{})
-			})
-
-			It("enables default snapshot protection without changing user-managed policies when snapshotPolicies is omitted", func() {
-				storageClassID := requireFileStorageClassID()
-				policies := dailyFileStorageSnapshotPolicies()
-				created := createDefaultProtectionUpdateTestStorage(storageClassID, ptr.To(false), &policies)
-
-				updated := updateFileStorageWithOmittedSnapshotPolicies(created.Metadata.Id, created.Metadata.Name, ptr.To(true))
-				expectDefaultProtectionUpdateState(updated, true, policies)
-
-				retrieved, err := regionClient.GetFileStorage(ctx, created.Metadata.Id)
-				Expect(err).NotTo(HaveOccurred())
-				expectDefaultProtectionUpdateState(retrieved, true, policies)
-			})
-
-			It("rejects explicit null snapshot policies and preserves the current state", func() {
-				storageClassID := requireFileStorageClassID()
-				policies := dailyFileStorageSnapshotPolicies()
-				created := createDefaultProtectionUpdateTestStorage(storageClassID, ptr.To(true), &policies)
-
-				resp, err := updateFileStorageWithNullSnapshotPolicies(created.Metadata.Id, created.Metadata.Name, ptr.To(false))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(SatisfyAny(Equal(http.StatusBadRequest), Equal(http.StatusUnprocessableEntity)))
-
-				retrieved, err := regionClient.GetFileStorage(ctx, created.Metadata.Id)
-				Expect(err).NotTo(HaveOccurred())
-				expectDefaultProtectionUpdateState(retrieved, true, policies)
-			})
-
-			It("rejects explicit null default snapshot protection and preserves the current state", func() {
-				storageClassID := requireFileStorageClassID()
-				policies := dailyFileStorageSnapshotPolicies()
-				created := createDefaultProtectionUpdateTestStorage(storageClassID, ptr.To(true), &policies)
-
-				resp, err := updateFileStorageWithNullDefaultProtection(created.Metadata.Id, created.Metadata.Name)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(SatisfyAny(Equal(http.StatusBadRequest), Equal(http.StatusUnprocessableEntity)))
-
-				retrieved, err := regionClient.GetFileStorage(ctx, created.Metadata.Id)
-				Expect(err).NotTo(HaveOccurred())
-				expectDefaultProtectionUpdateState(retrieved, true, policies)
-			})
-
-			It("clears user-managed snapshot policies without changing omitted default snapshot protection", func() {
-				storageClassID := requireFileStorageClassID()
-				policies := dailyFileStorageSnapshotPolicies()
-				emptyPolicies := regionopenapi.StorageSnapshotPolicyListV2Spec{}
-				created := createDefaultProtectionUpdateTestStorage(storageClassID, ptr.To(false), &policies)
-
-				update := defaultProtectionUpdateRequest(created.Metadata.Name, nil, &emptyPolicies)
-				updated, err := regionClient.UpdateFileStorage(ctx, created.Metadata.Id, update)
-				Expect(err).NotTo(HaveOccurred())
-				expectDefaultProtectionUpdateState(updated, false, emptyPolicies)
-
-				retrieved, err := regionClient.GetFileStorage(ctx, created.Metadata.Id)
-				Expect(err).NotTo(HaveOccurred())
-				expectDefaultProtectionUpdateState(retrieved, false, emptyPolicies)
-			})
-
 			It("changes default snapshot protection and replaces user-managed snapshot policies together", func() {
 				storageClassID := requireFileStorageClassID()
 				currentPolicies := dailyFileStorageSnapshotPolicies()
@@ -696,77 +470,6 @@ var _ = Describe("File Storage Management", func() {
 				retrieved, err := regionClient.GetFileStorage(ctx, created.Metadata.Id)
 				Expect(err).NotTo(HaveOccurred())
 				expectDefaultProtectionUpdateState(retrieved, true, replacementPolicies)
-			})
-		})
-	})
-
-	Context("When using protected snapshot policy names", func() {
-		Describe("Given File Storage snapshot policy requests", func() {
-			It("accepts user-managed default as an ordinary policy name", func() {
-				storageClassID := requireFileStorageClassID()
-				policies := defaultNamedFileStorageSnapshotPolicies()
-				created := createDefaultProtectionUpdateTestStorage(storageClassID, ptr.To(true), &policies)
-				expectDefaultProtectionUpdateState(created, true, policies)
-
-				retrieved, err := regionClient.GetFileStorage(ctx, created.Metadata.Id)
-				Expect(err).NotTo(HaveOccurred())
-				expectDefaultProtectionUpdateState(retrieved, true, policies)
-			})
-
-			It("rejects a user-managed system-default policy name on create", func() {
-				storageClassID := requireFileStorageClassID()
-				policies := systemDefaultFileStorageSnapshotPolicies()
-
-				resp, _, err := createFileStorageWithRawBody(storageClassID, ptr.To(true), &policies, 0)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(Equal(http.StatusUnprocessableEntity))
-			})
-
-			It("rejects a user-managed system-default policy name on update", func() {
-				storageClassID := requireFileStorageClassID()
-				policies := systemDefaultFileStorageSnapshotPolicies()
-				created := createDefaultProtectionUpdateTestStorage(storageClassID, ptr.To(true), nil)
-
-				update := defaultProtectionUpdateRequest(created.Metadata.Name, ptr.To(false), &policies)
-				resp, _, err := updateFileStorageWithRawBody(created.Metadata.Id, update, 0)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(Equal(http.StatusUnprocessableEntity))
-			})
-
-			It("rejects a single update that enables default protection and claims system-default", func() {
-				storageClassID := requireFileStorageClassID()
-				policies := systemDefaultFileStorageSnapshotPolicies()
-				created := createDefaultProtectionUpdateTestStorage(storageClassID, ptr.To(false), nil)
-
-				update := defaultProtectionUpdateRequest(created.Metadata.Name, ptr.To(true), &policies)
-				resp, _, err := updateFileStorageWithRawBody(created.Metadata.Id, update, 0)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(Equal(http.StatusUnprocessableEntity))
-			})
-
-			It("rejects claiming the system-default name even after default protection is disabled", func() {
-				storageClassID := requireFileStorageClassID()
-				policies := systemDefaultFileStorageSnapshotPolicies()
-				emptyPolicies := regionopenapi.StorageSnapshotPolicyListV2Spec{}
-				created := createDefaultProtectionUpdateTestStorage(storageClassID, ptr.To(true), nil)
-
-				disableUpdate := defaultProtectionUpdateRequest(created.Metadata.Name, ptr.To(false), &emptyPolicies)
-				disabled, err := regionClient.UpdateFileStorage(ctx, created.Metadata.Id, disableUpdate)
-				Expect(err).NotTo(HaveOccurred())
-				expectDefaultProtectionUpdateState(disabled, false, emptyPolicies)
-
-				// Disabling protection removes the hidden system-default baseline, but the
-				// name is reserved unconditionally, so a caller can never claim it as a
-				// user-managed policy. The rejection is synchronous request validation, so
-				// there is no cleanup window to wait on.
-				claimUpdate := defaultProtectionUpdateRequest(created.Metadata.Name, nil, &policies)
-				resp, _, err := updateFileStorageWithRawBody(created.Metadata.Id, claimUpdate, 0)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(Equal(http.StatusUnprocessableEntity))
-
-				retrieved, err := regionClient.GetFileStorage(ctx, created.Metadata.Id)
-				Expect(err).NotTo(HaveOccurred())
-				expectDefaultProtectionUpdateState(retrieved, false, emptyPolicies)
 			})
 		})
 	})


### PR DESCRIPTION
The removed integration tests are mostly input validation, which have been covered by unit tests already. Happy full-path assertions are kept in the integration tests.