### PR TITLE
Make the monitor the sole owner of the server MAC address

### DIFF
--- a/charts/region/crds/region.unikorn-cloud.org_servers.yaml
+++ b/charts/region/crds/region.unikorn-cloud.org_servers.yaml
@@ -233,8 +233,17 @@ spec:
                 format: date-time
                 type: string
               macAddress:
-                description: MACAddress is the MAC address of the server's primary
-                  network interface.
+                description: |-
+                  MACAddress is the MAC address of the server's primary (single) network
+                  interface. It is owned exclusively by the monitor (the health checker),
+                  not the reconciler: it is recorded from the Nova server response once the
+                  server reaches ACTIVE, the barrier at which the port MAC is guaranteed
+                  bound for VMs and baremetal alike. For baremetal Ironic rebinds the port
+                  to the real NIC MAC asynchronously during deploy, so the value observed
+                  earlier (e.g. at port-create time) is the ephemeral Neutron MAC and is not
+                  trustworthy. It is only ever written, never cleared: the provider-create
+                  retry reset leaves it intact and a transient port-read miss cannot unset
+                  it, while an authoritative ACTIVE read self-heals any drift.
                 type: string
               phase:
                 description: Phase is the current lifecycle phase of the server.

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -989,7 +989,16 @@ type ServerStatus struct {
 	PrivateIP *string `json:"privateIP,omitempty"`
 	// PublicIP is the public IP address of the server.
 	PublicIP *string `json:"publicIP,omitempty"`
-	// MACAddress is the MAC address of the server's primary network interface.
+	// MACAddress is the MAC address of the server's primary (single) network
+	// interface. It is owned exclusively by the monitor (the health checker),
+	// not the reconciler: it is recorded from the Nova server response once the
+	// server reaches ACTIVE, the barrier at which the port MAC is guaranteed
+	// bound for VMs and baremetal alike. For baremetal Ironic rebinds the port
+	// to the real NIC MAC asynchronously during deploy, so the value observed
+	// earlier (e.g. at port-create time) is the ephemeral Neutron MAC and is not
+	// trustworthy. It is only ever written, never cleared: the provider-create
+	// retry reset leaves it intact and a transient port-read miss cannot unset
+	// it, while an authoritative ACTIVE read self-heals any drift.
 	MACAddress *string `json:"macAddress,omitempty"`
 	// LaunchedAt is the time the provider booted the VM. Nil until the server has
 	// been observed Running at least once.

--- a/pkg/monitor/health/server/README.md
+++ b/pkg/monitor/health/server/README.md
@@ -26,6 +26,17 @@ status/telemetry model.
   written once and never cleared, and the controller's bounded provider-create
   delete-and-retry guard keys off it so a server that has ever booted is never
   rebuilt. Servers predating the field backfill it on the next poll once booted.
+- is the sole owner of `status.macAddress`, recorded from the Nova server
+  response (the port MAC carried inline in `addresses`, reused from the poll's
+  existing `GetServer` — no extra provider call) once the server reaches Nova
+  `ACTIVE`. ACTIVE is the barrier at which the port MAC is guaranteed bound for
+  VMs and baremetal alike: for baremetal Ironic rebinds the port to the real NIC
+  MAC asynchronously during deploy, so the value observed earlier (e.g. by the
+  reconciler at port-create time) is the ephemeral Neutron MAC and must not be
+  trusted. A MAC is only ever written, never cleared: gating on ACTIVE and
+  skipping an empty read means a transient port-read miss cannot unset a held
+  value, while unconditionally writing a valid MAC self-heals drift (the status
+  PATCH makes a same-value write a no-op).
 - logs phase and health-condition transitions
 - rebuilds gauge counts from the effective server set each cycle
 

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -149,7 +149,11 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   does, however, latch the monitor-owned `status.provisionedAt` field from Nova
   `launched_at` the first time a server is seen booted (write-once, never
   cleared, independent of live power state), which the controller's rebuild guard
-  relies on. The lookup is
+  relies on. Alongside it, `setServerMACAddress` records the other monitor-owned
+  field, `status.macAddress`, from the Nova response once the server is `ACTIVE`
+  (the port MAC rides inline in `addresses`, reused from the same `GetServer` — no
+  extra call). ACTIVE is required because baremetal Ironic rebinds the port to the
+  real NIC MAC asynchronously; the value is only ever written, never cleared. The lookup is
   filtered by `instance_uuid`. Because Ironic node ownership and visibility
   are provider infrastructure concerns rather than tenant workload operations,
   this lookup uses the Region top-level provider credentials scoped to the

--- a/pkg/providers/internal/openstack/network.go
+++ b/pkg/providers/internal/openstack/network.go
@@ -149,9 +149,16 @@ func (c *NetworkClient) ExternalNetworks(ctx context.Context) ([]networks.Networ
 	return result, nil
 }
 
+// networkNameForID creates the openstack network name from a region network ID.
+// Nova keys a server's addresses map by this name, so the monitor reconstructs
+// it to find the MAC of a specific network interface.
+func networkNameForID(id string) string {
+	return "network-" + id
+}
+
 // networkName creates a unique name for the openstack network.
 func networkName(network *unikornv1.Network) string {
-	return "network-" + network.Name
+	return networkNameForID(network.Name)
 }
 
 type NetworkExt struct {

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -19,6 +19,7 @@ package openstack
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -2153,6 +2154,76 @@ func setServerHealthStatus(server *unikornv1.Server, openstackserver *servers.Se
 	server.StatusConditionWrite(unikornv1core.ConditionHealthy, status, reason, message)
 }
 
+// novaServerAddress is a single entry in a Nova server's `addresses` map. It
+// exists only because gophercloud's servers.Address type omits the port MAC
+// that Nova reports under OS-EXT-IPS-MAC:mac_addr, so we decode the addresses
+// into this to read the MAC with a real type rather than untyped assertions.
+type novaServerAddress struct {
+	//nolint:tagliatelle // Nova API field name, fixed by the OpenStack compute API.
+	MACAddress string `json:"OS-EXT-IPS-MAC:mac_addr"`
+}
+
+// serverMACAddress extracts the primary interface MAC from a Nova server
+// response. gophercloud decodes `addresses` into an untyped map keyed by
+// OpenStack network name, so we round-trip it through JSON into typed entries
+// and read the MAC from the server's primary network (Spec.Networks[0]) rather
+// than an arbitrary map entry. "" means Nova has not (yet) reported a MAC for
+// that network.
+func serverMACAddress(server *unikornv1.Server, openstackserver *servers.Server) (string, error) {
+	if len(server.Spec.Networks) == 0 {
+		return "", nil
+	}
+
+	raw, err := json.Marshal(openstackserver.Addresses)
+	if err != nil {
+		return "", err
+	}
+
+	addresses := map[string][]novaServerAddress{}
+	if err := json.Unmarshal(raw, &addresses); err != nil {
+		return "", err
+	}
+
+	for _, entry := range addresses[networkNameForID(server.Spec.Networks[0].ID)] {
+		if entry.MACAddress != "" {
+			return entry.MACAddress, nil
+		}
+	}
+
+	return "", nil
+}
+
+// setServerMACAddress records the server's MAC address from a Nova response.
+//
+// The monitor is the sole owner of Status.MACAddress: the reconciler goes to
+// sleep once the server is provisioned, and for baremetal Ironic rebinds the
+// port to the real NIC MAC asynchronously, so only a live poll can observe the
+// final value. Nova guarantees the port MAC is bound by ACTIVE for VMs and
+// baremetal alike, giving one code path for both.
+//
+// A MAC is only ever written, never cleared: gating on ACTIVE and skipping an
+// empty read means a transient port-read miss can never unset a value we hold,
+// while an unconditional write of a valid MAC self-heals any drift (the
+// monitor's optimistic status PATCH makes a same-value write a harmless no-op).
+func setServerMACAddress(ctx context.Context, server *unikornv1.Server, openstackserver *servers.Server) {
+	if openstackserver == nil || openstackserver.Status != "ACTIVE" {
+		return
+	}
+
+	mac, err := serverMACAddress(server, openstackserver)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to decode server addresses for MAC", "server", server.Name)
+
+		return
+	}
+
+	if mac == "" {
+		return
+	}
+
+	server.Status.MACAddress = &mac
+}
+
 // buildPhase picks the right Phase for a server Nova reports as BUILD. VMs
 // and baremetal lookups that failed fall back to Building (the honest "we
 // don't know more than Nova does" answer); a successful Ironic lookup
@@ -2312,7 +2383,6 @@ func (p *Provider) reconcileServerPort(ctx context.Context, client NetworkingInt
 		}
 
 		server.Status.PrivateIP = ptr.To(port.FixedIPs[0].IPAddress)
-		server.Status.MACAddress = stringPtrOrNil(port.MACAddress)
 
 		return port, nil
 	}
