### PR TITLE
Guard server rebuild behind a durable provisioned latch

### DIFF
--- a/charts/region/crds/region.unikorn-cloud.org_servers.yaml
+++ b/charts/region/crds/region.unikorn-cloud.org_servers.yaml
@@ -252,6 +252,19 @@ spec:
                   ProviderCreateRetrying is true while the controller is deleting a failed
                   provider server before making another create attempt.
                 type: boolean
+              provisionedAt:
+                description: |-
+                  ProvisionedAt is a write-once latch recording that the server has booted at
+                  least once. It is set from the same Nova launched_at signal as LaunchedAt
+                  (so it fires for VMs and baremetal alike, regardless of live power state)
+                  but, unlike LaunchedAt, it is never cleared: not by the provider-create
+                  retry reset, nor by a re-reconcile against a flaky provider. The bounded
+                  provider-create delete-and-retry guard keys off this field so a server that
+                  has ever booted is never rebuilt (a rebuild after first boot would destroy
+                  data). Unlike the reconciler-owned Available condition, it does not flip back
+                  to a non-provisioned value on a later re-reconcile.
+                format: date-time
+                type: string
               publicIP:
                 description: PublicIP is the public IP address of the server.
                 type: string

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -984,6 +984,16 @@ type ServerStatus struct {
 	// ScheduledAt is the time the provider accepted and processed the creation request.
 	// Nil until the server has been observed in the provider at least once.
 	ScheduledAt *metav1.Time `json:"scheduledAt,omitempty"`
+	// ProvisionedAt is a write-once latch recording that the server has booted at
+	// least once. It is set from the same Nova launched_at signal as LaunchedAt
+	// (so it fires for VMs and baremetal alike, regardless of live power state)
+	// but, unlike LaunchedAt, it is never cleared: not by the provider-create
+	// retry reset, nor by a re-reconcile against a flaky provider. The bounded
+	// provider-create delete-and-retry guard keys off this field so a server that
+	// has ever booted is never rebuilt (a rebuild after first boot would destroy
+	// data). Unlike the reconciler-owned Available condition, it does not flip back
+	// to a non-provisioned value on a later re-reconcile.
+	ProvisionedAt *metav1.Time `json:"provisionedAt,omitempty"`
 	// ProviderCreateFailures records how many provider-accepted create attempts
 	// later landed in a provider error state before the server launched.
 	ProviderCreateFailures int32 `json:"providerCreateFailures,omitempty"`

--- a/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
@@ -2680,6 +2680,10 @@ func (in *ServerStatus) DeepCopyInto(out *ServerStatus) {
 		in, out := &in.ScheduledAt, &out.ScheduledAt
 		*out = (*in).DeepCopy()
 	}
+	if in.ProvisionedAt != nil {
+		in, out := &in.ProvisionedAt, &out.ProvisionedAt
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/managers/server/README.md
+++ b/pkg/managers/server/README.md
@@ -11,3 +11,11 @@ The watch is slightly broader than the other resource managers: besides server
 spec generation changes, it also wakes the controller when the monitor first
 observes a pre-launch provider server in `Healthy/Errored`. That status edge is
 the trigger for bounded delete-and-retry handling in the server provisioner.
+
+The "pre-launch" test is the shared `ProviderCreateFailure` predicate exported by
+[`pkg/provisioners/managers/server`](../../provisioners/managers/server/README.md),
+reused here verbatim so the watch trigger and the provisioner action are decided
+by the same code. It blocks the rebuild for any server that has ever been
+provisioned — authoritatively via the write-once `status.provisionedAt` latch,
+with `launchedAt`/phase as backstops — so a healthy, data-bearing server that
+later errors never re-arms delete-and-retry.

--- a/pkg/managers/server/manager.go
+++ b/pkg/managers/server/manager.go
@@ -18,7 +18,6 @@ limitations under the License.
 package server
 
 import (
-	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
 	coremanager "github.com/unikorn-cloud/core/pkg/manager"
 	"github.com/unikorn-cloud/core/pkg/manager/options"
@@ -27,8 +26,6 @@ import (
 	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/managers"
 	"github.com/unikorn-cloud/region/pkg/provisioners/managers/server"
-
-	corev1 "k8s.io/api/core/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -64,37 +61,12 @@ func (f *Factory) Reconciler(options *options.Options, controllerOptions coreman
 	return coremanager.NewReconciler(options, controllerOptions, manager, f.ProvisionerCreate(server.New))
 }
 
-func providerCreateFailure(server *unikornv1.Server) bool {
-	if server.Status.LaunchedAt != nil {
-		return false
-	}
-
-	switch server.Status.Phase {
-	case unikornv1.InstanceLifecyclePhaseRunning,
-		unikornv1.InstanceLifecyclePhaseStopping,
-		unikornv1.InstanceLifecyclePhaseStopped:
-		return false
-	case unikornv1.InstanceLifecyclePhasePending,
-		unikornv1.InstanceLifecyclePhaseQueued,
-		unikornv1.InstanceLifecyclePhaseBuilding,
-		"":
-	}
-
-	condition, err := server.StatusConditionRead(unikornv1core.ConditionHealthy)
-	if err != nil {
-		return false
-	}
-
-	return condition.Status == corev1.ConditionFalse &&
-		condition.Reason == unikornv1core.ConditionReasonErrored
-}
-
 func providerCreateFailureUpdate(e event.TypedUpdateEvent[*unikornv1.Server]) bool {
 	if e.ObjectOld == nil || e.ObjectNew == nil {
 		return false
 	}
 
-	return !providerCreateFailure(e.ObjectOld) && providerCreateFailure(e.ObjectNew)
+	return !server.ProviderCreateFailure(e.ObjectOld) && server.ProviderCreateFailure(e.ObjectNew)
 }
 
 // RegisterWatches adds any watches that would trigger a reconcile.

--- a/pkg/managers/server/manager_test.go
+++ b/pkg/managers/server/manager_test.go
@@ -86,4 +86,20 @@ func TestProviderCreateFailureUpdate(t *testing.T) {
 			ObjectNew: server,
 		}))
 	})
