### PR TITLE
Deny cross-network security group references on server create and update

### DIFF
--- a/pkg/handler/server/README.md
+++ b/pkg/handler/server/README.md
@@ -23,6 +23,20 @@ related dependencies rather than from nested path scope.
 - `v2` servers are network-linked resources with direct ID-based access
 - create/update validate referenced image existence through the provider layer
 - create/update can validate and bind an SSH certificate authority
+- create/update reject references that escape the server's scope, enforced at the
+  API edge with HTTP 422. The RBAC read check that fetches a reference only proves
+  the caller may see it — a caller authorized across several tenancies could
+  otherwise attach a resource from another tenancy — so an explicit scope check is
+  applied on top:
+  - a referenced security group must belong to the same **network** as the server.
+    A network belongs to exactly one identity (one underlying OpenStack project),
+    which belongs to one organization and project, so same-network is the natural
+    granularity that closes the cross-tenancy hole and matches what OpenStack itself
+    permits. The owning network is exposed identically in region (the `NetworkLabel`)
+    and in the read model the compute service consumes (`status.networkId`), so the
+    same rule is enforced uniformly across both services.
+  - a referenced SSH certificate authority (which is not network-scoped) must share
+    the server's organization and project.
 - create can carry an `infrastructureRef` that pins initial placement to a
   provider-specific physical host; reads expose the value in status so callers
   can verify the placement request that was persisted
@@ -83,5 +97,7 @@ related dependencies rather than from nested path scope.
   `v2` servers
 - [../sshcertificateauthority](../sshcertificateauthority/README.md) documents
   the referenced SSH CA resource model
+- [../securitygroup](../securitygroup/README.md) documents the referenced
+  security group resource model
 - [../image](../image/README.md) documents the image-side semantics that
   snapshot creation feeds into