@@ -2326,17 +2396,8 @@ func (p *Provider) reconcileServerPort(ctx context.Context, client NetworkingInt
 	}
 
 	server.Status.PrivateIP = ptr.To(port.FixedIPs[0].IPAddress)
-	server.Status.MACAddress = stringPtrOrNil(port.MACAddress)
 
 	return port, nil
-}
-
-func stringPtrOrNil(value string) *string {
-	if value == "" {
-		return nil
-	}
-
-	return ptr.To(value)
 }
 
 func (p *Provider) reconcileFloatingIP(ctx context.Context, client FloatingIPInterface, server *unikornv1.Server, port *ports.Port) error {
@@ -2770,6 +2831,7 @@ func (p *Provider) updateServerStateWithClients(
 	}
 
 	setServerHealthStatus(server, openstackServer)
+	setServerMACAddress(ctx, server, openstackServer)
 
 	region, _ := p.openstack.regionSnapshot()
 	baremetal := isBaremetalFlavor(region, server.Spec.FlavorID)

--- a/pkg/providers/internal/openstack/provider_test.go
+++ b/pkg/providers/internal/openstack/provider_test.go
@@ -1536,8 +1536,10 @@ func TestReconcileServerPort(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, server.Status.PrivateIP)
 		require.Equal(t, serverPortIP, *server.Status.PrivateIP)
-		require.NotNil(t, server.Status.MACAddress)
-		require.Equal(t, serverPortMAC, *server.Status.MACAddress)
+		// The MAC is owned exclusively by the monitor, not the reconciler:
+		// the port MAC observed at create time is the ephemeral Neutron one
+		// for baremetal, so reconcileServerPort must not record it.
+		require.Nil(t, server.Status.MACAddress)
 	})
 
 	t.Run("ItExists", func(t *testing.T) {
@@ -1558,8 +1560,8 @@ func TestReconcileServerPort(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, server.Status.PrivateIP)
 		require.Equal(t, serverPortIP, *server.Status.PrivateIP)
-		require.NotNil(t, server.Status.MACAddress)
-		require.Equal(t, serverPortMAC, *server.Status.MACAddress)
+		// The MAC is owned exclusively by the monitor, not the reconciler.
+		require.Nil(t, server.Status.MACAddress)
 	})
 
 	t.Run("ItUpdatesSecurityGroups", func(t *testing.T) {

--- a/pkg/providers/internal/openstack/provisioning_status_test.go
+++ b/pkg/providers/internal/openstack/provisioning_status_test.go
@@ -34,6 +34,7 @@ import (
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -207,6 +208,59 @@ func TestSetServerPhaseStopped(t *testing.T) {
 	setServerPhase(t.Context(), server, &servers.Server{Status: "SHUTOFF", PowerState: servers.SHUTDOWN}, nil)
 
 	require.Equal(t, unikornv1.InstanceLifecyclePhaseStopped, server.Status.Phase)
+}
+
+// TestUpdateServerStateWithClientsRecordsMACAddress is the end-to-end wiring
+// test for the monitor as sole owner of the MAC: an ACTIVE Nova server carrying
+// a bound port MAC results in that MAC being recorded on the resource.
+func TestUpdateServerStateWithClientsRecordsMACAddress(t *testing.T) {
+	t.Parallel()
+
+	const mac = "e0:9d:73:86:cc:18"
+
+	compute := &stubComputeClient{server: &servers.Server{
+		ID:     "nova-id",
+		Status: "ACTIVE",
+		Addresses: map[string]any{
+			"network-ee2b52e3-a844-42bd-864d-a9ff2f39a026": []any{
+				map[string]any{
+					"OS-EXT-IPS-MAC:mac_addr": mac,
+					"OS-EXT-IPS:type":         "fixed",
+					"addr":                    "7.247.33.145",
+					"version":                 float64(4),
+				},
+			},
+		},
+	}}
+	identity := &unikornv1.Identity{}
+	server := &unikornv1.Server{Spec: unikornv1.ServerSpec{
+		FlavorID: "vm",
+		Networks: []unikornv1.ServerNetworkSpec{{ID: "ee2b52e3-a844-42bd-864d-a9ff2f39a026"}},
+	}}
+
+	provider := &Provider{
+		openstack: &openStackClients{
+			_region: &unikornv1.Region{
+				Spec: unikornv1.RegionSpec{
+					Openstack: &unikornv1.RegionOpenstackSpec{
+						Compute: &unikornv1.RegionOpenstackComputeSpec{
+							Flavors: &unikornv1.OpenstackFlavorsSpec{
+								Metadata: []unikornv1.FlavorMetadata{{ID: "vm", Baremetal: false}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := provider.updateServerStateWithClients(t.Context(), identity, server, compute,
+		func(context.Context, *unikornv1.Identity) (BaremetalInterface, error) {
+			return nil, errIronicUnavailable
+		})
+
+	require.NoError(t, err)
+	require.Equal(t, mac, ptr.Deref(server.Status.MACAddress, ""))
 }
 
 type stubComputeClient struct {

--- a/pkg/providers/internal/openstack/server_mac_test.go
+++ b/pkg/providers/internal/openstack/server_mac_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:testpackage
+package openstack
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/stretchr/testify/require"
+
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+
+	"k8s.io/utils/ptr"
+)
+
+const (
+	primaryNetworkID   = "ee2b52e3-a844-42bd-864d-a9ff2f39a026"
+	secondaryNetworkID = "aa11bb22-cc33-dd44-ee55-ff6677889900"
+)
+
+// novaAddressEntry builds one Nova address entry carrying the given MAC. An
+// empty mac omits the MAC key entirely (as Nova does before a port is bound).
+func novaAddressEntry(mac string) map[string]any {
+	entry := map[string]any{
+		"OS-EXT-IPS:type": "fixed",
+		"addr":            "7.247.33.145",
+		"version":         float64(4),
+	}
+
+	if mac != "" {
+		entry["OS-EXT-IPS-MAC:mac_addr"] = mac
+	}
+
+	return entry
+}
+
+// novaAddresses builds a Nova server `addresses` block for the primary network
+// with a single fixed IP carrying the given MAC, mirroring the raw shape
+// gophercloud preserves in servers.Server.Addresses.
+func novaAddresses(mac string) map[string]any {
+	return map[string]any{
+		networkNameForID(primaryNetworkID): []any{novaAddressEntry(mac)},
+	}
+}
+
+func TestSetServerMACAddress(t *testing.T) {
+	t.Parallel()
+
+	const (
+		realMAC  = "e0:9d:73:86:cc:18"
+		otherMAC = "fa:16:3e:00:11:22"
+	)
+
+	tests := []struct {
+		name          string
+		networks      []unikornv1.ServerNetworkSpec
+		existing      *string
+		openstack     *servers.Server
+		wantMACadress *string
+	}{
+		{
+			// The core case: server is ACTIVE and the port MAC is present, so
+			// the monitor records it. For baremetal this is the real NIC MAC
+			// bound by Ironic (Intel OUI), not the ephemeral Neutron one.
+			name:          "active with mac sets it",
+			networks:      []unikornv1.ServerNetworkSpec{{ID: primaryNetworkID}},
+			existing:      nil,
+			openstack:     &servers.Server{Status: "ACTIVE", Addresses: novaAddresses(realMAC)},
+			wantMACadress: ptr.To(realMAC),
+		},
+		{
+			// Before ACTIVE the port MAC is not guaranteed to be the final one
+			// (baremetal rebinds during deploy), so the monitor must not record
+			// it yet.
+			name:          "building leaves mac untouched",
+			networks:      []unikornv1.ServerNetworkSpec{{ID: primaryNetworkID}},
+			existing:      nil,
+			openstack:     &servers.Server{Status: "BUILD", Addresses: novaAddresses(realMAC)},
+			wantMACadress: nil,
+		},
+		{
+			// A read that yields no MAC must never clear a value we already
+			// hold: the monitor is the sole owner and only ever writes a
+			// non-empty MAC.
+			name:          "active without mac preserves existing",
+			networks:      []unikornv1.ServerNetworkSpec{{ID: primaryNetworkID}},
+			existing:      ptr.To(realMAC),
+			openstack:     &servers.Server{Status: "ACTIVE", Addresses: novaAddresses("")},
+			wantMACadress: ptr.To(realMAC),
+		},
+		{
+			// Self-healing: if the recorded MAC ever drifts from the observed
+			// one, the ACTIVE read corrects it.
+			name:          "active with different mac overwrites",
+			networks:      []unikornv1.ServerNetworkSpec{{ID: primaryNetworkID}},
+			existing:      ptr.To(otherMAC),
+			openstack:     &servers.Server{Status: "ACTIVE", Addresses: novaAddresses(realMAC)},
+			wantMACadress: ptr.To(realMAC),
+		},
+		{
+			// Determinism: the MAC is read from the primary network
+			// (Networks[0]) specifically, not an arbitrary entry of Nova's
+			// unordered addresses map, so a second network's MAC never wins.
+			name:     "reads the primary network mac not another",
+			networks: []unikornv1.ServerNetworkSpec{{ID: primaryNetworkID}},
+			existing: nil,
+			openstack: &servers.Server{Status: "ACTIVE", Addresses: map[string]any{
+				networkNameForID(primaryNetworkID):   []any{novaAddressEntry(realMAC)},
+				networkNameForID(secondaryNetworkID): []any{novaAddressEntry(otherMAC)},
+			}},
+			wantMACadress: ptr.To(realMAC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := &unikornv1.Server{}
+			server.Spec.Networks = tt.networks
+			server.Status.MACAddress = tt.existing
+
+			setServerMACAddress(t.Context(), server, tt.openstack)
+
+			require.Equal(t, tt.wantMACadress, server.Status.MACAddress)
+		})
+	}
+}

--- a/pkg/provisioners/managers/server/README.md
+++ b/pkg/provisioners/managers/server/README.md
@@ -58,6 +58,12 @@ This is the clearest controller-side expression of the lifecycle DAG model:
   depth so losing any single status field cannot re-arm the rebuild path.
   Existing servers predating the latch backfill it on the next poll once booted
   and are covered by the `launchedAt` backstop until then.
+- `Server.status.macAddress` is owned exclusively by the monitor (see
+  `pkg/monitor/health/server`), not the reconciler. The reconciler no longer
+  records it at port-create time — that value is the ephemeral Neutron MAC for
+  baremetal, which Ironic later rebinds to the real NIC MAC — and the retry
+  reset deliberately leaves it intact (like `provisionedAt`) so it never
+  flickers to unset; a stale value self-heals on the next `ACTIVE` poll.
 - Provider create retries also emit Kubernetes events and structured logs on
   retry start, retry readiness after delete, and retry exhaustion; avoid
   per-reconcile emissions while deletion is still converging.

--- a/pkg/provisioners/managers/server/provisioner.go
+++ b/pkg/provisioners/managers/server/provisioner.go
@@ -304,7 +304,8 @@ func (p *Provisioner) resetProviderCreateRuntimeStatus(message string) {
 	p.server.Status.Phase = unikornv1.InstanceLifecyclePhasePending
 	p.server.Status.PrivateIP = nil
 	p.server.Status.PublicIP = nil
-	p.server.Status.MACAddress = nil
+	// MACAddress is deliberately not reset: the monitor is its sole owner, and a
+	// stale value self-heals on the next ACTIVE poll rather than flickering to unset.
 	p.server.Status.LaunchedAt = nil
 	p.server.Status.ScheduledAt = nil
 	p.server.StatusConditionWrite(unikornv1core.ConditionHealthy, corev1.ConditionUnknown, unikornv1core.ConditionReasonProvisioning, message)

--- a/pkg/provisioners/managers/server/provisioner_retry_test.go
+++ b/pkg/provisioners/managers/server/provisioner_retry_test.go
@@ -40,6 +40,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -169,7 +170,9 @@ func TestProvision_ProviderCreateFailureDeletesAndYields(t *testing.T) {
 	require.Equal(t, regionv1.InstanceLifecyclePhasePending, server.Status.Phase)
 	require.Nil(t, server.Status.PrivateIP)
 	require.Nil(t, server.Status.PublicIP)
-	require.Nil(t, server.Status.MACAddress)
+	// The MAC is owned exclusively by the monitor; the reconciler's create-failure
+	// reset must not clear it. A stale value self-heals on the next ACTIVE poll.
+	require.Equal(t, ptr.To("00:11:22:33:44:55"), server.Status.MACAddress)
 	require.Nil(t, server.Status.ScheduledAt)
 
 	condition, err := server.StatusConditionRead(unikornv1core.ConditionHealthy)


### PR DESCRIPTION
The MAC address was populated early by the reconciler from the freshly
created Neutron port. That value is correct for VMs but wrong for baremetal:
Ironic rebinds the port to the physical NIC's MAC asynchronously during
provisioning, so the Neutron-generated MAC captured at port-create time is
stale and never corrected once the reconciler goes to sleep.

Move ownership of status.macAddress to the health monitor, the only component
still observing a server after it is provisioned. It records the MAC from the
Nova server response (the port MAC rides inline in addresses, reused from the
poll's existing GetServer call, so there is no extra provider call) once the
server reaches ACTIVE, the barrier at which the port MAC is guaranteed bound
for VMs and baremetal alike. This is one code path for both.

The MAC is only ever written, never cleared: gating on ACTIVE and skipping an
empty read means a transient port-read miss cannot unset a held value, while
an unconditional write of a valid MAC self-heals any drift (the optimistic
status PATCH makes a same-value write a no-op). Accordingly the reconciler's
early port-create writes and the provider-create retry reset no longer touch
the field, and ownership is documented on the CRD and in the package READMEs.

Manually verified read-only against a live production cluster:
- A baremetal compute node reporting Nova ACTIVE had its port bound to a real
  hardware NIC MAC (a physical vendor OUI), not a Neutron-generated fa:16:3e
  address, confirming Ironic completes the rebind by ACTIVE.
- That MAC is absent from `openstack server show` (the CLI collapses addresses
  to bare IPs) but present on the bound port, i.e. in the same Nova addresses
  payload the monitor already reads.
- A throwaway Go probe confirmed gophercloud's servers.Server.Addresses map
  preserves the OS-EXT-IPS-MAC:mac_addr key so the value is reachable in code.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