+
+	// A server that has ever been provisioned must never re-arm the rebuild path,
+	// even if its launch timestamp and phase have been lost and a health error
+	// then appears (e.g. a flaky-provider re-reconcile after a controller restart).
+	t.Run("ProvisionedWithoutLaunchTimestamp", func(t *testing.T) {
+		t.Parallel()
+
+		server := serverWithProviderCreateFailure()
+		provisionedAt := metav1.NewTime(time.Now().Add(-time.Hour))
+		server.Status.ProvisionedAt = &provisionedAt
+
+		require.False(t, providerCreateFailureUpdate(event.TypedUpdateEvent[*unikornv1.Server]{
+			ObjectOld: &unikornv1.Server{},
+			ObjectNew: server,
+		}))
+	})
 }

--- a/pkg/monitor/health/server/README.md
+++ b/pkg/monitor/health/server/README.md
@@ -18,6 +18,14 @@ status/telemetry model.
 - resolves provider and flavor context per region and caches it for a poll cycle
 - updates server status through provider `UpdateServerState(...)`
 - refines the server's live `Phase` from observed Nova + Ironic state. For OpenStack baremetal servers in Nova `BUILD`, an Ironic node lookup distinguishes `Queued` (provider has accepted the create but hardware is not yet engaged — pre-deploy Ironic states) from `Building` (Ironic actively deploying, including transient deploy failures). VMs in Nova `BUILD` go straight to `Building`. Provisioning status itself stays purely condition-derived (provisioner-owned, one-shot): the monitor never writes it. Phase is the live readiness signal once provisioning status reaches `provisioned`.
+- latches `status.provisionedAt` from Nova `launched_at`, alongside `launchedAt`
+  and ahead of the `BUILD` early-return, so it fires for VMs and baremetal alike
+  regardless of live power state. This is monitor-owned observed state (like
+  `launchedAt`), not the provisioner-owned provisioning-status condition; the
+  rebuild decision itself stays with the controller. Unlike `launchedAt` it is
+  written once and never cleared, and the controller's bounded provider-create
+  delete-and-retry guard keys off it so a server that has ever booted is never
+  rebuilt. Servers predating the field backfill it on the next poll once booted.
 - logs phase and health-condition transitions
 - rebuilds gauge counts from the effective server set each cycle
 

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -140,7 +140,11 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   The node lifecycle eventually terminates via delete; splitting "in the
   pipeline" from "in the pipeline but unhappy" across both Phase and Healthy
   would just duplicate one concept across two axes). Provisioning status
