### PR TITLE
Check flavour traits in preflight

### DIFF
--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -94,9 +94,11 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   - pinned server creation can also enable a transient
     `openstack.compute.placementPreflight` check. When enabled, the provider
     asks OpenStack Placement whether the pinned resource provider has available
-    inventory for the flavor's positive custom `resources:*` extra spec and any
-    configured `requiredTraits`. Empty `requiredTraits` means no trait filter.
-    A miss yields and lets the controller retry.
+    inventory for the flavor's positive custom `resources:*` extra spec and
+    any `trait:*` extra specs, unioned with configured `requiredTraits`.
+    Required flavor traits are sent as positive Placement `required` entries;
+    forbidden flavor traits are sent as `!TRAIT` entries. Empty trait inputs
+    mean no trait filter. A miss yields and lets the controller retry.
 - `OpenstackIdentity` is the remaining persisted provider-state anchor. It
   currently stores the secret-bearing user/project/application-credential and
   bootstrap state needed to operate on behalf of a region `Identity`.

--- a/pkg/providers/internal/openstack/export_test.go
+++ b/pkg/providers/internal/openstack/export_test.go
@@ -120,6 +120,9 @@ var PlacementResourceQuery = placementResourceQuery
 //nolint:gochecknoglobals
 var FlavorPlacementResourceClass = flavorPlacementResourceClass
 
