### PR TITLE
Await network visibility before dependent creates in API tests

### DIFF
--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -406,3 +406,17 @@ func WaitForLoadBalancerGone(c *APIClient, ctx context.Context, lbID string) {
 		Should(And(HaveOccurred(), MatchError(coreclient.ErrResourceNotFound)),
 			"load balancer should eventually be deleted")
 }
+
+// WaitForNetworkVisible polls until the network is readable at the API. The
+// region API is eventually consistent on reads: writes are synchronous but
+// GETs are served from the controller-runtime cache, so a just-created network
+// can briefly 404. A dependent create that resolves the network reference
+// (e.g. a load balancer) reads through the same cache and would fail with that
+// transient 404, so await visibility before referencing it.
+func WaitForNetworkVisible(c *APIClient, ctx context.Context, networkID string) {
+	Eventually(func() error {
+		_, err := c.GetNetwork(ctx, networkID)
+		return err
+	}).WithTimeout(5*time.Second).WithPolling(250*time.Millisecond).
+		Should(Succeed(), "network should become visible at the API")
+}

--- a/test/api/suites/loadbalancers_test.go
+++ b/test/api/suites/loadbalancers_test.go
@@ -53,6 +53,11 @@ var _ = Describe("LoadBalancer", func() {
 			networkID = network.Metadata.Id
 			GinkgoWriter.Printf("Created network fixture: %s\n", networkID)
 
+			// Reads are served from the controller-runtime cache, so the
+			// load balancer create below can resolve the network reference
+			// against a stale cache and 404. Await visibility first.
+			api.WaitForNetworkVisible(regionClient, ctx, networkID)
+
 			DeferCleanup(func() {
 				if lbID != "" {
 					if err := regionClient.DeleteLoadBalancer(ctx, lbID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
@@ -244,6 +249,11 @@ var _ = Describe("LoadBalancer", func() {
 			networkID = network.Metadata.Id
 			GinkgoWriter.Printf("Created network fixture: %s\n", networkID)
 
+			// Reads are served from the controller-runtime cache, so the
+			// load balancer create below can resolve the network reference
+			// against a stale cache and 404. Await visibility first.
+			api.WaitForNetworkVisible(regionClient, ctx, networkID)
+
 			DeferCleanup(func() {
 				if lbID != "" {
 					if err := regionClient.DeleteLoadBalancer(ctx, lbID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
@@ -304,6 +314,11 @@ var _ = Describe("LoadBalancer", func() {
 			Expect(network).NotTo(BeNil())
 			networkID = network.Metadata.Id
 			GinkgoWriter.Printf("Created network fixture: %s\n", networkID)
+
+			// Reads are served from the controller-runtime cache, so the
+			// load balancer create below can resolve the network reference
+			// against a stale cache and 404. Await visibility first.
+			api.WaitForNetworkVisible(regionClient, ctx, networkID)
 
 			DeferCleanup(func() {
 				if lbID != "" {

--- a/test/api/suites/securitygroups_test.go
+++ b/test/api/suites/securitygroups_test.go
@@ -55,6 +55,11 @@ var _ = Describe("SecurityGroup", func() {
 			})
 			GinkgoWriter.Printf("Created network fixture: %s\n", networkID)
 
+			// Reads are served from the controller-runtime cache, so the
+			// security group create below can resolve the network reference
+			// against a stale cache and 404. Await visibility first.
+			api.WaitForNetworkVisible(regionClient, ctx, networkID)
+
 			createReq = api.NewSecurityGroupPayload(networkID).Build()
 			created, err := regionClient.CreateSecurityGroup(ctx, createReq)
 			Expect(err).NotTo(HaveOccurred(), "failed to create security group fixture")


### PR DESCRIPTION
The region API is eventually consistent on reads: writes are synchronous but GETs are served from the controller-runtime cache. Create handlers that resolve a network reference read through that same cache (`CreateV2 -> network.GetV2Raw`), so a resource created immediately after its network fixture can fail with a transient 404 (`"resource not found"`) before the cache catches up.

This affects both:
- **load balancer** create (`pkg/handler/loadbalancer/client_v2.go`)
- **security group** create (`pkg/handler/securitygroup/client_v2.go`)

Add a `WaitForNetworkVisible` helper and await the fixture network before referencing it in the load balancer (all three `BeforeAll` contexts) and security group tests, matching the read-after-write `Eventually` convention already used elsewhere in the suite.

Server reads are deliberately left cache-backed — resolving references through an uncached/etcd read would be a DoS vector without rate limiting, so we accept eventual consistency and tolerate the lag test-side. Server tests already await `Provisioned` (a stronger condition) so they are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)