### PR TITLE
Avoid updating status when retries are exhausted

### DIFF
--- a/pkg/provisioners/managers/server/provisioner.go
+++ b/pkg/provisioners/managers/server/provisioner.go
@@ -354,10 +354,17 @@ func (p *Provisioner) handleProviderCreateRetry(ctx context.Context, provider ty
 		return false, nil
 	}
 
-	attempt := p.server.Status.ProviderCreateFailures + 1
+	attempts := p.server.Status.ProviderCreateFailures
+	if attempts >= maxAttempts {
+		p.server.Status.ProviderCreateRetrying = false
+
+		return true, fmt.Errorf("%w after %d attempts", errProviderServerCreateFailed, attempts)
+	}
+
+	attempt := attempts + 1
 	p.server.Status.ProviderCreateFailures = attempt
 
-	if attempt >= maxAttempts {
+	if attempt == maxAttempts { // i.e., this was the last attempt
 		p.server.Status.ProviderCreateRetrying = false
 		p.recordProviderCreateRetryEvent(
 			ctx,

--- a/pkg/provisioners/managers/server/provisioner_retry_test.go
+++ b/pkg/provisioners/managers/server/provisioner_retry_test.go
@@ -233,6 +233,34 @@ func TestProvision_ProviderCreateFailureStopsAtAttemptLimit(t *testing.T) {
 	require.Equal(t, int32(3), server.Status.ProviderCreateFailures)
 	require.False(t, server.Status.ProviderCreateRetrying)
 	requireEvent(t, recorder, corev1.EventTypeWarning, "ProviderCreateFailed", "after 3 attempts")
+
+	prov = retryProvisioner(t, server, &serverprovisioner.Options{ProviderCreateMaxAttempts: 3}, provider, recorder)
+	err = prov.Provision(coreclient.NewContext(t.Context(), cli))
+	require.ErrorContains(t, err, "provider server create failed after 3 attempts")
+	require.Equal(t, int32(3), server.Status.ProviderCreateFailures)
+	require.False(t, server.Status.ProviderCreateRetrying)
+	requireNoEvent(t, recorder)
+}
+
+func TestProvision_ProviderCreateFailurePastAttemptLimitDoesNotAdvance(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	server := retryServer(withProviderCreateFailure)
+	server.Status.ProviderCreateFailures = 4
+
+	provider := mocktypes.NewMockProvider(ctrl)
+
+	cli := retryClient(t, retryIdentity(), server)
+	recorder := record.NewFakeRecorder(1)
+	prov := retryProvisioner(t, server, &serverprovisioner.Options{ProviderCreateMaxAttempts: 3}, provider, recorder)
+
+	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
+	require.ErrorContains(t, err, "provider server create failed after 4 attempts")
+	require.Equal(t, int32(4), server.Status.ProviderCreateFailures)
+	require.False(t, server.Status.ProviderCreateRetrying)
+	requireNoEvent(t, recorder)
 }
 
 func TestProvision_LaunchedServerHealthErrorDoesNotRetryCreate(t *testing.T) {


### PR DESCRIPTION
A Server object can be reconciled even if it's in an error state and has exhausted its retries. If the retry attempts _are_ exhausted, it should exit without changing the count; otherwise each reconcile increments providerCreateFailures again and reports a higher attempt count than the configured max.