+//nolint:gochecknoglobals
+var FlavorPlacementTraits = flavorPlacementTraits
+
 func NewTestServerCreatePlacementPreflight(config *unikornv1.PlacementPreflightSpec, flavorClient FlavorInterface, placementClient PlacementInterface) func(context.Context, *unikornv1.Server) error {
 	preflight := serverCreatePlacementPreflight{
 		config: func() *unikornv1.PlacementPreflightSpec {

--- a/pkg/providers/internal/openstack/placement.go
+++ b/pkg/providers/internal/openstack/placement.go
@@ -35,13 +35,21 @@ import (
 )
 
 const (
-	placementAPIMicroversion = "1.18"
+	placementAPIMicroversion = "1.22"
 
 	placementResourceExtraSpecPrefix = "resources:"
+	placementTraitExtraSpecPrefix    = "trait:"
+	placementRequiredTraitValue      = "required"
+	placementForbiddenTraitValue     = "forbidden"
+	placementForbiddenTraitPrefix    = "!"
 	customPlacementResourcePrefix    = "CUSTOM_"
 )
 
-var errPlacementResourceClassRequired = errors.New("placement resource class is required")
+var (
+	errPlacementResourceClassRequired     = errors.New("placement resource class is required")
+	errPlacementRequiredTraitNameRequired = errors.New("placement required trait name is required")
+	errPlacementRequiredTraitUnsupported  = errors.New("placement required trait is unsupported")
+)
 
 // PlacementResourceProviderQuery scopes an OpenStack Placement provider lookup.
 type PlacementResourceProviderQuery struct {
@@ -135,12 +143,17 @@ func customPlacementResourceClass(resourceClass string) string {
 	return customPlacementResourcePrefix + strings.Trim(normalized, "_")
 }
 
-func placementPreflightRequiredTraits(preflight *unikornv1.PlacementPreflightSpec) []string {
-	if preflight == nil || len(preflight.RequiredTraits) == 0 {
+func placementPreflightRequiredTraits(preflight *unikornv1.PlacementPreflightSpec, flavorTraits []string) []string {
+	traits := flavorTraits
+	if preflight != nil && len(preflight.RequiredTraits) > 0 {
+		traits = append(traits, preflight.RequiredTraits...)
+	}
+
+	if len(traits) == 0 {
 		return nil
 	}
 
-	return normalizePlacementRequiredTraits(preflight.RequiredTraits)
+	return normalizePlacementRequiredTraits(traits)
 }
 
 func placementRequiredTraitsQuery(traits []string) string {
@@ -185,7 +198,7 @@ func (p serverCreatePlacementPreflight) check(ctx context.Context, server *uniko
 		return nil
 	}
 
-	resourceClass, err := p.flavorPlacementResourceClass(ctx, server.Spec.FlavorID)
+	resourceClass, flavorTraits, err := p.flavorPlacementRequirements(ctx, server.Spec.FlavorID)
 	if err != nil {
 		return err
 	}
@@ -198,7 +211,7 @@ func (p serverCreatePlacementPreflight) check(ctx context.Context, server *uniko
 	available, err := placementClient.ResourceProviderAvailable(ctx, PlacementResourceProviderQuery{
 		InfrastructureRef: *server.Spec.InfrastructureRef,
 		ResourceClass:     resourceClass,
-		RequiredTraits:    placementPreflightRequiredTraits(config),
+		RequiredTraits:    placementPreflightRequiredTraits(config, flavorTraits),
 	})
 	if err != nil {
 		return err
@@ -211,24 +224,36 @@ func (p serverCreatePlacementPreflight) check(ctx context.Context, server *uniko
 	return nil
 }
 
-func (p serverCreatePlacementPreflight) flavorPlacementResourceClass(ctx context.Context, flavorID string) (string, error) {
+func (p serverCreatePlacementPreflight) flavorPlacementRequirements(ctx context.Context, flavorID string) (string, []string, error) {
 	flavors, err := p.flavorClient.GetFlavors(ctx)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
-	return serverFlavorPlacementResourceClass(flavors, flavorID)
+	return serverFlavorPlacementRequirements(flavors, flavorID)
 }
 
-func serverFlavorPlacementResourceClass(openstackFlavors []flavors.Flavor, flavorID string) (string, error) {
+func serverFlavorPlacementRequirements(openstackFlavors []flavors.Flavor, flavorID string) (string, []string, error) {
 	index := slices.IndexFunc(openstackFlavors, func(flavor flavors.Flavor) bool {
 		return flavor.ID == flavorID
 	})
 	if index < 0 {
-		return "", fmt.Errorf("%w: flavor %q not found", coreerrors.ErrConsistency, flavorID)
+		return "", nil, fmt.Errorf("%w: flavor %q not found", coreerrors.ErrConsistency, flavorID)
 	}
 
-	return flavorPlacementResourceClass(openstackFlavors[index])
+	flavor := openstackFlavors[index]
+
+	resourceClass, err := flavorPlacementResourceClass(flavor)
+	if err != nil {
+		return "", nil, err
+	}
+
+	requiredTraits, err := flavorPlacementTraits(flavor)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return resourceClass, requiredTraits, nil
 }
 
 func flavorPlacementResourceClass(flavor flavors.Flavor) (string, error) {
@@ -277,6 +302,48 @@ func placementResourceClassFromExtraSpec(key, value string) (string, bool, error
 	}
 
 	return resourceClass, true, nil
+}
+
+func flavorPlacementTraits(flavor flavors.Flavor) ([]string, error) {
+	traits := []string{}
+
+	for key, value := range flavor.ExtraSpecs {
+		trait, ok, err := placementRequiredTraitFromExtraSpec(key, value)
+		if err != nil {
+			return nil, fmt.Errorf("%w: flavor %q placement required trait: %w", coreerrors.ErrConsistency, flavor.ID, err)
+		}
+
+		if !ok {
+			continue
+		}
+
+		traits = append(traits, trait)
+	}
+
+	slices.Sort(traits)
+
+	return normalizePlacementRequiredTraits(traits), nil
+}
+
+func placementRequiredTraitFromExtraSpec(key, value string) (string, bool, error) {
+	key = strings.TrimSpace(key)
+	if !strings.HasPrefix(strings.ToLower(key), placementTraitExtraSpecPrefix) {
+		return "", false, nil
+	}
+
+	trait := strings.ToUpper(strings.TrimSpace(key[len(placementTraitExtraSpecPrefix):]))
+	if trait == "" {
+		return "", false, fmt.Errorf("%w: %q", errPlacementRequiredTraitNameRequired, key)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case placementRequiredTraitValue:
+		return trait, true, nil
+	case placementForbiddenTraitValue:
+		return placementForbiddenTraitPrefix + trait, true, nil
+	default:
+		return "", false, fmt.Errorf("%w: %q value %q", errPlacementRequiredTraitUnsupported, key, value)
+	}
 }
 
 func placementPreflightConfig(region *unikornv1.Region) *unikornv1.PlacementPreflightSpec {

--- a/pkg/providers/internal/openstack/placement_test.go
+++ b/pkg/providers/internal/openstack/placement_test.go
@@ -66,20 +66,23 @@ func TestNewPlacementClientSetsMicroversion(t *testing.T) {
 func TestPlacementPreflightRequiredTraits(t *testing.T) {
 	t.Parallel()
 
-	require.Empty(t, openstack.PlacementPreflightRequiredTraits(nil))
-	require.Empty(t, openstack.PlacementPreflightRequiredTraits(&unikornv1.PlacementPreflightSpec{}))
+	require.Empty(t, openstack.PlacementPreflightRequiredTraits(nil, nil))
+	require.Empty(t, openstack.PlacementPreflightRequiredTraits(&unikornv1.PlacementPreflightSpec{}, nil))
 
-	traits := openstack.PlacementPreflightRequiredTraits(&unikornv1.PlacementPreflightSpec{
-		RequiredTraits: []string{
-			" custom_customer_ready ",
-			"",
-			"CUSTOM_CUSTOMER_READY",
-			"hw_cpu_x86_avx",
+	traits := openstack.PlacementPreflightRequiredTraits(
+		&unikornv1.PlacementPreflightSpec{
+			RequiredTraits: []string{
+				" custom_customer_ready ",
+				"",
+				"CUSTOM_CUSTOMER_READY",
+				"hw_cpu_x86_avx",
+			},
 		},
-	})
+		[]string{"CUSTOM_FLAVOR_READY", "custom_customer_ready"},
+	)
 
-	require.Equal(t, []string{"CUSTOM_CUSTOMER_READY", "HW_CPU_X86_AVX"}, traits)
-	require.Equal(t, "CUSTOM_CUSTOMER_READY,HW_CPU_X86_AVX", openstack.PlacementRequiredTraitsQuery(traits))
+	require.Equal(t, []string{"CUSTOM_FLAVOR_READY", "CUSTOM_CUSTOMER_READY", "HW_CPU_X86_AVX"}, traits)
+	require.Equal(t, "CUSTOM_FLAVOR_READY,CUSTOM_CUSTOMER_READY,HW_CPU_X86_AVX", openstack.PlacementRequiredTraitsQuery(traits))
 }
 
 func TestPlacementResourceQuery(t *testing.T) {
@@ -148,6 +151,40 @@ func TestFlavorPlacementResourceClass(t *testing.T) {
 	})
 }
 
+func TestFlavorPlacementTraits(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RequiredTraits", func(t *testing.T) {
+		t.Parallel()
+
+		traits, err := openstack.FlavorPlacementTraits(flavors.Flavor{
+			ID: "gpu",
+			ExtraSpecs: map[string]string{
+				"trait:CUSTOM_CUSTOMER_READY": "required",
+				"trait:HW_CPU_X86_AVX":        " required ",
+				"trait:CUSTOM_BLOCKED":        "forbidden",
+				"resources:CUSTOM_GPU":        "1",
+			},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"!CUSTOM_BLOCKED", "CUSTOM_CUSTOMER_READY", "HW_CPU_X86_AVX"}, traits)
+	})
+
+	t.Run("InvalidValue", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := openstack.FlavorPlacementTraits(flavors.Flavor{
+			ID: "invalid",
+			ExtraSpecs: map[string]string{
+				"trait:CUSTOM_READY": "sometimes",
+			},
+		})
+
+		require.ErrorIs(t, err, coreerrors.ErrConsistency)
+	})
+}
+
 func TestServerCreatePlacementPreflight(t *testing.T) {
 	t.Parallel()
 
@@ -202,7 +239,9 @@ func TestServerCreatePlacementPreflight(t *testing.T) {
 			{
 				ID: "flavor-a",
 				ExtraSpecs: map[string]string{
-					"resources:CUSTOM_GPU": "1",
+					"resources:CUSTOM_GPU":        "1",
+					"trait:CUSTOM_FLAVOR_READY":   "required",
+					"trait:CUSTOM_PROVIDER_BLOCK": "forbidden",
 				},
 			},
 		}, nil)
@@ -211,7 +250,7 @@ func TestServerCreatePlacementPreflight(t *testing.T) {
 		placementClient.EXPECT().ResourceProviderAvailable(t.Context(), openstack.PlacementResourceProviderQuery{
 			InfrastructureRef: "node-a",
 			ResourceClass:     "CUSTOM_GPU",
-			RequiredTraits:    []string{"CUSTOM_READY"},
+			RequiredTraits:    []string{"!CUSTOM_PROVIDER_BLOCK", "CUSTOM_FLAVOR_READY", "CUSTOM_READY"},
 		}).Return(true, nil)
 
 		preflight := openstack.NewTestServerCreatePlacementPreflight(
@@ -278,7 +317,7 @@ func TestPlacementClientResourceProviderAvailable(t *testing.T) {
 			t.Errorf("required query = %q, want %q", got, want)
 		}
 
-		if got, want := r.Header.Get("Openstack-Api-Version"), "placement 1.18"; got != want {
+		if got, want := r.Header.Get("Openstack-Api-Version"), "placement 1.22"; got != want {
 			t.Errorf("microversion header = %q, want %q", got, want)
 		}
 


### PR DESCRIPTION
Nova flavour specs are the scheduling contract that Placement enforces -- we need to check all of them, not just the device resource class.

Therefore: include required and forbidden flavour traits in the pre-flight query, so a pinned host that is missing or carrying the wrong trait yields before Nova create.

Placement's forbidden trait filter needs microversion 1.22, so bump the client version alongside the parser.
