### PR TITLE
Drop Neutron and file-injection quotas from the Nova quota update

### DIFF
--- a/pkg/providers/internal/openstack/compute.go
+++ b/pkg/providers/internal/openstack/compute.go
@@ -212,22 +212,20 @@ func (c *ComputeClient) UpdateQuotas(ctx context.Context, projectID string) erro
 
 	// Quotas are handled globally, not on a per-region basis, so it's safe to
 	// unconditionally remove all OpenStack compute limits here.
+	//
+	// Only the quotas Nova still owns are set here. The networking quotas
+	// (floating IPs, security groups and security group rules) moved to Neutron
+	// and the file-injection quotas were deprecated and removed, so Nova now
+	// rejects them as unexpected properties.
 	opts := &quotasets.UpdateOpts{
 		// TODO: instances, cores and ram need to be driven by client input.
-		Instances:                ptr.To(-1),
-		Cores:                    ptr.To(-1),
-		RAM:                      ptr.To(-1),
-		FixedIPs:                 ptr.To(-1),
-		FloatingIPs:              ptr.To(-1),
-		InjectedFileContentBytes: ptr.To(-1),
-		InjectedFilePathBytes:    ptr.To(-1),
-		InjectedFiles:            ptr.To(-1),
-		KeyPairs:                 ptr.To(-1),
-		MetadataItems:            ptr.To(-1),
-		SecurityGroupRules:       ptr.To(-1),
-		SecurityGroups:           ptr.To(-1),
-		ServerGroups:             ptr.To(-1),
-		ServerGroupMembers:       ptr.To(-1),
+		Instances:          ptr.To(-1),
+		Cores:              ptr.To(-1),
+		RAM:                ptr.To(-1),
+		KeyPairs:           ptr.To(-1),
+		MetadataItems:      ptr.To(-1),
+		ServerGroups:       ptr.To(-1),
+		ServerGroupMembers: ptr.To(-1),
 	}
 
 	return quotasets.Update(ctx, c.client, projectID, opts).Err


### PR DESCRIPTION
Commit ef75543 set every gophercloud-exposed compute quota field to -1,
but Nova rejects the networking quotas (fixed_ips, floating_ips,
security_groups, security_group_rules) that moved to Neutron and the
file-injection quotas (injected_files, injected_file_content_bytes,
injected_file_path_bytes) that were deprecated and removed. The result
was a "Additional properties are not allowed" 400 on the quota set
update.

Keep only the quotas Nova still owns. The networking quotas are already
unlimited via the Neutron quota update in network.go.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