--- a/pkg/handler/server/client_v2.go
+++ b/pkg/handler/server/client_v2.go
@@ -44,6 +44,7 @@ import (
 	"github.com/unikorn-cloud/region/pkg/handler/common"
 	"github.com/unikorn-cloud/region/pkg/handler/identity"
 	"github.com/unikorn-cloud/region/pkg/handler/network"
+	"github.com/unikorn-cloud/region/pkg/handler/securitygroup"
 	"github.com/unikorn-cloud/region/pkg/handler/sshcertificateauthority"
 	"github.com/unikorn-cloud/region/pkg/handler/util"
 	regionids "github.com/unikorn-cloud/region/pkg/ids"
@@ -326,6 +327,41 @@ func (c *ClientV2) validateSSHCertificateAuthorityReference(ctx context.Context,
 	return nil
 }
 
+// assertSameNetwork denies a security group reference that belongs to a different
+// network. A network belongs to exactly one identity (one underlying OpenStack
+// project), which in turn belongs to one organization and project, so requiring the
+// security group to share the server's network closes the cross-tenancy hole at its
+// natural granularity — and is what OpenStack itself permits. The security group's
+// owning network is exposed identically in region (the NetworkLabel) and in the read
+// model the compute service consumes (status.networkId), so the same rule is enforced
+// uniformly across both services.
+func assertSameNetwork(networkID string, securityGroup *regionv1.SecurityGroup) error {
+	if securityGroup.Labels[constants.NetworkLabel] != networkID {
+		return errors.HTTPUnprocessableContent("a referenced security group must belong to the same network as the server")
+	}
+
+	return nil
+}
+
+func (c *ClientV2) validateSecurityGroupReferences(ctx context.Context, networkID string, networking *openapi.ServerV2Networking) error {
+	if networking == nil || networking.SecurityGroups == nil {
+		return nil
+	}
+
+	for _, id := range *networking.SecurityGroups {
+		securityGroup, err := securitygroup.New(c.Client.ClientArgs).GetV2Raw(ctx, id)
+		if err != nil {
+			return err
+		}
+
+		if err := assertSameNetwork(networkID, securityGroup); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (c *ClientV2) validateInfrastructureRefForFlavor(ctx context.Context, regionID, flavorID string, infrastructureRef *string) error {
 	if infrastructureRef != nil {
 		return nil
@@ -462,7 +498,8 @@ func (c *ClientV2) ListV2(ctx context.Context, params openapi.GetApiV2ServersPar
 
 // validateCreateV2Request runs the request-level validations for a v2 server
 // create: SSH certificate authority user-data coupling, that any referenced SSH
-// certificate authority shares the server's tenancy, and the infrastructure
+// certificate authority shares the server's organization and project, that any
+// referenced security group belongs to the server's network, and the infrastructure
 // reference requirements of the requested flavor.
 func (c *ClientV2) validateCreateV2Request(ctx context.Context, request *openapi.ServerV2Create, network *regionv1.Network) error {
 	if err := validateUserDataForSSHCertificateAuthority(request.Spec.SshCertificateAuthorityId, request.Spec.UserData); err != nil {
@@ -470,6 +507,10 @@ func (c *ClientV2) validateCreateV2Request(ctx context.Context, request *openapi
 	}
 
 	if err := c.validateSSHCertificateAuthorityReference(ctx, network, request.Spec.SshCertificateAuthorityId); err != nil {
+		return err
+	}
+
+	if err := c.validateSecurityGroupReferences(ctx, network.Name, request.Spec.Networking); err != nil {
 		return err
 	}
 
@@ -579,6 +620,14 @@ func (c *ClientV2) UpdateV2(ctx context.Context, serverID regionids.ServerID, re
 
 	if request.Metadata.Name != current.Labels[coreconstants.NameLabel] {
 		return nil, errors.HTTPUnprocessableContent("server names are immutable")
+	}
+
+	// Security groups are mutable, so re-validate that every referenced group still
+	// belongs to the server's network. The SSH certificate authority and
+	// infrastructure reference are immutable, so they keep the scope validated at
+	// create time.
+	if err := c.validateSecurityGroupReferences(ctx, current.Labels[constants.NetworkLabel], request.Spec.Networking); err != nil {
+		return nil, err
 	}
 
 	// Get the network, required for generation.

--- a/pkg/handler/server/client_v2_test.go
+++ b/pkg/handler/server/client_v2_test.go
@@ -94,8 +94,9 @@ func testSrvNetworkWithProject(projID string) *regionv1.Network {
 	}
 }
 
-// aclWithOrgScopeServerCreate grants network:read and region:servers/Create at
-// organization scope so GetV2Raw passes and AllowProjectScopeCreate is reached.
+// aclWithOrgScopeServerCreate grants network:read, securitygroups:read,
+// sshcertificateauthorities:read and region:servers/Create at organization scope so
+// the referenced-resource GetV2Raw calls pass and AllowProjectScopeCreate is reached.
 func aclWithOrgScopeServerCreate() *identityapi.Acl {
 	return &identityapi.Acl{
 		Organizations: &identityapi.AclOrganizationList{
@@ -109,6 +110,10 @@ func aclWithOrgScopeServerCreate() *identityapi.Acl {
 					{
 						Name:       "region:servers",
 						Operations: identityapi.AclOperations{identityapi.Create},
+					},
+					{
+						Name:       "region:securitygroups:v2",
+						Operations: identityapi.AclOperations{identityapi.Read},
 					},
 					{
 						Name:       "region:sshcertificateauthorities:v2",
@@ -242,6 +247,21 @@ func testServerWithSSHCertificateAuthority(orgID, projID, serverID, caID string)
 	}
 }
 
+func testSecurityGroupInNetwork(networkID, securityGroupID string) *regionv1.SecurityGroup {
+	return &regionv1.SecurityGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      securityGroupID,
+			Namespace: srvNamespace,
+			Labels: map[string]string{
+				coreconstants.OrganizationLabel:   srvOrganizationID,
+				coreconstants.ProjectLabel:        srvProjectID,
+				constants.NetworkLabel:            networkID,
+				constants.ResourceAPIVersionLabel: constants.MarshalAPIVersion(2),
+			},
+		},
+	}
+}
+
 // TestServerCreateV2RBACOrgScopedProjectNotFound verifies that CreateV2 returns
 // a 404 Not Found when the caller has org-scoped ACL but the project from the
 // network labels does not exist in the identity service.
@@ -361,6 +381,106 @@ func TestServerCreateV2SSHCertificateAuthorityRejectsCrossProjectReference(t *te
 
 	require.Error(t, err)
 	require.True(t, coreerrors.IsUnprocessableContent(err), "expected 422 unprocessable content, got: %v", err)
+}
+
+func TestServerCreateV2SecurityGroupNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	network := testSrvNetworkWithProject(srvProjectID)
+
+	k8sClient := newSrvFakeClient(t, network).Build()
+
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+	expectProjectFound(mockIdentity)
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := rbac.NewContext(t.Context(), aclWithOrgScopeServerCreate())
+
+	request := minimalServerV2CreateRequest()
+	request.Spec.Networking = &openapi.ServerV2Networking{
+		SecurityGroups: &openapi.ServerV2SecurityGroupIDList{"missing-security-group"},
+	}
+
+	_, err := c.CreateV2(ctx, request)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsHTTPNotFound(err), "expected 404 not found, got: %v", err)
+}
+
+func TestServerCreateV2SecurityGroupRejectsDifferentNetwork(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	network := testSrvNetworkWithProject(srvProjectID)
+	// A security group in the same organization and project as the server, but in a
+	// different network — and therefore a different identity / OpenStack project.
+	securityGroup := testSecurityGroupInNetwork("99999999-9999-4999-a999-999999999999", "sg-1")
+
+	k8sClient := newSrvFakeClient(t, network, securityGroup).Build()
+
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+	expectProjectFound(mockIdentity)
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := rbac.NewContext(t.Context(), aclWithOrgScopeServerCreate())
+
+	request := minimalServerV2CreateRequest()
+	request.Spec.Networking = &openapi.ServerV2Networking{
+		SecurityGroups: &openapi.ServerV2SecurityGroupIDList{securityGroup.Name},
+	}
+
+	_, err := c.CreateV2(ctx, request)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsUnprocessableContent(err), "expected 422 unprocessable content, got: %v", err)
+}
+
+func TestServerCreateV2SecurityGroupAcceptsSameNetwork(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	network := testSrvNetworkWithProject(srvProjectID)
+	securityGroup := testSecurityGroupInNetwork(srvNetworkID, "sg-1")
+
+	k8sClient := newSrvFakeClient(t, network, securityGroup).Build()
+
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+	expectProjectFound(mockIdentity)
+
+	mockProviders := newMockProvidersWithNoFlavors(ctrl)
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+		Providers: mockProviders,
+	})
+
+	ctx := withPrincipal(rbac.NewContext(t.Context(), aclWithOrgScopeServerCreate()))
+
+	request := minimalServerV2CreateRequest()
+	request.Spec.Networking = &openapi.ServerV2Networking{
+		SecurityGroups: &openapi.ServerV2SecurityGroupIDList{securityGroup.Name},
+	}
+
+	result, err := c.CreateV2(ctx, request)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
 }
 
 func TestServerCreateV2SSHCertificateAuthorityRejectsUnsupportedUserData(t *testing.T) {


### PR DESCRIPTION
A server could reference a security group belonging to a different network — and therefore a different identity and underlying OpenStack project — than the server itself. The RBAC read check performed when a reference is fetched only proves the caller may see the resource, which a caller authorized across several tenancies satisfies even for an out-of-scope security group, so nothing kept the reference within the server's own network.

Add `assertSameNetwork` and validate every referenced security group against the server's network on both create and update (security groups are mutable). A network belongs to exactly one identity (one OpenStack project), which belongs to one organization and project, so same-network is the natural granularity that closes the cross-tenancy hole and matches what OpenStack itself permits. The owning network is exposed both as the region `NetworkLabel` and as `status.networkId` in the read model the compute service consumes, so the identical rule applies across services. Mismatches are rejected at the API edge with HTTP 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)