### PR TITLE
Abort server provider create terminally after retry exhaustion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spjmurray/go-util v0.1.3
 	github.com/stretchr/testify v1.11.1
-	github.com/unikorn-cloud/core v1.17.1
+	github.com/unikorn-cloud/core v1.18.0
 	github.com/unikorn-cloud/identity v1.17.8
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v1.17.1 h1:HTdh055cAyqROqFUTGRQE4zJW9J5Xzm/6Naa/YGYY3M=
-github.com/unikorn-cloud/core v1.17.1/go.mod h1:t91+Hw7YbNt5nOtp93Ij826iQfYDcz6Og0KAi2xq+B8=
+github.com/unikorn-cloud/core v1.18.0 h1:94HsQS0qfsK6F8U+xRjimp6tpWjjBkSoKcMYt/6fy3Q=
+github.com/unikorn-cloud/core v1.18.0/go.mod h1:t91+Hw7YbNt5nOtp93Ij826iQfYDcz6Og0KAi2xq+B8=
 github.com/unikorn-cloud/identity v1.17.8 h1:ZP1n9j/wB+l2JHsHWjFkG5zIx5dfr9tUPvc7P0WTY5A=
 github.com/unikorn-cloud/identity v1.17.8/go.mod h1:zdd93lbGvx90cduY/EAj5Mo9Irq/u5B75kIET0/Ql1w=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/pkg/provisioners/managers/server/README.md
+++ b/pkg/provisioners/managers/server/README.md
@@ -13,7 +13,8 @@ Distinctive behaviour:
 - augments provider create options with managed cloud-init parts for SSH CA use
 - retries provider-accepted create attempts that later land in provider error,
   deleting the failed provider server before a bounded re-attempt, but only for
-  servers that have never been successfully provisioned
+  servers that have never been successfully provisioned; once the attempt cap is
+  reached it aborts terminally rather than retrying further
 - clears or updates consumed-resource references during reprovision and teardown
 
 This is the clearest controller-side expression of the lifecycle DAG model:
@@ -27,9 +28,19 @@ This is the clearest controller-side expression of the lifecycle DAG model:
 
 - Reference maintenance here is easy to underappreciate, but it is central to
   keeping server deletion and dependent-resource blocking semantics correct.
-- Provider create retry state is stored on `Server.status`; changing retry
-  behaviour must preserve the invariant that transient provider create failures
-  return `ErrYield` until the configured attempt limit is reached.
+- Provider create retry state is stored on `Server.status.providerCreateFailures`.
+  Transient provider create failures return `ErrYield` (a fixed-interval requeue)
+  until the configured attempt cap is reached. At the cap the provisioner returns
+  the core `provisioners.Terminal` disposition, so the reconciler parks the server
+  (writes `Errored`, stops requeuing) instead of looping forever on a failure that
+  cannot self-heal — the bare error it used to return was requeued every yield
+  interval indefinitely, starving the workqueue. The counter is tested against the
+  prospective attempt and clamped to the cap, so it settles at the cap and cannot
+  drift on re-reconcile or controller restart (an already-drifted counter heals
+  back down on its next pass). Recovery is deliberately out of band: the terminal
+  state is sticky until an operator resets `providerCreateFailures`, which re-arms
+  the retry on the next reconcile. Changing retry behaviour must preserve these
+  invariants.
 - The delete-and-retry decision lives in the single `ProviderCreateFailure`
   predicate, shared with the controller watch predicate
   (`pkg/managers/server`) so the trigger and the action cannot drift. It fails

--- a/pkg/provisioners/managers/server/provisioner.go
+++ b/pkg/provisioners/managers/server/provisioner.go
@@ -51,8 +51,6 @@ const (
 	eventReasonProviderCreateFailed     = "ProviderCreateFailed"
 )
 
