### PR TITLE
Surface Nova server fault in the health condition

### DIFF
--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -2139,7 +2139,15 @@ func convertServerHealthStatus(server *servers.Server) (corev1.ConditionStatus, 
 	case "ACTIVE":
 		return corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "server is healthy"
 	case "ERROR":
-		return corev1.ConditionFalse, unikornv1core.ConditionReasonErrored, "server is in an error state"
+		// Nova records the failure cause (e.g. a scheduler "No valid host was
+		// found") on the server fault, visible to the owner; surface it so the
+		// condition explains the error without cloud-side log access.
+		message := "server is in an error state"
+		if server.Fault.Message != "" {
+			message += ": " + server.Fault.Message
+		}
+
+		return corev1.ConditionFalse, unikornv1core.ConditionReasonErrored, message
 	case "UNKNOWN":
 		return corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "unable to determine server status"
 	default:

--- a/pkg/providers/internal/openstack/server_health_test.go
+++ b/pkg/providers/internal/openstack/server_health_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:testpackage
+package openstack
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/stretchr/testify/require"
+
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestConvertServerHealthStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		server      *servers.Server
+		wantStatus  corev1.ConditionStatus
+		wantReason  unikornv1core.ConditionReason
+		wantMessage string
+	}{
+		{
+			name:        "nil server",
+			server:      nil,
+			wantStatus:  corev1.ConditionUnknown,
+			wantReason:  unikornv1core.ConditionReasonUnknown,
+			wantMessage: "unable to determine server status",
+		},
+		{
+			name:        "active",
+			server:      &servers.Server{Status: "ACTIVE"},
+			wantStatus:  corev1.ConditionTrue,
+			wantReason:  unikornv1core.ConditionReasonHealthy,
+			wantMessage: "server is healthy",
+		},
+		{
+			name:        "error without fault",
+			server:      &servers.Server{Status: "ERROR"},
+			wantStatus:  corev1.ConditionFalse,
+			wantReason:  unikornv1core.ConditionReasonErrored,
+			wantMessage: "server is in an error state",
+		},
+		{
+			// Nova attaches the scheduling/build failure cause to the server
+			// fault; surface it so the CR condition explains the error rather
+			// than requiring cloud-side log access.
+			name: "error with fault message",
+			server: &servers.Server{
+				Status: "ERROR",
+				Fault: servers.Fault{
+					Code:    500,
+					Message: "No valid host was found. There are not enough hosts available.",
+				},
+			},
+			wantStatus:  corev1.ConditionFalse,
+			wantReason:  unikornv1core.ConditionReasonErrored,
+			wantMessage: "server is in an error state: No valid host was found. There are not enough hosts available.",
+		},
+		{
+			// A stale fault from a recovered server must not leak into the
+			// healthy condition message.
+			name: "active with stale fault",
+			server: &servers.Server{
+				Status: "ACTIVE",
+				Fault:  servers.Fault{Message: "old failure"},
+			},
+			wantStatus:  corev1.ConditionTrue,
+			wantReason:  unikornv1core.ConditionReasonHealthy,
+			wantMessage: "server is healthy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			status, reason, message := convertServerHealthStatus(tt.server)
+
+			require.Equal(t, tt.wantStatus, status)
+			require.Equal(t, tt.wantReason, reason)
+			require.Equal(t, tt.wantMessage, message)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When a server create is accepted by Nova but the instance subsequently goes to `ERROR` (e.g. a scheduler `NoValidHost`), the Server CR's `Healthy` condition only says `server is in an error state`. The controller retries (`providerCreateFailures` climbs) but the underlying cause is invisible: the fault Nova attaches to the server — which carries the real error message — was fetched by the health monitor and then discarded by `convertServerHealthStatus`. Diagnosing today's failure on devstack-stg required SSH access to nova-conductor logs.

## Change

Append `server.Fault.Message` to the `Healthy` condition message when the server status is `ERROR`:

```
server is in an error state: No valid host was found. There are not enough hosts available.
```

Faults are only surfaced on `ERROR` — a stale fault on a recovered (`ACTIVE`) server does not leak into the healthy message (covered by a test).

## Testing

- New table-driven `TestConvertServerHealthStatus` covering nil/ACTIVE/ERROR, ERROR+fault, and ACTIVE+stale-fault.
- `go test ./pkg/...` and `golangci-lint run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)