### PR TITLE
Set all OpenStack compute, network and block storage quotas to unlimited

### DIFF
--- a/pkg/providers/internal/openstack/blockstorage.go
+++ b/pkg/providers/internal/openstack/blockstorage.go
@@ -85,12 +85,16 @@ func (c *BlockStorageClient) UpdateQuotas(ctx context.Context, projectID string)
 	_, span := traceStart(ctx, "PUT /block-storage/v3/os-quota-sets")
 	defer span.End()
 
+	// Quotas are handled globally, not on a per-region basis, so it's safe to
+	// unconditionally remove all OpenStack block storage limits here.
 	opts := &quotasets.UpdateOpts{
-		Volumes:         ptr.To(-1),
-		Gigabytes:       ptr.To(-1),
-		Snapshots:       ptr.To(-1),
-		Backups:         ptr.To(-1),
-		BackupGigabytes: ptr.To(-1),
+		Volumes:            ptr.To(-1),
+		Gigabytes:          ptr.To(-1),
+		Snapshots:          ptr.To(-1),
+		Backups:            ptr.To(-1),
+		BackupGigabytes:    ptr.To(-1),
+		PerVolumeGigabytes: ptr.To(-1),
+		Groups:             ptr.To(-1),
 	}
 
 	return quotasets.Update(ctx, c.client, projectID, opts).Err

--- a/pkg/providers/internal/openstack/compute.go
+++ b/pkg/providers/internal/openstack/compute.go
@@ -210,11 +210,24 @@ func (c *ComputeClient) UpdateQuotas(ctx context.Context, projectID string) erro
 	_, span := traceStart(ctx, "PUT /compute/v2/os-quota-sets")
 	defer span.End()
 
+	// Quotas are handled globally, not on a per-region basis, so it's safe to
+	// unconditionally remove all OpenStack compute limits here.
 	opts := &quotasets.UpdateOpts{
 		// TODO: instances, cores and ram need to be driven by client input.
-		Instances: ptr.To(-1),
-		Cores:     ptr.To(-1),
-		RAM:       ptr.To(-1),
+		Instances:                ptr.To(-1),
+		Cores:                    ptr.To(-1),
+		RAM:                      ptr.To(-1),
+		FixedIPs:                 ptr.To(-1),
+		FloatingIPs:              ptr.To(-1),
+		InjectedFileContentBytes: ptr.To(-1),
+		InjectedFilePathBytes:    ptr.To(-1),
+		InjectedFiles:            ptr.To(-1),
+		KeyPairs:                 ptr.To(-1),
+		MetadataItems:            ptr.To(-1),
+		SecurityGroupRules:       ptr.To(-1),
+		SecurityGroups:           ptr.To(-1),
+		ServerGroups:             ptr.To(-1),
+		ServerGroupMembers:       ptr.To(-1),
 	}
 
 	return quotasets.Update(ctx, c.client, projectID, opts).Err

--- a/pkg/providers/internal/openstack/network.go
+++ b/pkg/providers/internal/openstack/network.go
@@ -771,7 +771,7 @@ func (c *NetworkClient) DeletePort(ctx context.Context, portID string) error {
 }
 
 // Update quotas overrides any OpenStack default quotas for the project's networking.
-// At present it's only security groups, security group rules and floating IPs that are affected.
+// All networking limits are removed.
 func (c *NetworkClient) UpdateQuotas(ctx context.Context, projectID string) error {
 	spanAttributes := trace.WithAttributes(
 		attribute.String("network.project.id", projectID),
@@ -780,10 +780,19 @@ func (c *NetworkClient) UpdateQuotas(ctx context.Context, projectID string) erro
 	_, span := traceStart(ctx, "PUT /network/v2.0/quotas/{id}", spanAttributes)
 	defer span.End()
 
+	// Quotas are handled globally, not on a per-region basis, so it's safe to
+	// unconditionally remove all OpenStack networking limits here.
 	opts := &quotas.UpdateOpts{
 		SecurityGroup:     ptr.To(-1),
 		SecurityGroupRule: ptr.To(-1),
 		FloatingIP:        ptr.To(-1),
+		Network:           ptr.To(-1),
+		Port:              ptr.To(-1),
+		RBACPolicy:        ptr.To(-1),
+		Router:            ptr.To(-1),
+		Subnet:            ptr.To(-1),
+		SubnetPool:        ptr.To(-1),
+		Trunk:             ptr.To(-1),
 	}
 
 	return quotas.Update(ctx, c.client, projectID, opts).Err


### PR DESCRIPTION
Expand the quota override in the OpenStack provisioner so that every quota
field the gophercloud compute (nova), networking (neutron) and block storage
(cinder) clients expose is set to -1 (unlimited), rather than just the subset
we previously overrode.

Quotas are handled globally, not on a per-region basis, so unconditionally
removing all per-project limits in the region provisioner is safe.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
