### PR TITLE
Fail fast on malformed cloud-init at server create

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -28,10 +28,11 @@ The useful way to read it is not as a directory tree, but as one system:
 - [apis/unikorn/v1alpha1](./apis/unikorn/v1alpha1/README.md)
 - [ids](./ids/README.md)
 - [openapi](./openapi/README.md)
+- [userdata](./userdata/README.md)
 
 These packages define the shared control vocabulary, the stored Kubernetes
-resource model, the typed resource identifiers exposed at the API layer, and the
-HTTP wire contract.
+resource model, the typed resource identifiers exposed at the API layer, the
+HTTP wire contract, and the cross-service user-data validation contract.
 
 The most important direction here is that `v2` is the intended API shape.
 `v1` remains as deprecated compatibility surface and should be migrated away

--- a/pkg/handler/server/README.md
+++ b/pkg/handler/server/README.md
@@ -69,8 +69,12 @@ related dependencies rather than from nested path scope.
 - direct `v2` object access is gated to resources labeled with
   `ResourceAPIVersionLabel=2`.
 - A `Server v2` is owned by its network for cascading deletion.
-- User data and SSH certificate authority combinations are validated together to
-  avoid unsupported managed-userdata states.
+- User data is validated at create time against the server provisioner's
+  cloud-init parser, so malformed payloads are rejected with HTTP 422 instead of
+  failing mid-provision (when managed augmentation parses them) or silently
+  inside the guest at boot. With an SSH certificate authority the payload must
+  additionally support managed cloud-init augmentation (which excludes gzip);
+  without one, gzip payloads are accepted and passed through unmodified.
 - `GET /api/v2/servers/{serverID}/sshkey` only returns the identity private key
   for servers where Region requested `identityKeypair` SSH injection during
   create. It returns not found for `ca` and `none` servers.
@@ -93,8 +97,10 @@ related dependencies rather than from nested path scope.
   provider compute API.
 - Snapshot behaviour is coupled to image provenance and ownership semantics, so
   server is not fully self-contained as a lifecycle concept.
-- Some semantics, such as managed user-data validation for SSH CA use, are
-  important but narrow enough that they should stay local to this package.
+- Some semantics, such as user-data validation, are important but narrow enough
+  that they should stay local to this package; the parser itself is owned by the
+  server provisioner so the boundary check and provisioning behaviour cannot
+  drift apart.
 
 ## TODO
 