-var errProviderServerCreateFailed = errors.New("provider server create failed")
-
 // Options allows access to CLI options in the provisioner.
 type Options struct {
 	// ProviderCreateMaxAttempts bounds provider server create attempts before
@@ -355,23 +353,30 @@ func (p *Provisioner) handleProviderCreateRetry(ctx context.Context, provider ty
 	}
 
 	attempt := p.server.Status.ProviderCreateFailures + 1
-	p.server.Status.ProviderCreateFailures = attempt
 
 	if attempt >= maxAttempts {
+		// We have reached the attempt cap. Clamp the counter to the cap before
+		// returning so a re-reconcile (for example after a controller restart,
+		// where the failure predicate still holds) cannot advance it any further,
+		// then abort terminally instead of retrying. Recovery is out of band:
+		// once the underlying fault is fixed an operator resets
+		// ProviderCreateFailures to re-arm the retry process.
+		p.server.Status.ProviderCreateFailures = maxAttempts
 		p.server.Status.ProviderCreateRetrying = false
 		p.recordProviderCreateRetryEvent(
 			ctx,
 			corev1.EventTypeWarning,
 			eventReasonProviderCreateFailed,
 			"provider server create failed after all retry attempts",
-			fmt.Sprintf("Provider server create failed after %d attempts", attempt),
-			attempt,
+			fmt.Sprintf("Provider server create failed after %d attempts", maxAttempts),
+			maxAttempts,
 			maxAttempts,
 		)
 
-		return true, fmt.Errorf("%w after %d attempts", errProviderServerCreateFailed, attempt)
+		return true, provisioners.Terminal("provider_create_failed", fmt.Sprintf("provider server create failed after %d attempts", maxAttempts))
 	}
 
+	p.server.Status.ProviderCreateFailures = attempt
 	p.server.Status.ProviderCreateRetrying = true
 	p.recordProviderCreateRetryEvent(
 		ctx,

--- a/pkg/provisioners/managers/server/provisioner_retry_test.go
+++ b/pkg/provisioners/managers/server/provisioner_retry_test.go
@@ -230,9 +230,34 @@ func TestProvision_ProviderCreateFailureStopsAtAttemptLimit(t *testing.T) {
 
 	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
 	require.ErrorContains(t, err, "provider server create failed after 3 attempts")
+	require.ErrorIs(t, err, provisioners.ErrTerminal)
 	require.Equal(t, int32(3), server.Status.ProviderCreateFailures)
 	require.False(t, server.Status.ProviderCreateRetrying)
 	requireEvent(t, recorder, corev1.EventTypeWarning, "ProviderCreateFailed", "after 3 attempts")
+}
+
+// TestProvision_ProviderCreateFailureAtLimitDoesNotAdvance proves that a
+// re-reconcile of an already-exhausted server (e.g. after a controller restart,
+// where the failure predicate still holds) aborts terminally without advancing
+// the counter past the cap.
+func TestProvision_ProviderCreateFailureAtLimitDoesNotAdvance(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	server := retryServer(withProviderCreateFailure)
+	server.Status.ProviderCreateFailures = 3
+
+	provider := mocktypes.NewMockProvider(ctrl)
+
+	cli := retryClient(t, retryIdentity(), server)
+	recorder := record.NewFakeRecorder(1)
+	prov := retryProvisioner(t, server, &serverprovisioner.Options{ProviderCreateMaxAttempts: 3}, provider, recorder)
+
+	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
+	require.ErrorIs(t, err, provisioners.ErrTerminal)
+	require.Equal(t, int32(3), server.Status.ProviderCreateFailures)
+	require.False(t, server.Status.ProviderCreateRetrying)
 }
 
 func TestProvision_LaunchedServerHealthErrorDoesNotRetryCreate(t *testing.T) {


### PR DESCRIPTION
The bounded provider-create retry was meant to stop after a small cap (default
3), but the exhausted state ran away: the ProviderCreateFailures counter was
seen climbing into the hundreds across ~19 dev servers at a steady ~10s cadence.
Two independent defects combined to cause it.

1. No terminal path. The generic core reconciler requeues every non-ErrYield
   provisioner error on a fixed 10s interval, so returning a bare error at the
   cap looped forever, re-running Provision (and its provider/identity client
   calls) against a failure that cannot self-heal — starving the workqueue and
   robbing other resources of reconcile time.

2. Increment before the cap check. The counter was advanced before the limit was
   tested, so every re-entry into the failure branch bumped it. Even once the
   loop is stopped, a re-reconcile of an already-exhausted server (notably after
   a controller restart, where the failure predicate still holds) would keep
   advancing the counter past the cap.

Fix both at the single decision site in handleProviderCreateRetry:

- At the cap, return the new core provisioners.Terminal disposition instead of a
  bare error. The reconciler parks the resource (writes the Errored condition,
  no requeue) rather than retrying, so the workqueue goes quiet. The underlying
  "provider server create failed after N attempts" detail rides the
  disposition's operator-facing Why(); the user-visible message is the stable
  reason code. (Requires core with terminal dispositions; go.mod bumped.)

- Test the cap against the prospective attempt and clamp the persisted counter to
  maxAttempts, advancing it only on the retry path. The counter now settles at
  the cap and cannot drift on re-reconcile or restart; an already-drifted
  counter heals back down to the cap on its next pass.

The terminal state is sticky by design: recovery is out of band. Once the
underlying fault is fixed an operator resets ProviderCreateFailures, which
re-arms the retry on the next reconcile. The disposition is Terminal (not
UserActionRequired) precisely because there is no automatic, spec-driven
recovery.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

**Dependency:** requires `core` >= v1.18.0 for the terminal dispositions (nscaledev/uni-core#306, merged & tagged). `go.mod` is pinned to v1.18.0 — no longer a merge blocker.

**Relation to the counter-guard approach (#586):** complementary, and a superset. #586 stops the counter advancing past the cap; this does that too (clamp, not just guard, so it also heals already-drifted counters and cannot drift across controller restarts), and additionally eliminates the fixed-interval requeue of an exhausted create — the workqueue starvation that a counter-only fix leaves in place.