### PR TITLE
fix: Wait longer on file storage deletion test

### DIFF
--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -518,21 +518,29 @@ func (c *APIClient) CreateFileStorage(ctx context.Context, request regionopenapi
 }
 
 // GetFileStorage gets a specific file storage resource by ID.
+// Returns ErrResourceNotFound if the file storage resource does not exist.
 func (c *APIClient) GetFileStorage(ctx context.Context, filestorageID string) (*regionopenapi.StorageV2Read, error) {
 	path := c.endpoints.GetFileStorage(filestorageID)
 
 	//nolint:bodyclose // DoRequest handles response body closing internally
-	_, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, http.StatusOK)
+	resp, respBody, err := c.regionClient.DoRequest(ctx, http.MethodGet, path, nil, 0)
 	if err != nil {
 		return nil, fmt.Errorf("getting filestorage: %w", err)
 	}
 
-	var storage regionopenapi.StorageV2Read
-	if err := json.Unmarshal(respBody, &storage); err != nil {
-		return nil, fmt.Errorf("unmarshaling filestorage: %w", err)
-	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var storage regionopenapi.StorageV2Read
+		if err := json.Unmarshal(respBody, &storage); err != nil {
+			return nil, fmt.Errorf("unmarshaling filestorage: %w", err)
+		}
 
-	return &storage, nil
+		return &storage, nil
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("filestorage '%s': %w", filestorageID, coreclient.ErrResourceNotFound)
+	default:
+		return nil, fmt.Errorf("getting filestorage: status %d: %w", resp.StatusCode, coreclient.ErrUnexpectedStatus)
+	}
 }
 
 // UpdateFileStorage updates a file storage resource.

--- a/test/api/suites/filestorage_test.go
+++ b/test/api/suites/filestorage_test.go
@@ -22,6 +22,8 @@ limitations under the License.
 package suites
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -155,6 +157,23 @@ func expectDefaultProtectionUpdateState(storage *regionopenapi.StorageV2Read, de
 	Expect(*storage.Spec.DefaultSnapshotProtectionEnabled).To(Equal(defaultProtectionEnabled))
 	Expect(storage.Spec.SnapshotPolicies).NotTo(BeNil())
 	Expect(*storage.Spec.SnapshotPolicies).To(Equal(snapshotPolicies))
+}
+
+func EventuallyFileStorageDeleted(ctx context.Context, filestorageID string) {
+	Eventually(func() error {
+		_, err := regionClient.GetFileStorage(ctx, filestorageID)
+		if errors.Is(err, coreclient.ErrResourceNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("file storage %s still exists", filestorageID)
+	}).
+		WithTimeout(5*time.Minute).
+		WithPolling(5*time.Second).
+		Should(Succeed(), "Storage should be deleted")
 }
 
 // INST-926 tracks Dev environment setup for file storage classes. Until Dev exposes
@@ -728,13 +747,7 @@ var _ = Describe("File Storage Management", func() {
 
 				GinkgoWriter.Printf("Deleted file storage: %s\n", filestorageID)
 
-				Eventually(func() error {
-					_, err := regionClient.GetFileStorage(ctx, filestorageID)
-					return err
-				}).WithTimeout(2*time.Minute).
-					WithPolling(5*time.Second).
-					Should(And(HaveOccurred(), MatchError(coreclient.ErrUnexpectedStatusCode)),
-						"Storage should be deleted")
+				EventuallyFileStorageDeleted(ctx, filestorageID)
 
 				GinkgoWriter.Printf("Confirmed file storage deleted: %s\n", filestorageID)
 				filestorageID = "" // suppress AfterAll cleanup; storage has been confirmed deleted
@@ -781,13 +794,7 @@ var _ = Describe("File Storage Management", func() {
 				}
 
 				GinkgoWriter.Printf("Waiting for storage cleanup: %s\n", filestorageID)
-				Eventually(func() error {
-					_, err := regionClient.GetFileStorage(ctx, filestorageID)
-					return err
-				}).WithTimeout(2*time.Minute).
-					WithPolling(5*time.Second).
-					Should(And(HaveOccurred(), MatchError(coreclient.ErrUnexpectedStatusCode)),
-						"Storage should be deleted during cleanup")
+				EventuallyFileStorageDeleted(ctx, filestorageID)
 			}
 
 			if networkID != "" {


### PR DESCRIPTION
## Summary

- Map file storage `GET` 404 responses to `coreclient.ErrResourceNotFound`, matching the other typed API clients.
- Wait for that explicit not-found condition when deleting file storage after detachment.
- Increase the file storage deletion wait from 2 minutes to 5 minutes for the spec and cleanup path.

## Root Cause

The UAT failure showed the file storage resource still returned `200` in `deprovisioning` state when the 2 minute assertion expired, then returned `404` immediately afterward during cleanup. The deletion path worked, but the test timeout was too tight for observed UAT latency. The previous assertion also treated any unexpected status as successful deletion because `GetFileStorage` did not classify 404s separately.

## Validation

- `make touch`
- `make license`
- `make validate`
- `make lint`
- `make generate`
- `GOTOOLCHAIN=go1.25.8 make test-unit`
- `go test ./test/api`
- `go test -tags integration ./test/api/suites -run '^$'`

Note: I did not dispatch the focused UAT workflow because the current API Tests workflow checks out the deployed UAT ref from the resolver rather than this branch.