-  itself is provisioner-owned and the monitor never writes it. The lookup is
+  itself is provisioner-owned and the monitor never writes it; `setServerPhase`
+  does, however, latch the monitor-owned `status.provisionedAt` field from Nova
+  `launched_at` the first time a server is seen booted (write-once, never
+  cleared, independent of live power state), which the controller's rebuild guard
+  relies on. The lookup is
   filtered by `instance_uuid`. Because Ironic node ownership and visibility
   are provider infrastructure concerns rather than tenant workload operations,
   this lookup uses the Region top-level provider credentials scoped to the

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -2194,6 +2194,18 @@ func setServerPhase(ctx context.Context, server *unikornv1.Server, openstackserv
 	if !openstackserver.LaunchedAt.IsZero() {
 		t := metav1.NewTime(openstackserver.LaunchedAt)
 		server.Status.LaunchedAt = &t
+
+		// ProvisionedAt is a write-once latch recording that the server has booted
+		// at least once. It mirrors the same Nova launched_at signal as LaunchedAt
+		// (set here, ahead of the BUILD early-return and independent of power
+		// state, so it fires for VMs and baremetal alike) but, unlike LaunchedAt,
+		// it is never cleared: not by the provider-create retry reset, nor by a
+		// re-reconcile against a flaky provider. The bounded delete-and-retry guard
+		// keys off it so a server that has booted is never rebuilt, which would
+		// destroy data.
+		if server.Status.ProvisionedAt == nil {
+			server.Status.ProvisionedAt = &t
+		}
 	}
 
 	// Nova BUILD is the window where the live monitor refines the lifecycle

--- a/pkg/providers/internal/openstack/provisioning_status_test.go
+++ b/pkg/providers/internal/openstack/provisioning_status_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
@@ -128,11 +129,74 @@ func TestSetServerPhaseBuildBaremetalBuilding(t *testing.T) {
 func TestSetServerPhaseRunning(t *testing.T) {
 	t.Parallel()
 
+	launchedAt := time.Now().Add(-time.Minute)
 	server := &unikornv1.Server{}
 
-	setServerPhase(t.Context(), server, &servers.Server{Status: "ACTIVE", PowerState: servers.RUNNING}, nil)
+	setServerPhase(t.Context(), server, &servers.Server{Status: "ACTIVE", PowerState: servers.RUNNING, LaunchedAt: launchedAt}, nil)
 
 	require.Equal(t, unikornv1.InstanceLifecyclePhaseRunning, server.Status.Phase)
+	require.NotNil(t, server.Status.ProvisionedAt)
+	require.Equal(t, metav1.NewTime(launchedAt), *server.Status.ProvisionedAt, "ProvisionedAt latches the Nova launched_at signal")
+}
+
+// TestSetServerPhaseRunningLatchesProvisionedAtOnce proves ProvisionedAt is
+// write-once: a later observation with a fresh launched_at must not overwrite the
+// original latched value.
+func TestSetServerPhaseRunningLatchesProvisionedAtOnce(t *testing.T) {
+	t.Parallel()
+
+	provisionedAt := metav1.NewTime(time.Now().Add(-time.Hour))
+	server := &unikornv1.Server{}
+	server.Status.ProvisionedAt = &provisionedAt
+
+	setServerPhase(t.Context(), server, &servers.Server{Status: "ACTIVE", PowerState: servers.RUNNING, LaunchedAt: time.Now()}, nil)
+
+	require.Equal(t, unikornv1.InstanceLifecyclePhaseRunning, server.Status.Phase)
+	require.Equal(t, provisionedAt, *server.Status.ProvisionedAt, "ProvisionedAt must not be overwritten once latched")
+}
+
+// TestSetServerPhaseLatchesProvisionedAtWithoutRunningPowerState proves the latch
+// is driven by Nova launched_at, not the live power state. A booted server that
+// does not report PowerState RUNNING (e.g. a baremetal node surfacing NOSTATE
+// while Nova-ACTIVE) must still be recorded as provisioned.
+func TestSetServerPhaseLatchesProvisionedAtWithoutRunningPowerState(t *testing.T) {
+	t.Parallel()
+
+	launchedAt := time.Now().Add(-time.Minute)
+	server := &unikornv1.Server{}
+
+	setServerPhase(t.Context(), server, &servers.Server{Status: "ACTIVE", PowerState: servers.NOSTATE, LaunchedAt: launchedAt}, nil)
+
+	require.NotNil(t, server.Status.ProvisionedAt, "a booted server must latch regardless of live power state")
+	require.Equal(t, metav1.NewTime(launchedAt), *server.Status.ProvisionedAt)
+}
+
+// TestSetServerPhaseStoppedStillLatchesProvisionedAt proves a booted server later
+// observed stopped is still recorded as provisioned: it holds data, so the rebuild
+// guard must protect it, and legacy stopped servers backfill the latch.
+func TestSetServerPhaseStoppedStillLatchesProvisionedAt(t *testing.T) {
+	t.Parallel()
+
+	launchedAt := time.Now().Add(-time.Hour)
+	server := &unikornv1.Server{}
+
+	setServerPhase(t.Context(), server, &servers.Server{Status: "SHUTOFF", PowerState: servers.SHUTDOWN, LaunchedAt: launchedAt}, nil)
+
+	require.Equal(t, unikornv1.InstanceLifecyclePhaseStopped, server.Status.Phase)
+	require.NotNil(t, server.Status.ProvisionedAt, "a booted-then-stopped server must remain provisioned")
+}
+
+// TestSetServerPhaseBuildDoesNotLatchProvisionedAt proves a server that has not
+// yet booted (no Nova launched_at) is not considered provisioned, keeping it
+// eligible for delete-and-retry while Ironic provisioning is still flaky.
+func TestSetServerPhaseBuildDoesNotLatchProvisionedAt(t *testing.T) {
+	t.Parallel()
+
+	server := &unikornv1.Server{}
+
+	setServerPhase(t.Context(), server, &servers.Server{Status: "BUILD"}, nil)
+
+	require.Nil(t, server.Status.ProvisionedAt, "a building server must not be considered provisioned")
 }
 
 func TestSetServerPhaseStopped(t *testing.T) {

--- a/pkg/provisioners/managers/server/README.md
+++ b/pkg/provisioners/managers/server/README.md
@@ -12,7 +12,8 @@ Distinctive behaviour:
   as lifecycle transitions
 - augments provider create options with managed cloud-init parts for SSH CA use
 - retries provider-accepted create attempts that later land in provider error,
-  deleting the failed provider server before a bounded re-attempt
+  deleting the failed provider server before a bounded re-attempt, but only for
+  servers that have never been successfully provisioned
 - clears or updates consumed-resource references during reprovision and teardown
 
 This is the clearest controller-side expression of the lifecycle DAG model:
@@ -29,6 +30,23 @@ This is the clearest controller-side expression of the lifecycle DAG model:
 - Provider create retry state is stored on `Server.status`; changing retry
   behaviour must preserve the invariant that transient provider create failures
   return `ErrYield` until the configured attempt limit is reached.
+- The delete-and-retry decision lives in the single `ProviderCreateFailure`
+  predicate, shared with the controller watch predicate
+  (`pkg/managers/server`) so the trigger and the action cannot drift. It fails
+  closed: a rebuild destroys data, so any signal that the server has ever booted
+  blocks it. In steady state the load-bearing guard is `launchedAt` (mirrored
+  from Nova `launched_at`, which Nova sets at first boot and never clears).
+  `Server.status.provisionedAt` is a durable, write-once copy of that same Nova
+  signal that the retry reset never clears; it closes the one window `launchedAt`
+  alone cannot — a launched server whose `launchedAt` is wiped by an in-flight
+  retry reset, or a re-reconcile against a flaky provider. A reconciler-owned
+  `Available`/Provisioned condition would be unsuitable for this: it is
+  re-derived every reconcile and legitimately flips to `Errored`/`Provisioning`
+  on a controller restart against a flaky provider — exactly when a rebuild would
+  be catastrophic. The post-launch phases are retained as further defence in
+  depth so losing any single status field cannot re-arm the rebuild path.
+  Existing servers predating the latch backfill it on the next poll once booted
+  and are covered by the `launchedAt` backstop until then.
 - Provider create retries also emit Kubernetes events and structured logs on
   retry start, retry readiness after delete, and retry exhaustion; avoid
   per-reconcile emissions while deletion is still converging.

--- a/pkg/provisioners/managers/server/provisioner.go
+++ b/pkg/provisioners/managers/server/provisioner.go
@@ -248,12 +248,37 @@ func (p *Provisioner) recordProviderCreateRetryEvent(ctx context.Context, eventT
 	p.eventRecorder(ctx).Event(p.server, eventType, reason, eventMessage)
 }
 
-func (p *Provisioner) providerCreateFailure() bool {
-	if p.server.Status.LaunchedAt != nil {
+// ProviderCreateFailure reports whether a server is a pre-launch provider create
+// failure that is eligible for bounded delete-and-retry (rebuild). It is the
+// single source of truth for that decision, shared by the provisioner and the
+// controller's watch predicate so the two can never drift.
+//
+// It deliberately fails closed: any signal that the server has ever booted blocks
+// a rebuild, because a rebuild after first boot destroys data and forecloses
+// debugging or recovery.
+//
+//   - LaunchedAt is the steady-state guard: it mirrors Nova launched_at, which is
+//     set at first boot and never cleared by Nova, so LaunchedAt != nil means the
+//     server has booted.
+//   - ProvisionedAt is a durable, write-once copy of that same launched_at signal
+//     that nothing in this package ever clears. It exists because LaunchedAt is
+//     cleared by resetProviderCreateRuntimeStatus during an in-flight retry: the
+//     latch closes that window (and any future loss of LaunchedAt) so a server
+//     that has booted cannot be re-armed for rebuild. A reconciler-owned Available
+//     condition cannot serve this role — it is re-derived every reconcile and
+//     flips to a non-provisioned value when a reconcile re-runs against a flaky
+//     provider (for example on a controller restart).
+//   - The post-launch Phases are retained as further defence in depth.
+func ProviderCreateFailure(server *unikornv1.Server) bool {
+	if server.Status.ProvisionedAt != nil {
 		return false
 	}
 
-	switch p.server.Status.Phase {
+	if server.Status.LaunchedAt != nil {
+		return false
+	}
+
+	switch server.Status.Phase {
 	case unikornv1.InstanceLifecyclePhaseRunning,
 		unikornv1.InstanceLifecyclePhaseStopping,
 		unikornv1.InstanceLifecyclePhaseStopped:
@@ -264,13 +289,17 @@ func (p *Provisioner) providerCreateFailure() bool {
 		"":
 	}
 
-	condition, err := p.server.StatusConditionRead(unikornv1core.ConditionHealthy)
+	condition, err := server.StatusConditionRead(unikornv1core.ConditionHealthy)
 	if err != nil {
 		return false
 	}
 
 	return condition.Status == corev1.ConditionFalse &&
 		condition.Reason == unikornv1core.ConditionReasonErrored
+}
+
+func (p *Provisioner) providerCreateFailure() bool {
+	return ProviderCreateFailure(p.server)
 }
 
 func (p *Provisioner) resetProviderCreateRuntimeStatus(message string) {

--- a/pkg/provisioners/managers/server/provisioner_retry_test.go
+++ b/pkg/provisioners/managers/server/provisioner_retry_test.go
@@ -254,3 +254,27 @@ func TestProvision_LaunchedServerHealthErrorDoesNotRetryCreate(t *testing.T) {
 	require.Zero(t, server.Status.ProviderCreateFailures)
 	require.False(t, server.Status.ProviderCreateRetrying)
 }
+
+// TestProvision_ProvisionedServerHealthErrorDoesNotRetryCreate proves the
+// ProvisionedAt latch blocks a rebuild even when the launch timestamp and phase
+// have been lost: a server that has ever been provisioned must never be deleted
+// and recreated, only reconciled normally.
+func TestProvision_ProvisionedServerHealthErrorDoesNotRetryCreate(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	server := retryServer(withProviderCreateFailure)
+	provisionedAt := metav1.NewTime(time.Now().Add(-time.Hour))
+	server.Status.ProvisionedAt = &provisionedAt
+
+	provider := mocktypes.NewMockProvider(ctrl)
+	provider.EXPECT().CreateServer(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil)
+
+	cli := retryClient(t, retryIdentity(), server)
+	prov := retryProvisioner(t, server, nil, provider)
+
+	require.NoError(t, prov.Provision(coreclient.NewContext(t.Context(), cli)))
+	require.Zero(t, server.Status.ProviderCreateFailures)
+	require.False(t, server.Status.ProviderCreateRetrying)
+}


### PR DESCRIPTION
The monitor triggers a bounded delete-and-retry ("rebuild") when it
observes a pre-launch provider server in Healthy/Errored, to ride out
flaky Ironic provisioning. Rebuilding a server that has already booted
would destroy data and foreclose debugging or recovery, so the trigger
must be restricted to servers that have never been successfully
provisioned.

The previous guard keyed off LaunchedAt plus the lifecycle Phase. That
held, but the natural "provisioned" signal — the reconciler-owned
Available condition — is unsuitable: it is re-derived every reconcile
and legitimately flips to Errored/Provisioning on a controller restart
against a flaky provider, exactly when a rebuild would be catastrophic.

Add a write-once status.provisionedAt latch, set by the monitor on the
first Running observation and never cleared, surviving restarts and
provider flakiness. Gate the rebuild on it, keeping LaunchedAt and the
post-launch phases as defence in depth so losing any single status field
cannot re-arm the rebuild path. Existing servers are backfilled on their
next Running poll and covered by the LaunchedAt backstop until then.

De-duplicate the rebuild-eligibility predicate into a single shared
ProviderCreateFailure used by both the provisioner and the controller
watch predicate so the trigger and the action cannot drift.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