--- a/pkg/handler/server/client_v2.go
+++ b/pkg/handler/server/client_v2.go
@@ -51,7 +51,7 @@ import (
 	"github.com/unikorn-cloud/region/pkg/openapi"
 	"github.com/unikorn-cloud/region/pkg/providers"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
-	servermanager "github.com/unikorn-cloud/region/pkg/provisioners/managers/server"
+	"github.com/unikorn-cloud/region/pkg/userdata"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -312,18 +312,6 @@ func generateUserData(in *[]byte) []byte {
 	return *in
 }
 
-func validateUserDataForSSHCertificateAuthority(sshCertificateAuthorityID *string, userData *[]byte) error {
-	if sshCertificateAuthorityID == nil || userData == nil || len(*userData) == 0 {
-		return nil
-	}
-
-	if err := servermanager.ValidateManagedUserData(*userData); err == nil {
-		return nil
-	}
-
-	return errors.HTTPUnprocessableContent("userData must be a recognized cloud-init format when sshCertificateAuthorityId is specified")
-}
-
 func (c *ClientV2) validateSSHCertificateAuthorityReference(ctx context.Context, scope identityids.ProjectScopeReader, sshCertificateAuthorityID *string) error {
 	if sshCertificateAuthorityID == nil {
 		return nil
@@ -542,8 +530,8 @@ func (c *ClientV2) ListV2(ctx context.Context, params openapi.GetApiV2ServersPar
 }
 
 // validateCreateV2Request runs the request-level validations for a v2 server
-// create: SSH injection mode compatibility, SSH certificate authority user-data
-// coupling, that any referenced SSH certificate authority shares the server's
+// create: SSH injection mode compatibility, that any user-data is well-formed
+// cloud-init, that any referenced SSH certificate authority shares the server's
 // organization and project, that any referenced security group belongs to the
 // server's network, and the infrastructure reference requirements of the
 // requested flavor.
@@ -554,7 +542,10 @@ func (c *ClientV2) validateCreateV2Request(ctx context.Context, request *openapi
 		return err
 	}
 
-	if err := validateUserDataForSSHCertificateAuthority(request.Spec.SshCertificateAuthorityId, request.Spec.UserData); err != nil {
+	// Reject user-data that is not recognizable cloud-init, so a malformed
+	// payload surfaces as a 422 at create time rather than failing mid-provision
+	// (when managed augmentation parses it) or silently inside the guest at boot.
+	if err := userdata.Validate(request.Spec.UserData, request.Spec.SshCertificateAuthorityId != nil); err != nil {
 		return err
 	}
 

--- a/pkg/handler/server/client_v2_test.go
+++ b/pkg/handler/server/client_v2_test.go
@@ -569,6 +569,134 @@ func TestServerCreateV2SSHCertificateAuthorityAcceptsSupportedUserData(t *testin
 	}
 }
 
+func TestServerCreateV2RejectsMalformedUserDataWithoutSSHCertificateAuthority(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	network := testSrvNetworkWithProject(srvProjectID)
+
+	k8sClient := newSrvFakeClient(t, network).Build()
+
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+	expectProjectFound(mockIdentity)
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := withPrincipal(rbac.NewContext(t.Context(), aclWithOrgScopeServerCreate()))
+
+	request := minimalServerV2CreateRequest()
+	request.Spec.UserData = ptr.To([]byte("echo hello"))
+
+	_, err := c.CreateV2(ctx, request)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsUnprocessableContent(err), "expected 422 unprocessable content, got: %v", err)
+	require.ErrorContains(t, err, "unsupported userData format")
+}
+
+func TestServerCreateV2AcceptsUserDataWithoutSSHCertificateAuthority(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		userData []byte
+	}{
+		{
+			name:     "CloudConfig",
+			userData: []byte("#cloud-config\nusers: []\n"),
+		},
+		{
+			name:     "ShellScript",
+			userData: []byte("#!/bin/sh\necho hello\n"),
+		},
+		{
+			name:     "Multipart",
+			userData: []byte("Content-Type: multipart/mixed; boundary=\"BOUNDARY\"\r\nMIME-Version: 1.0\r\n\r\n--BOUNDARY\r\nContent-Type: text/x-shellscript\r\n\r\n#!/bin/sh\necho hello\r\n--BOUNDARY--\r\n"),
+		},
+		{
+			// Gzip user-data is passed to the platform unmodified when no managed
+			// augmentation occurs, so it must not be rejected at the boundary.
+			name:     "Gzip",
+			userData: []byte{0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+
+			network := testSrvNetworkWithProject(srvProjectID)
+
+			k8sClient := newSrvFakeClient(t, network).Build()
+
+			mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+			expectProjectFound(mockIdentity)
+
+			mockProviders := newMockProvidersWithNoFlavors(ctrl)
+
+			c := server.NewClientV2(common.ClientArgs{
+				Client:    k8sClient,
+				Namespace: srvNamespace,
+				Identity:  mockIdentity,
+				Providers: mockProviders,
+			})
+
+			ctx := withPrincipal(rbac.NewContext(t.Context(), aclWithOrgScopeServerCreate()))
+
+			request := minimalServerV2CreateRequest()
+			request.Spec.UserData = ptr.To(test.userData)
+
+			result, err := c.CreateV2(ctx, request)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			resource := &regionv1.Server{}
+			require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKey{Namespace: srvNamespace, Name: result.Metadata.Id}, resource))
+			require.Equal(t, test.userData, resource.Spec.UserData)
+		})
+	}
+}
+
+func TestServerCreateV2SSHCertificateAuthorityRejectsGzipUserData(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	network := testSrvNetworkWithProject(srvProjectID)
+	ca := testSSHCertificateAuthorityWithProject(srvProjectID)
+
+	k8sClient := newSrvFakeClient(t, network, ca).Build()
+
+	mockIdentity := identitymock.NewMockClientWithResponsesInterface(ctrl)
+	expectProjectFound(mockIdentity)
+
+	c := server.NewClientV2(common.ClientArgs{
+		Client:    k8sClient,
+		Namespace: srvNamespace,
+		Identity:  mockIdentity,
+	})
+
+	ctx := withPrincipal(rbac.NewContext(t.Context(), aclWithOrgScopeServerCreate()))
+
+	request := minimalServerV2CreateRequest()
+	request.Spec.SshCertificateAuthorityId = ptr.To(ca.Name)
+	request.Spec.UserData = ptr.To([]byte{0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00})
+
+	_, err := c.CreateV2(ctx, request)
+
+	require.Error(t, err)
+	require.True(t, coreerrors.IsUnprocessableContent(err), "expected 422 unprocessable content, got: %v", err)
+	require.ErrorContains(t, err, "gzip")
+}
+
 func TestServerCreateV2RejectsInvalidAllowedSourceAddress(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/provisioners/managers/server/cloudinit.go
+++ b/pkg/provisioners/managers/server/cloudinit.go
@@ -45,6 +45,26 @@ type cloudConfigWriteFile struct {
 	Content     string `json:"content"`
 }
 
+// UserDataError reports why a user-data payload was rejected. It unwraps to
+// ErrConsistency so provisioner-side error classification is unchanged, while
+// boundary callers can recover the caller-facing reason structurally instead
+// of parsing the message.
+type UserDataError struct {
+	Reason string
+}
+
+func (e *UserDataError) Error() string {
+	return coreerrors.ErrConsistency.Error() + ": " + e.Reason
+}
+
+func (e *UserDataError) Unwrap() error {
+	return coreerrors.ErrConsistency
+}
+
+func userDataError(reason string) error {
+	return &UserDataError{Reason: reason}
+}
+
 type cloudInitPart struct {
 	ContentType string
 	FileName    string
@@ -114,27 +134,46 @@ func userDataParts(userData []byte) ([]userDataPart, error) {
 }
 
 func isMultipartUserData(userData []byte) bool {
-	return strings.HasPrefix(strings.ToLower(firstUserDataLine(userData)), "content-type: multipart/")
+	// Fast path, and the fallback for payloads that declare multipart but have
+	// otherwise malformed headers, so those still surface multipart-specific
+	// parse errors rather than an unrecognized-format error.
+	if strings.HasPrefix(strings.ToLower(firstUserDataLine(userData)), "content-type: multipart/") {
+		return true
+	}
+
+	// MIME does not mandate header order, so Content-Type need not be the first
+	// line (e.g. MIME-Version first); parse the headers to detect those.
+	message, err := mail.ReadMessage(bytes.NewReader(userData))
+	if err != nil {
+		return false
+	}
+
+	mediaType, _, err := mime.ParseMediaType(message.Header.Get("Content-Type"))
+	if err != nil {
+		return false
+	}
+
+	return strings.HasPrefix(mediaType, "multipart/")
 }
 
 func parseMultipartUserData(userData []byte) ([]userDataPart, error) {
 	message, err := mail.ReadMessage(bytes.NewReader(userData))
 	if err != nil {
-		return nil, fmt.Errorf("%w: unable to parse multipart userData", coreerrors.ErrConsistency)
+		return nil, userDataError("unable to parse multipart userData")
 	}
 
 	mediaType, params, err := mime.ParseMediaType(message.Header.Get("Content-Type"))
 	if err != nil {
-		return nil, fmt.Errorf("%w: unable to parse multipart userData content type", coreerrors.ErrConsistency)
+		return nil, userDataError("unable to parse multipart userData content type")
 	}
 
 	if !strings.HasPrefix(mediaType, "multipart/") {
-		return nil, fmt.Errorf("%w: userData is not multipart", coreerrors.ErrConsistency)
+		return nil, userDataError("userData is not multipart")
 	}
 
 	boundary, ok := params["boundary"]
 	if !ok || boundary == "" {
-		return nil, fmt.Errorf("%w: multipart userData boundary missing", coreerrors.ErrConsistency)
+		return nil, userDataError("multipart userData boundary missing")
 	}
 
 	reader := multipart.NewReader(message.Body, boundary)
@@ -147,12 +186,12 @@ func parseMultipartUserData(userData []byte) ([]userDataPart, error) {
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("%w: unable to parse multipart userData part", coreerrors.ErrConsistency)
+			return nil, userDataError("unable to parse multipart userData part")
 		}
 
 		body, err := io.ReadAll(part)
 		if err != nil {
-			return nil, fmt.Errorf("%w: unable to read multipart userData part", coreerrors.ErrConsistency)
+			return nil, userDataError("unable to read multipart userData part")
 		}
 
 		parts = append(parts, userDataPart{
@@ -164,9 +203,13 @@ func parseMultipartUserData(userData []byte) ([]userDataPart, error) {
 	return parts, nil
 }
 
+func isGzipUserData(userData []byte) bool {
+	return bytes.HasPrefix(userData, []byte{0x1f, 0x8b})
+}
+
 func userDataContentType(userData []byte) (string, error) {
-	if bytes.HasPrefix(userData, []byte{0x1f, 0x8b}) {
-		return "", fmt.Errorf("%w: gzip userData cannot be combined with managed cloud-init augmentation", coreerrors.ErrConsistency)
+	if isGzipUserData(userData) {
+		return "", userDataError("gzip userData cannot be combined with managed cloud-init augmentation")
 	}
 
 	switch firstLine := firstUserDataLine(userData); {
@@ -185,7 +228,7 @@ func userDataContentType(userData []byte) (string, error) {
 	case strings.HasPrefix(firstLine, "#part-handler"):
 		return "text/part-handler", nil
 	default:
-		return "", fmt.Errorf("%w: unsupported userData format for managed cloud-init augmentation", coreerrors.ErrConsistency)
+		return "", userDataError("unsupported userData format: first line must identify a cloud-init payload (e.g. #cloud-config, #!, or a multipart Content-Type header)")
 	}
 }
 
@@ -196,6 +239,20 @@ func UserDataContentType(userData []byte) (string, error) {
 
 // ValidateManagedUserData checks that user-data can be safely combined with managed cloud-init augmentation.
 func ValidateManagedUserData(userData []byte) error {
+	_, err := userDataParts(userData)
+
+	return err
+}
+
+// ValidateUserData checks that user-data is a payload this provisioner will accept.
+// Unlike ValidateManagedUserData, gzip payloads are permitted: without managed
+// augmentation user-data is passed to the platform unmodified, so compressed
+// payloads remain valid.
+func ValidateUserData(userData []byte) error {
+	if isGzipUserData(userData) {
+		return nil
+	}
+
 	_, err := userDataParts(userData)
 
 	return err

--- a/pkg/provisioners/managers/server/cloudinit_test.go
+++ b/pkg/provisioners/managers/server/cloudinit_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	serverprovisioner "github.com/unikorn-cloud/region/pkg/provisioners/managers/server"
+)
+
+func TestValidateUserDataAcceptsSupportedPayloads(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		userData []byte
+	}{
+		{
+			name:     "Empty",
+			userData: nil,
+		},
+		{
+			name:     "CloudConfig",
+			userData: []byte("#cloud-config\nusers: []\n"),
+		},
+		{
+			name:     "ShellScript",
+			userData: []byte("#!/bin/sh\necho hello\n"),
+		},
+		{
+			name:     "JinjaTemplate",
+			userData: []byte("## template: jinja\n#cloud-config\nhostname: {{ ds.meta_data.hostname }}\n"),
+		},
+		{
+			name:     "IncludeURL",
+			userData: []byte("#include\nhttps://example.com/user-data\n"),
+		},
+		{
+			name:     "CloudBoothook",
+			userData: []byte("#cloud-boothook\n#!/bin/sh\necho hello\n"),
+		},
+		{
+			name:     "CloudConfigArchive",
+			userData: []byte("#cloud-config-archive\n- type: text/cloud-config\n  content: |\n    users: []\n"),
+		},
+		{
+			name:     "PartHandler",
+			userData: []byte("#part-handler\ndef list_types():\n    return [\"text/plain\"]\n"),
+		},
+		{
+			name:     "CRLFLineEndings",
+			userData: []byte("#cloud-config\r\nusers: []\r\n"),
+		},
+		{
+			name:     "Multipart",
+			userData: []byte("Content-Type: multipart/mixed; boundary=\"BOUNDARY\"\r\nMIME-Version: 1.0\r\n\r\n--BOUNDARY\r\nContent-Type: text/x-shellscript\r\n\r\n#!/bin/sh\necho hello\r\n--BOUNDARY--\r\n"),
+		},
+		{
+			// Multipart detection must not depend on header order: MIME allows any
+			// header first, and cloud-init accepts this payload.
+			name:     "MultipartMIMEVersionFirst",
+			userData: []byte("MIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=\"BOUNDARY\"\r\n\r\n--BOUNDARY\r\nContent-Type: text/x-shellscript\r\n\r\n#!/bin/sh\necho hello\r\n--BOUNDARY--\r\n"),
+		},
+		{
+			// Gzip payloads are passed to the platform unmodified when no managed
+			// augmentation occurs, so they are accepted here.
+			name:     "Gzip",
+			userData: []byte{0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.NoError(t, serverprovisioner.ValidateUserData(test.userData))
+		})
+	}
+}
+
+func TestValidateUserDataRejectsMalformedPayloads(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		userData []byte
+		contains string
+	}{
+		{
+			name:     "PlainTextWithoutSentinel",
+			userData: []byte("echo hello"),
+			contains: "unsupported userData format",
+		},
+		{
+			name:     "MultipartMissingBoundary",
+			userData: []byte("Content-Type: multipart/mixed\r\nMIME-Version: 1.0\r\n\r\nbody\r\n"),
+			contains: "boundary missing",
+		},
+		{
+			name:     "MultipartMalformedHeaders",
+			userData: []byte("Content-Type: multipart/mixed; boundary=\"BOUNDARY\"\nnot a valid header\n\n--BOUNDARY--\n"),
+			contains: "unable to parse multipart userData",
+		},
+		{
+			name:     "MultipartTruncatedPart",
+			userData: []byte("Content-Type: multipart/mixed; boundary=\"BOUNDARY\"\r\nMIME-Version: 1.0\r\n\r\n--BOUNDARY\r\nContent-Type: text/x-shellscript\r\n\r\n#!/bin/sh\r\n"),
+			contains: "multipart userData",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := serverprovisioner.ValidateUserData(test.userData)
+
+			require.Error(t, err)
+			require.ErrorContains(t, err, test.contains)
+		})
+	}
+}
+
+func TestValidateUserDataUnsupportedFormatMessageIsContextNeutral(t *testing.T) {
+	t.Parallel()
+
+	err := serverprovisioner.ValidateUserData([]byte("echo hello"))
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unsupported userData format")
+	// The unrecognized-format error surfaces on paths with no managed
+	// augmentation involved, so it must not blame augmentation.
+	require.NotContains(t, err.Error(), "managed cloud-init augmentation")
+}
+
+func TestValidateManagedUserDataRejectsGzip(t *testing.T) {
+	t.Parallel()
+
+	err := serverprovisioner.ValidateManagedUserData([]byte{0x1f, 0x8b, 0x08, 0x00})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "gzip userData cannot be combined with managed cloud-init augmentation")
+}
+
+func TestUserDataErrorCarriesStructuredReason(t *testing.T) {
+	t.Parallel()
+
+	err := serverprovisioner.ValidateUserData([]byte("echo hello"))
+
+	require.Error(t, err)
+
+	// The reason must be recoverable structurally, not by string surgery.
+	udErr := &serverprovisioner.UserDataError{}
+	require.ErrorAs(t, err, &udErr)
+	require.Contains(t, udErr.Reason, "unsupported userData format")
+	require.NotContains(t, udErr.Reason, "consistency error")
+
+	// Provisioner-side classification must keep seeing the sentinel.
+	require.ErrorIs(t, err, coreerrors.ErrConsistency)
+}

--- a/pkg/userdata/README.md
+++ b/pkg/userdata/README.md
@@ -1,0 +1,29 @@
+# User Data
+
+## Purpose
+
+`pkg/userdata` owns the API-boundary contract for cloud-init user-data
+validation: which payloads a create request may carry, and the exact HTTP 422
+(status and message) returned when one is rejected.
+
+It exists as a standalone package — rather than living in a handler — because
+the contract is shared across services: this repository's v2 server handler
+and the compute service's instances handler both call `Validate`, so the
+behaviour is identical everywhere by construction rather than by convention.
+
+## Behaviour
+
+- Absent user-data is valid.
+- Unmanaged payloads (no SSH certificate authority) must be recognizable
+  cloud-init; gzip is additionally permitted because it is passed to the
+  platform unmodified.
+- Managed payloads (an SSH certificate authority is referenced) must support
+  managed cloud-init augmentation, which excludes gzip.
+- Rejections carry the parser's specific reason, recovered structurally from
+  the parser's typed error — never by parsing message strings.
+
+## Cross-Package Context
+
+- [../provisioners/managers/server](../provisioners/managers/server/README.md)
+  owns the underlying cloud-init parser, so the boundary check and provisioning
+  behaviour cannot drift apart.

--- a/pkg/userdata/userdata.go
+++ b/pkg/userdata/userdata.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package userdata owns the API-boundary contract for cloud-init user-data
+// validation. It is deliberately importable by other services (the compute
+// instances API consumes it alongside this repository's own server handler) so
+// the HTTP status and message for rejected user-data are identical everywhere
+// by construction rather than by convention.
+package userdata
+
+import (
+	"errors"
+
+	coreerrors "github.com/unikorn-cloud/core/pkg/server/errors"
+	servermanager "github.com/unikorn-cloud/region/pkg/provisioners/managers/server"
+)
+
+// Validate is the canonical boundary check for user-data carried on create
+// requests. Absent user-data is valid. managed selects the stricter check for
+// payloads that will receive managed cloud-init augmentation (an SSH
+// certificate authority is referenced), which excludes gzip. Malformed
+// payloads yield the ready HTTP 422 carrying the parser's specific reason.
+func Validate(userData *[]byte, managed bool) error {
+	if userData == nil || len(*userData) == 0 {
+		return nil
+	}
+
+	validate := servermanager.ValidateUserData
+	if managed {
+		validate = servermanager.ValidateManagedUserData
+	}
+
+	if err := validate(*userData); err != nil {
+		return coreerrors.HTTPUnprocessableContent("userData must be a recognized cloud-init format: " + validationReason(err))
+	}
+
+	return nil
+}
+
+// validationReason extracts the caller-facing reason from a cloud-init parser
+// error, without the internal consistency-error sentinel.
+func validationReason(err error) string {
+	udErr := &servermanager.UserDataError{}
+	if errors.As(err, &udErr) {
+		return udErr.Reason
+	}
+
+	return err.Error()
+}

--- a/pkg/userdata/userdata_test.go
+++ b/pkg/userdata/userdata_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userdata_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/core/pkg/server/errors"
+	"github.com/unikorn-cloud/region/pkg/userdata"
+)
+
+func TestValidateReturnsCanonical422(t *testing.T) {
+	t.Parallel()
+
+	gzipData := []byte{0x1f, 0x8b, 0x08, 0x00}
+	malformed := []byte("echo hello")
+	valid := []byte("#cloud-config\nusers: []\n")
+
+	tests := []struct {
+		name      string
+		userData  *[]byte
+		managed   bool
+		wantError bool
+	}{
+		{name: "NilUserData", userData: nil, managed: true, wantError: false},
+		{name: "EmptyUserData", userData: &[]byte{}, managed: false, wantError: false},
+		{name: "ValidUnmanaged", userData: &valid, managed: false, wantError: false},
+		{name: "ValidManaged", userData: &valid, managed: true, wantError: false},
+		{name: "GzipUnmanaged", userData: &gzipData, managed: false, wantError: false},
+		{name: "GzipManaged", userData: &gzipData, managed: true, wantError: true},
+		{name: "MalformedUnmanaged", userData: &malformed, managed: false, wantError: true},
+		{name: "MalformedManaged", userData: &malformed, managed: true, wantError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := userdata.Validate(test.userData, test.managed)
+
+			if !test.wantError {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			require.True(t, errors.IsUnprocessableContent(err), "expected 422 unprocessable content, got: %v", err)
+			require.ErrorContains(t, err, "userData must be a recognized cloud-init format")
+			// The internal consistency-error sentinel must not leak to callers.
+			require.NotContains(t, err.Error(), "consistency error")
+		})
+	}
+}

--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -939,6 +939,30 @@ func (c *APIClient) CreateServer(ctx context.Context, request regionopenapi.Serv
 	return &server, nil
 }
 
+// CreateServerExpectError attempts a server create that is expected to be rejected
+// with the given status, returning the decoded standard error body.
+func (c *APIClient) CreateServerExpectError(ctx context.Context, request regionopenapi.ServerV2Create, expectedStatus int) (*coreapi.Error, error) {
+	path := c.endpoints.CreateServer()
+
+	reqBody, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling server request: %w", err)
+	}
+
+	//nolint:bodyclose // DoInternalRegionRequest handles response body closing internally
+	_, respBody, err := c.DoInternalRegionRequest(ctx, http.MethodPost, path, bytes.NewReader(reqBody), expectedStatus)
+	if err != nil {
+		return nil, fmt.Errorf("creating server: %w", err)
+	}
+
+	var apiError coreapi.Error
+	if err := json.Unmarshal(respBody, &apiError); err != nil {
+		return nil, fmt.Errorf("unmarshaling error response: %w", err)
+	}
+
+	return &apiError, nil
+}
+
 // GetServer gets a specific server by ID.
 func (c *APIClient) GetServer(ctx context.Context, serverID string) (*regionopenapi.ServerV2Read, error) {
 	path := c.endpoints.GetServer(serverID)

--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -367,6 +367,12 @@ func (b *ServerPayloadBuilder) WithInfrastructureRef(infrastructureRef string) *
 	return b
 }
 
+// WithUserData sets the cloud-init user data supplied at boot.
+func (b *ServerPayloadBuilder) WithUserData(userData []byte) *ServerPayloadBuilder {
+	b.server.Spec.UserData = &userData
+	return b
+}
+
 // Build returns the typed ServerV2Create struct.
 func (b *ServerPayloadBuilder) Build() regionopenapi.ServerV2Create {
 	return b.server

--- a/test/api/suites/servers_test.go
+++ b/test/api/suites/servers_test.go
@@ -21,6 +21,7 @@ limitations under the License.
 package suites
 
 import (
+	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -110,6 +111,51 @@ var _ = Describe("Server Management", func() {
 					g.Expect(got.Spec.ImageId).To(Equal(createReq.Spec.ImageId))
 					g.Expect(got.Status.NetworkId).To(Equal(networkID))
 				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
+			})
+		})
+	})
+
+	Context("When creating a server with user data", Ordered, func() {
+		var networkID string
+
+		BeforeAll(func() {
+			api.SkipUnlessOpenStackRegion(regionClient, ctx, config)
+			api.SkipUnlessInternalAPIConfigured(regionClient)
+			api.SkipUnlessServerFixtureConfigured(config)
+
+			networkReq := api.NewNetworkPayload(config.OrgID, config.ProjectID, config.RegionID).Build()
+			network, cleanupNetwork := api.MustProvisionNetwork(regionClient, ctx, networkReq)
+			DeferCleanup(cleanupNetwork)
+			networkID = network.Metadata.Id
+		})
+
+		Describe("Given malformed cloud-init user data", func() {
+			It("should reject the request with an actionable validation error", func() {
+				createReq := api.NewServerPayload(networkID, testFlavorID(), testImageID()).
+					WithUserData([]byte("echo hello")).
+					Build()
+
+				apiError, err := regionClient.CreateServerExpectError(ctx, createReq, http.StatusUnprocessableEntity)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(apiError.Error).To(Equal(coreapi.UnprocessableContent))
+				Expect(apiError.ErrorDescription).To(ContainSubstring("cloud-init"))
+				Expect(apiError.ErrorDescription).To(ContainSubstring("unsupported userData format"))
+			})
+		})
+
+		Describe("Given valid cloud-config user data", func() {
+			It("should create the server and preserve the user data unchanged", func() {
+				userData := []byte("#cloud-config\npackages:\n - vim\n")
+				createReq := api.NewServerPayload(networkID, testFlavorID(), testImageID()).
+					WithUserData(userData).
+					Build()
+
+				created, cleanup := api.MustCreateServer(regionClient, ctx, createReq)
+				DeferCleanup(cleanup)
+
+				Expect(created.Metadata.ProvisioningStatus).To(Equal(coreapi.ResourceProvisioningStatusPending))
+				Expect(created.Spec.UserData).NotTo(BeNil())
+				Expect(*created.Spec.UserData).To(Equal(userData))
 			})
 		})
 	})


### PR DESCRIPTION
Part of [INST-1075](https://linear.app/nscale-workspace/issue/INST-1075/fail-fast-on-malformed-cloud-init) (INST-1073 customer issues / release work). Companion: nscaledev/uni-compute#310. Single commit, rebased on main (SSH injection modes).

## Problem

User-data was only validated at the v2 server create boundary when an SSH certificate authority was referenced. Without one, malformed cloud-init passed straight through — failing mid-provision when managed augmentation parses it, or silently inside the guest at boot — leaving customers without an actionable error.

## Change

- **`pkg/userdata` (new)** — owns the API-boundary contract, per review feedback that the *whole* 422 behaviour (status + message) must be shared across services by construction, not convention. `userdata.Validate(userData, managed)` returns the ready `HTTPUnprocessableContent` carrying the parser's specific reason. This repository's v2 server handler and the compute instances handler both call it; it lives outside the handler tree so compute doesn't import another service's handler layer (matching the existing accepted cross-repo surface: `constants`/`ids`/`openapi`/`provisioners/managers/server`).
- **`pkg/provisioners/managers/server/cloudinit.go`** — validation failures now return a typed `*UserDataError{Reason}` that unwraps to `ErrConsistency` (provisioner-side classification and every message byte-identical), so the boundary recovers the caller-facing reason with `errors.As` instead of string surgery. Exports `ValidateUserData` (gzip permitted: passed through unmodified when unmanaged) alongside the existing `ValidateManagedUserData` (gzip rejected: managed augmentation can't merge into it). Multipart detection is now header-order independent (`MIME-Version:` first is valid, as cloud-init accepts), and the unrecognized-format message states what a valid first line looks like.
- **`pkg/handler/server/client_v2.go`** — create validation is unconditional and one line: `userdata.Validate(...)`. `UpdateV2` intentionally still skips it (user-data is only consumed at bootstrap; see existing comment).

## Tests

- `pkg/userdata`: table-driven canonical-422 contract (dispatch, gzip both modes, 422 type, no sentinel leak).
- Parser: every recognized sentinel, multipart edge cases (order-independent, missing boundary, malformed headers, truncated part), CRLF, typed-error contract (`errors.As` + `errors.Is(ErrConsistency)`).
- Handler: no-CA malformed → 422 with actionable message (red-first), valid payloads stored byte-identical, gzip-with-CA → 422.
- Integration (`test/api`): malformed → 422 asserting `error` + `error_description` body fields; valid cloud-config round-trips.

Also verified live on a kind+stgstack dev env through the console: malformed user-data → immediate 422 toast with the actionable message and no CRs created; valid cloud-config and MIME-Version-first multipart → provisioned with user-data byte-identical in both services' CRs.

**Merge ordering:** this must merge and tag before uni-compute#310, which imports `pkg/userdata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)