### PR TITLE
Add VolumeClass contract and OpenStack discovery

### DIFF
--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -43,6 +43,7 @@ packages are the concrete provider implementations.
 - `types.CommonProvider` is the minimum substrate contract:
   - return the effective `Region`
   - return allocatable `Flavor` inventory
+  - return Region-scoped `VolumeClass` inventory
 - `types.Provider` extends that common base with the broader image, identity,
   network, security-group, load-balancer, server, console, and snapshot
   lifecycle surfaces.
@@ -100,6 +101,9 @@ packages are the concrete provider implementations.
   - it exposes a Kubernetes-backed region as a cloud-like substrate
   - it exports curated node-class-backed flavor inventory for higher layers that
     can consume the normal region shape
+  - it returns empty block-storage `VolumeClass` inventory because the
+    Kubernetes-backed substrate does not currently expose a Region block-storage
+    class surface
 - [./internal/simulated](./internal/simulated/README.md) implements the full
   interface in contract-shaped but deliberately incomplete form:
   - it exists to push broad integration coverage left

--- a/pkg/providers/internal/kubernetes/README.md
+++ b/pkg/providers/internal/kubernetes/README.md
@@ -26,6 +26,7 @@ Kubernetes regions:
 - connect to the remote cluster using the referenced kubeconfig secret
 - discover schedulable node classes
 - convert declared node-class metadata into provider-neutral `Flavor` values
+- return empty provider-neutral `VolumeClass` inventory
 
 ## Links
 
@@ -52,6 +53,8 @@ belongs to human administrators rather than this package contract summary.
   auto-derived from raw node objects.
 - The package therefore treats the region spec as the authoritative flavor
   description and the cluster as the availability check.
+- VolumeClass inventory is empty because this provider does not currently expose
+  a block-storage class model.
 - Architecture is currently hard-coded to `x86_64`.
 
 ## Caveats

--- a/pkg/providers/internal/kubernetes/provider.go
+++ b/pkg/providers/internal/kubernetes/provider.go
@@ -194,3 +194,8 @@ func (p *Provider) Flavors(ctx context.Context) (types.FlavorList, error) {
 
 	return flavors, nil
 }
+
+// VolumeClasses returns block-storage inventory for this region.
+func (p *Provider) VolumeClasses(_ context.Context) (types.VolumeClassList, error) {
+	return types.VolumeClassList{}, nil
+}

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -274,7 +274,10 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   provider-neutral `VolumeClass` values. Maximum performance metadata records
   caps rather than guaranteed reservations. `VolumeClass` is
   Region-scoped inventory configuration, not a project-owned resource or
-  lifecycle object.
+  lifecycle object. The block-storage service client is cached with the other
+  OpenStack service clients so Cinder volume-type inventory cache survives
+  repeated provider calls and is refreshed only when Region configuration or
+  credentials change.
 - Image handling is a first-class contract surface here:
   - OpenStack image properties are validated against a schema
   - public images can additionally be signature-verified

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -269,9 +269,10 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   storage: Region configuration under
   `openstack.blockStorage.volumeClasses` selects which provider volume classes
   are eligible for export and enriches them with user-facing metadata such as
-  media, maximum performance caps, and encryption signals. OpenStack maps this
-  configuration to Cinder volume types internally. Maximum performance metadata
-  records caps rather than guaranteed reservations. `VolumeClass` is
+  media, maximum performance caps, and encryption signals. The provider
+  discovers Cinder volume types and converts the selected/enriched result into
+  provider-neutral `VolumeClass` values. Maximum performance metadata records
+  caps rather than guaranteed reservations. `VolumeClass` is
   Region-scoped inventory configuration, not a project-owned resource or
   lifecycle object.
 - Image handling is a first-class contract surface here:

--- a/pkg/providers/internal/openstack/blockstorage.go
+++ b/pkg/providers/internal/openstack/blockstorage.go
@@ -149,7 +149,7 @@ func (c *BlockStorageClient) UpdateQuotas(ctx context.Context, projectID string)
 }
 
 func (p *Provider) VolumeClasses(ctx context.Context) (types.VolumeClassList, error) {
-	blockStorage, err := p.blockStorage(ctx)
+	blockStorage, err := p.openstack.blockStorage(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -162,17 +162,6 @@ func (p *Provider) VolumeClasses(ctx context.Context) (types.VolumeClassList, er
 	region, _ := p.openstack.regionSnapshot()
 
 	return convertVolumeClasses(region, resources), nil
-}
-
-func (p *Provider) blockStorage(ctx context.Context) (VolumeTypeInterface, error) {
-	region, credentials, err := p.openstack.regionRefresh(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	providerClient := NewPasswordProvider(region.Spec.Openstack.Endpoint, credentials.userID, credentials.password, credentials.projectID)
-
-	return NewBlockStorageClient(ctx, providerClient, region.Spec.Openstack.BlockStorage)
 }
 
 func convertVolumeClasses(region *unikornv1.Region, resources []volumetypes.VolumeType) types.VolumeClassList {

--- a/pkg/providers/internal/openstack/blockstorage.go
+++ b/pkg/providers/internal/openstack/blockstorage.go
@@ -20,22 +20,31 @@ package openstack
 
 import (
 	"context"
+	"slices"
+	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/availabilityzones"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/quotasets"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
+
+	"github.com/unikorn-cloud/core/pkg/util/cache"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
 
 	"k8s.io/utils/ptr"
 )
 
 // BlockStorageClient wraps the generic client because gophercloud is unsafe.
 type BlockStorageClient struct {
-	client *gophercloud.ServiceClient
+	client          *gophercloud.ServiceClient
+	options         *unikornv1.RegionOpenstackBlockStorageSpec
+	volumeTypeCache *cache.TimeoutCache[[]volumetypes.VolumeType]
 }
 
 // NewBlockStorageClient provides a simple one-liner to start computing.
-func NewBlockStorageClient(ctx context.Context, provider CredentialProvider) (*BlockStorageClient, error) {
+func NewBlockStorageClient(ctx context.Context, provider CredentialProvider, options *unikornv1.RegionOpenstackBlockStorageSpec) (*BlockStorageClient, error) {
 	providerClient, err := provider.Client(ctx)
 	if err != nil {
 		return nil, err
@@ -47,7 +56,9 @@ func NewBlockStorageClient(ctx context.Context, provider CredentialProvider) (*B
 	}
 
 	c := &BlockStorageClient{
-		client: client,
+		client:          client,
+		options:         options,
+		volumeTypeCache: cache.New[[]volumetypes.VolumeType](time.Hour),
 	}
 
 	return c, nil
@@ -81,6 +92,43 @@ func (c *BlockStorageClient) AvailabilityZones(ctx context.Context) ([]availabil
 	return filtered, nil
 }
 
+func (c *BlockStorageClient) GetVolumeTypes(ctx context.Context) ([]volumetypes.VolumeType, error) {
+	if result, ok := c.volumeTypeCache.Get(); ok {
+		return result, nil
+	}
+
+	_, span := traceStart(ctx, "GET /block-storage/v3/types")
+	defer span.End()
+
+	pages, err := volumetypes.List(c.client, nil).AllPages(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := volumetypes.ExtractVolumeTypes(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	result = slices.DeleteFunc(result, func(volumeType volumetypes.VolumeType) bool {
+		// We are admin, so see all the things, throw out private volume types.
+		if !volumeTypeIsPublic(volumeType) {
+			return true
+		}
+
+		config := openstackVolumeClassesConfig(c.options)
+		if config == nil || config.Selector == nil || len(config.Selector.IDs) == 0 {
+			return false
+		}
+
+		return !slices.Contains(config.Selector.IDs, volumeType.ID)
+	})
+
+	c.volumeTypeCache.Set(result)
+
+	return result, nil
+}
+
 func (c *BlockStorageClient) UpdateQuotas(ctx context.Context, projectID string) error {
 	_, span := traceStart(ctx, "PUT /block-storage/v3/os-quota-sets")
 	defer span.End()
@@ -98,4 +146,106 @@ func (c *BlockStorageClient) UpdateQuotas(ctx context.Context, projectID string)
 	}
 
 	return quotasets.Update(ctx, c.client, projectID, opts).Err
+}
+
+func (p *Provider) VolumeClasses(ctx context.Context) (types.VolumeClassList, error) {
+	blockStorage, err := p.blockStorage(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resources, err := blockStorage.GetVolumeTypes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	region, _ := p.openstack.regionSnapshot()
+
+	return convertVolumeClasses(region, resources), nil
+}
+
+func (p *Provider) blockStorage(ctx context.Context) (VolumeTypeInterface, error) {
+	region, credentials, err := p.openstack.regionRefresh(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	providerClient := NewPasswordProvider(region.Spec.Openstack.Endpoint, credentials.userID, credentials.password, credentials.projectID)
+
+	return NewBlockStorageClient(ctx, providerClient, region.Spec.Openstack.BlockStorage)
+}
+
+func convertVolumeClasses(region *unikornv1.Region, resources []volumetypes.VolumeType) types.VolumeClassList {
+	var config *unikornv1.OpenstackVolumeClassesSpec
+	if region != nil && region.Spec.Openstack != nil {
+		config = openstackVolumeClassesConfig(region.Spec.Openstack.BlockStorage)
+	}
+
+	result := make(types.VolumeClassList, 0, len(resources))
+
+	for i := range resources {
+		resource := &resources[i]
+
+		class := types.VolumeClass{
+			ID:          resource.ID,
+			Name:        resource.Name,
+			Description: resource.Description,
+		}
+
+		if metadata := volumeClassMetadata(config, resource.ID); metadata != nil {
+			class.Media = types.VolumeClassMedia(metadata.Media)
+			class.Encrypted = metadata.Encrypted
+
+			class.Performance = convertVolumeClassPerformance(metadata.Performance)
+		}
+
+		result = append(result, class)
+	}
+
+	return result
+}
+
+func volumeTypeIsPublic(volumeType volumetypes.VolumeType) bool {
+	return volumeType.IsPublic || volumeType.PublicAccess
+}
+
+func openstackVolumeClassesConfig(blockStorage *unikornv1.RegionOpenstackBlockStorageSpec) *unikornv1.OpenstackVolumeClassesSpec {
+	if blockStorage == nil {
+		return nil
+	}
+
+	return blockStorage.VolumeClasses
+}
+
+func volumeClassMetadata(config *unikornv1.OpenstackVolumeClassesSpec, id string) *unikornv1.VolumeClassMetadata {
+	if config == nil {
+		return nil
+	}
+
+	i := slices.IndexFunc(config.Metadata, func(metadata unikornv1.VolumeClassMetadata) bool {
+		return id == metadata.ID
+	})
+	if i < 0 {
+		return nil
+	}
+
+	return &config.Metadata[i]
+}
+
+func convertVolumeClassPerformance(in *unikornv1.VolumeClassPerformanceSpec) *types.VolumeClassPerformance {
+	if in == nil {
+		return nil
+	}
+
+	out := &types.VolumeClassPerformance{}
+
+	if in.MaxIOPS != nil {
+		out.MaxIOPS = ptr.To(*in.MaxIOPS)
+	}
+
+	if in.MaxThroughput != nil {
+		out.MaxThroughput = ptr.To(*in.MaxThroughput)
+	}
+
+	return out
 }

--- a/pkg/providers/internal/openstack/blockstorage_test.go
+++ b/pkg/providers/internal/openstack/blockstorage_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -107,6 +109,90 @@ func TestGetVolumeTypesAppliesSelectorVisibilityAndCache(t *testing.T) {
 	}, first)
 	require.Equal(t, first, second)
 	require.Equal(t, 1, requests)
+}
+
+func TestProviderVolumeClassesReusesBlockStorageClientCacheWithDefaultSelector(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		blockStorage *unikornv1.RegionOpenstackBlockStorageSpec
+	}{
+		{
+			name:         "WithoutVolumeClassesConfig",
+			blockStorage: &unikornv1.RegionOpenstackBlockStorageSpec{},
+		},
+		{
+			name: "WithEmptySelector",
+			blockStorage: &unikornv1.RegionOpenstackBlockStorageSpec{
+				VolumeClasses: &unikornv1.OpenstackVolumeClassesSpec{
+					Selector: &unikornv1.VolumeClassSelector{},
+				},
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ks := newFakeOpenstack(t)
+
+			region := &unikornv1.Region{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-region",
+					Namespace: "default",
+				},
+				Spec: unikornv1.RegionSpec{
+					Openstack: &unikornv1.RegionOpenstackSpec{
+						Endpoint: ks.ts.URL,
+						ServiceAccountSecret: &unikornv1.NamespacedObject{
+							Name:      "test-secret",
+							Namespace: "default",
+						},
+						BlockStorage: test.blockStorage,
+					},
+				},
+			}
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"domain-id":  []byte("domain"),
+					"user-id":    []byte("user"),
+					"password":   []byte("password"),
+					"project-id": []byte("project"),
+				},
+			}
+
+			client := newRaceTestClient(t, region, secret)
+			provider := openstack.NewTestProvider(client, region)
+
+			first, err := provider.VolumeClasses(t.Context())
+			require.NoError(t, err)
+
+			second, err := provider.VolumeClasses(t.Context())
+			require.NoError(t, err)
+
+			require.Equal(t, types.VolumeClassList{
+				{
+					ID:          "slow",
+					Name:        "slow-hdd",
+					Description: "Bulk capacity",
+				},
+				{
+					ID:          "fast",
+					Name:        "fast-nvme",
+					Description: "Latency sensitive",
+				},
+			}, first)
+			require.Equal(t, first, second)
+			require.Equal(t, int64(1), ks.volumeTypeRequests.Load())
+		})
+	}
 }
 
 func TestConvertVolumeClassesAppliesMetadata(t *testing.T) {

--- a/pkg/providers/internal/openstack/blockstorage_test.go
+++ b/pkg/providers/internal/openstack/blockstorage_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
+	"github.com/stretchr/testify/require"
+
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
+
+	"k8s.io/utils/ptr"
+)
+
+func TestGetVolumeTypesAppliesSelectorVisibilityAndCache(t *testing.T) {
+	t.Parallel()
+
+	var (
+		requests           int
+		gotMethod, gotPath string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+
+		if r.Method != http.MethodGet || r.URL.Path != "/types" {
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+
+		requests++
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{"volume_types":[
+			{
+				"id":"slow",
+				"name":"slow-hdd",
+				"description":"Bulk capacity",
+				"is_public":true,
+				"os-volume-type-access:is_public":true
+			},
+			{
+				"id":"fast",
+				"name":"fast-nvme",
+				"description":"Latency sensitive",
+				"is_public":true,
+				"os-volume-type-access:is_public":true
+			},
+			{
+				"id":"private",
+				"name":"private-nvme",
+				"description":"Provider internal",
+				"is_public":false,
+				"os-volume-type-access:is_public":false
+			}
+		]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := openstack.NewTestBlockStorageClient(srv.URL+"/", &unikornv1.RegionOpenstackBlockStorageSpec{
+		VolumeClasses: &unikornv1.OpenstackVolumeClassesSpec{
+			Selector: &unikornv1.VolumeClassSelector{
+				IDs: []string{"fast", "private"},
+			},
+		},
+	})
+
+	first, err := client.GetVolumeTypes(t.Context())
+	require.NoError(t, err)
+
+	second, err := client.GetVolumeTypes(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodGet, gotMethod)
+	require.Equal(t, "/types", gotPath)
+	require.Equal(t, []volumetypes.VolumeType{
+		{
+			ID:           "fast",
+			Name:         "fast-nvme",
+			Description:  "Latency sensitive",
+			IsPublic:     true,
+			PublicAccess: true,
+		},
+	}, first)
+	require.Equal(t, first, second)
+	require.Equal(t, 1, requests)
+}
+
+func TestConvertVolumeClassesAppliesMetadata(t *testing.T) {
+	t.Parallel()
+
+	region := &unikornv1.Region{
+		Spec: unikornv1.RegionSpec{
+			Openstack: &unikornv1.RegionOpenstackSpec{
+				BlockStorage: &unikornv1.RegionOpenstackBlockStorageSpec{
+					VolumeClasses: &unikornv1.OpenstackVolumeClassesSpec{
+						Metadata: []unikornv1.VolumeClassMetadata{
+							{
+								ID:    "fast",
+								Media: unikornv1.VolumeClassMediaNVMe,
+								Performance: &unikornv1.VolumeClassPerformanceSpec{
+									MaxIOPS:       ptr.To(25000),
+									MaxThroughput: ptr.To(500),
+								},
+								Encrypted: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	in := []volumetypes.VolumeType{
+		{
+			ID:          "fast",
+			Name:        "fast-nvme",
+			Description: "Latency sensitive",
+		},
+	}
+
+	out := openstack.ConvertVolumeClasses(region, in)
+
+	require.Equal(t, types.VolumeClassList{
+		{
+			ID:          "fast",
+			Name:        "fast-nvme",
+			Description: "Latency sensitive",
+			Media:       types.VolumeClassMediaNVMe,
+			Performance: &types.VolumeClassPerformance{
+				MaxIOPS:       ptr.To(25000),
+				MaxThroughput: ptr.To(500),
+			},
+			Encrypted: true,
+		},
+	}, out)
+}

--- a/pkg/providers/internal/openstack/export_test.go
+++ b/pkg/providers/internal/openstack/export_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/listeners"
@@ -50,6 +51,9 @@ func NewImageQuery(listFunc func() (*cache.ListSnapshot[types.Image], error)) ty
 
 //nolint:gochecknoglobals
 var ConvertImage = convertImage
+
+//nolint:gochecknoglobals
+var ConvertVolumeClasses = convertVolumeClasses
 
 //nolint:gochecknoglobals
 var GatewayIP = gatewayIP
@@ -148,6 +152,17 @@ func NewTestComputeClient(endpoint string) *ComputeClient {
 			Endpoint:       endpoint,
 		},
 		flavorCache: cache.New[[]flavors.Flavor](time.Hour),
+	}
+}
+
+func NewTestBlockStorageClient(endpoint string, options *unikornv1.RegionOpenstackBlockStorageSpec) *BlockStorageClient {
+	return &BlockStorageClient{
+		client: &gophercloud.ServiceClient{
+			ProviderClient: &gophercloud.ProviderClient{},
+			Endpoint:       endpoint,
+		},
+		options:         options,
+		volumeTypeCache: cache.New[[]volumetypes.VolumeType](time.Hour),
 	}
 }
 

--- a/pkg/providers/internal/openstack/interfaces.go
+++ b/pkg/providers/internal/openstack/interfaces.go
@@ -23,6 +23,7 @@ import (
 	"context"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/remoteconsoles"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servergroups"
@@ -193,6 +194,10 @@ type ComputeInterface interface {
 
 type PlacementInterface interface {
 	ResourceProviderAvailable(ctx context.Context, query PlacementResourceProviderQuery) (bool, error)
+}
+
+type VolumeTypeInterface interface {
+	GetVolumeTypes(ctx context.Context) ([]volumetypes.VolumeType, error)
 }
 
 // BaremetalInterface lets the live monitor look up the Ironic node bound to a

--- a/pkg/providers/internal/openstack/mock/interfaces.go
+++ b/pkg/providers/internal/openstack/mock/interfaces.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	nodes "github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	volumetypes "github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
 	flavors "github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	remoteconsoles "github.com/gophercloud/gophercloud/v2/openstack/compute/v2/remoteconsoles"
 	servergroups "github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servergroups"
@@ -2465,6 +2466,44 @@ func (m *MockPlacementInterface) ResourceProviderAvailable(ctx context.Context, 
 func (mr *MockPlacementInterfaceMockRecorder) ResourceProviderAvailable(ctx, query any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceProviderAvailable", reflect.TypeOf((*MockPlacementInterface)(nil).ResourceProviderAvailable), ctx, query)
+}
+
+// MockVolumeTypeInterface is a mock of VolumeTypeInterface interface.
+type MockVolumeTypeInterface struct {
+	ctrl     *gomock.Controller
+	recorder *MockVolumeTypeInterfaceMockRecorder
+}
+
+// MockVolumeTypeInterfaceMockRecorder is the mock recorder for MockVolumeTypeInterface.
+type MockVolumeTypeInterfaceMockRecorder struct {
+	mock *MockVolumeTypeInterface
+}
+
+// NewMockVolumeTypeInterface creates a new mock instance.
+func NewMockVolumeTypeInterface(ctrl *gomock.Controller) *MockVolumeTypeInterface {
+	mock := &MockVolumeTypeInterface{ctrl: ctrl}
+	mock.recorder = &MockVolumeTypeInterfaceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockVolumeTypeInterface) EXPECT() *MockVolumeTypeInterfaceMockRecorder {
+	return m.recorder
+}
+
+// GetVolumeTypes mocks base method.
+func (m *MockVolumeTypeInterface) GetVolumeTypes(ctx context.Context) ([]volumetypes.VolumeType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeTypes", ctx)
+	ret0, _ := ret[0].([]volumetypes.VolumeType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolumeTypes indicates an expected call of GetVolumeTypes.
+func (mr *MockVolumeTypeInterfaceMockRecorder) GetVolumeTypes(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeTypes", reflect.TypeOf((*MockVolumeTypeInterface)(nil).GetVolumeTypes), ctx)
 }
 
 // MockBaremetalInterface is a mock of BaremetalInterface interface.

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -1172,7 +1172,7 @@ func (p *Provider) provisionQuotas(ctx context.Context, identity *unikornv1.Open
 		return err
 	}
 
-	blockstorage, err := NewBlockStorageClient(ctx, providerClient)
+	blockstorage, err := NewBlockStorageClient(ctx, providerClient, region.Spec.Openstack.BlockStorage)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/internal/openstack/provider_race_test.go
+++ b/pkg/providers/internal/openstack/provider_race_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -43,7 +44,8 @@ import (
 // It handles authentication (returning a token + service catalog) and returns a
 // single fake flavor for any other request.
 type fakeOpenstack struct {
-	ts *httptest.Server
+	ts                 *httptest.Server
+	volumeTypeRequests atomic.Int64
 }
 
 func newFakeOpenstack(t *testing.T) *fakeOpenstack {
@@ -66,7 +68,8 @@ func (f *fakeOpenstack) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			{"type":"identity","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
 			{"type":"compute","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
 			{"type":"image","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
-			{"type":"network","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]}
+			{"type":"network","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]},
+			{"type":"block-storage","endpoints":[{"interface":"public","url":%[1]q,"region_id":""}]}
 			],"expires_at":"2099-01-01T00:00:00.000000Z"}}`,
 			f.ts.URL)
 
@@ -86,6 +89,39 @@ func (f *fakeOpenstack) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				{"id":"v3","status":"current","links":[{"href":%q,"rel":"self"}]}
 				]}}`,
 			f.ts.URL+"/v2.1/", f.ts.URL+"/v3/")
+
+		return
+	}
+
+	if r.Method == http.MethodGet && r.URL.Path == "/types" {
+		f.volumeTypeRequests.Add(1)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{"volume_types":[
+			{
+				"id":"slow",
+				"name":"slow-hdd",
+				"description":"Bulk capacity",
+				"is_public":true,
+				"os-volume-type-access:is_public":true
+			},
+			{
+				"id":"fast",
+				"name":"fast-nvme",
+				"description":"Latency sensitive",
+				"is_public":true,
+				"os-volume-type-access:is_public":true
+			},
+			{
+				"id":"private",
+				"name":"private-nvme",
+				"description":"Provider internal",
+				"is_public":false,
+				"os-volume-type-access:is_public":false
+			}
+		]}`)
 
 		return
 	}

--- a/pkg/providers/internal/openstack/serviceclients.go
+++ b/pkg/providers/internal/openstack/serviceclients.go
@@ -39,6 +39,8 @@ type openStackClients struct {
 	_compute  *ComputeClient
 	_image    *ImageClient
 	_network  NetworkingInterface
+	// _blockStorage is the region-scoped block-storage client used for inventory.
+	_blockStorage *BlockStorageClient
 
 	// region is the current region configuration.
 	_region *unikornv1.Region
@@ -54,13 +56,14 @@ type openStackClients struct {
 // It is separate from openStackClients so bootstrap can build the derived state
 // once and then install it onto the long-lived runtime wrapper.
 type serviceClientState struct {
-	region      *unikornv1.Region
-	secret      *corev1.Secret
-	credentials *providerCredentials
-	identity    *IdentityClient
-	compute     *ComputeClient
-	image       *ImageClient
-	network     NetworkingInterface
+	region       *unikornv1.Region
+	secret       *corev1.Secret
+	credentials  *providerCredentials
+	identity     *IdentityClient
+	compute      *ComputeClient
+	image        *ImageClient
+	network      NetworkingInterface
+	blockStorage *BlockStorageClient
 }
 
 // bootstrapServiceClientState performs the direct Kubernetes reads needed to build
@@ -146,14 +149,20 @@ func newServiceClientState(ctx context.Context, region *unikornv1.Region, secret
 		return nil, err
 	}
 
+	blockStorage, err := NewBlockStorageClient(ctx, providerClient, region.Spec.Openstack.BlockStorage)
+	if err != nil {
+		return nil, err
+	}
+
 	return &serviceClientState{
-		region:      region,
-		secret:      secret,
-		credentials: credentials,
-		identity:    identity,
-		compute:     compute,
-		image:       image,
-		network:     network,
+		region:       region,
+		secret:       secret,
+		credentials:  credentials,
+		identity:     identity,
+		compute:      compute,
+		image:        image,
+		network:      network,
+		blockStorage: blockStorage,
 	}, nil
 }
 
@@ -167,6 +176,7 @@ func (c *openStackClients) install(state *serviceClientState) {
 	c._compute = state.compute
 	c._image = state.image
 	c._network = state.network
+	c._blockStorage = state.blockStorage
 }
 
 // serviceClientRefresh updates clients if they need to e.g. in the event
@@ -284,4 +294,16 @@ func (c *openStackClients) network(ctx context.Context) (NetworkingInterface, er
 	}
 
 	return c._network, nil
+}
+
+// blockStorage returns an admin-level block storage client.
+func (c *openStackClients) blockStorage(ctx context.Context) (VolumeTypeInterface, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if err := c.serviceClientRefresh(ctx); err != nil {
+		return nil, err
+	}
+
+	return c._blockStorage, nil
 }

--- a/pkg/providers/internal/simulated/README.md
+++ b/pkg/providers/internal/simulated/README.md
@@ -25,8 +25,9 @@ development, while keeping behaviour deterministic and cheap to run.
 - The current implementation is deliberately incomplete. It represents the
   smallest useful amount of work needed to unlock broad push-left integration
   coverage, not a mature simulation of the full provider surface.
-- Determinism matters more than provider fidelity. Built-in flavors, images,
-  external networks, and synthetic addresses are stable by design.
+- Determinism matters more than provider fidelity. Built-in flavors,
+  volume classes, images, external networks, and synthetic addresses are stable
+  by design.
 - Custom images are stored in-memory behind a lock and merged with built-in
   images through the same query/filter contract used by real providers.
 - Unsupported operations fail explicitly with `ErrUnsupportedOperation` rather

--- a/pkg/providers/internal/simulated/provider.go
+++ b/pkg/providers/internal/simulated/provider.go
@@ -154,6 +154,28 @@ func (p *Provider) Flavors(_ context.Context) (types.FlavorList, error) {
 	}, nil
 }
 
+func (p *Provider) VolumeClasses(_ context.Context) (types.VolumeClassList, error) {
+	return types.VolumeClassList{
+		{
+			ID:          "33333333-3333-3333-3333-333333333333",
+			Name:        "sim-standard-volume",
+			Description: "Simulated SSD block storage",
+			Media:       types.VolumeClassMediaSSD,
+		},
+		{
+			ID:          "44444444-4444-4444-4444-444444444444",
+			Name:        "sim-fast-volume",
+			Description: "Simulated NVMe block storage",
+			Media:       types.VolumeClassMediaNVMe,
+			Performance: &types.VolumeClassPerformance{
+				MaxIOPS:       ptr(25000),
+				MaxThroughput: ptr(500),
+			},
+			Encrypted: true,
+		},
+	}, nil
+}
+
 func (p *Provider) QueryImages() (types.ImageQuery, error) {
 	return &imageQuery{
 		images: p.listImages,

--- a/pkg/providers/types/README.md
+++ b/pkg/providers/types/README.md
@@ -15,7 +15,8 @@ That makes this package a mixed abstraction layer on purpose:
 - when the thing is provider-derived, query-driven, transient, or otherwise not
   represented as a concrete CRD, this package provides the neutral shape and
   capability contract instead, for example `Flavor`, `Image`,
-  `ExternalNetwork`, `ServerCreateOptions`, and the image query interfaces
+  `VolumeClass`, `ExternalNetwork`, `ServerCreateOptions`, and the image query
+  interfaces
 
 So this package is not "all provider models". It is the intermediate
 portability layer for provider-facing concepts that higher layers still need to
@@ -44,6 +45,10 @@ continue to be passed directly through many provider interface methods.
   implementations choose to provide them.
 - `Image.Index()`, `Image.Equal()`, and `Image.DeepCopy()` are part of that
   cached-snapshot contract, not incidental helpers.
+- `VolumeClass` is Region-scoped provider inventory, not a Volume lifecycle
+  resource. It carries the immutable provider identifier and user-facing
+  metadata that Region configuration can filter or enrich before a public API
+  exposes the inventory.
 - `ServerCreateOptions` carries launch-time derived inputs without forcing them
   into the persisted `Server` CRD shape.
 - Exported errors such as `ErrImageNotReadyForUpload` and

--- a/pkg/providers/types/interfaces.go
+++ b/pkg/providers/types/interfaces.go
@@ -124,6 +124,8 @@ type CommonProvider interface {
 	Region(ctx context.Context) (*unikornv1.Region, error)
 	// Flavors list all available flavors.
 	Flavors(ctx context.Context) (FlavorList, error)
+	// VolumeClasses lists all available block-storage volume classes.
+	VolumeClasses(ctx context.Context) (VolumeClassList, error)
 }
 
 // Providers are expected to provide a provider agnostic manner.

--- a/pkg/providers/types/mock/interfaces.go
+++ b/pkg/providers/types/mock/interfaces.go
@@ -686,6 +686,21 @@ func (mr *MockCommonProviderMockRecorder) Region(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Region", reflect.TypeOf((*MockCommonProvider)(nil).Region), ctx)
 }
 
+// VolumeClasses mocks base method.
+func (m *MockCommonProvider) VolumeClasses(ctx context.Context) (types.VolumeClassList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VolumeClasses", ctx)
+	ret0, _ := ret[0].(types.VolumeClassList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VolumeClasses indicates an expected call of VolumeClasses.
+func (mr *MockCommonProviderMockRecorder) VolumeClasses(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VolumeClasses", reflect.TypeOf((*MockCommonProvider)(nil).VolumeClasses), ctx)
+}
+
 // MockProvider is a mock of Provider interface.
 type MockProvider struct {
 	ctrl     *gomock.Controller
@@ -1052,4 +1067,19 @@ func (m *MockProvider) UpdateServerState(ctx context.Context, identity *v1alpha1
 func (mr *MockProviderMockRecorder) UpdateServerState(ctx, identity, server any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServerState", reflect.TypeOf((*MockProvider)(nil).UpdateServerState), ctx, identity, server)
+}
+
+// VolumeClasses mocks base method.
+func (m *MockProvider) VolumeClasses(ctx context.Context) (types.VolumeClassList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VolumeClasses", ctx)
+	ret0, _ := ret[0].(types.VolumeClassList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VolumeClasses indicates an expected call of VolumeClasses.
+func (mr *MockProviderMockRecorder) VolumeClasses(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VolumeClasses", reflect.TypeOf((*MockProvider)(nil).VolumeClasses), ctx)
 }

--- a/pkg/providers/types/types.go
+++ b/pkg/providers/types/types.go
@@ -88,6 +88,42 @@ type GPU struct {
 // FlavorList allows us to attach sort functions and the like.
 type FlavorList []Flavor
 
+// VolumeClassMedia describes the physical storage medium backing a volume class.
+type VolumeClassMedia string
+
+const (
+	VolumeClassMediaHDD  VolumeClassMedia = "hdd"
+	VolumeClassMediaSSD  VolumeClassMedia = "ssd"
+	VolumeClassMediaNVMe VolumeClassMedia = "nvme"
+)
+
+// VolumeClass represents provider block-storage inventory exposed by a Region.
+type VolumeClass struct {
+	// ID is the immutable provider identifier.
+	ID string
+	// Name is the provider display name.
+	Name string
+	// Description is the provider display description.
+	Description string
+	// Media describes the backing storage medium.
+	Media VolumeClassMedia
+	// Performance describes advertised performance caps.
+	Performance *VolumeClassPerformance
+	// Encrypted indicates whether volumes provisioned from this class are encrypted at rest by the provider.
+	Encrypted bool
+}
+
+// VolumeClassPerformance describes advertised performance caps for a volume class.
+type VolumeClassPerformance struct {
+	// MaxIOPS is the advertised maximum input/output operations per second cap.
+	MaxIOPS *int
+	// MaxThroughput is the advertised maximum throughput cap in mebibytes per second.
+	MaxThroughput *int
+}
+
+// VolumeClassList is a list of provider volume classes.
+type VolumeClassList []VolumeClass
+
 type ImageVirtualization string
 
 const (

--- a/test/contracts/provider/compute/openstack_mock_test.go
+++ b/test/contracts/provider/compute/openstack_mock_test.go
@@ -61,8 +61,9 @@ func writeKeystoneToken(w http.ResponseWriter, base string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 
-	// The provider builds identity, compute, image and network clients on auth,
-	// so all four must resolve from the catalog.
+	// The provider builds service clients on auth, so every bootstrapped service
+	// must resolve from the catalog even if the current contract only exercises
+	// image listing.
 	service := func(id, svcType, url string) map[string]any {
 		return map[string]any{
 			"id":   id,
@@ -88,6 +89,7 @@ func writeKeystoneToken(w http.ResponseWriter, base string) {
 				service("nova", "compute", base+"/compute/v2.1"),
 				service("glance", "image", base+"/image"),
 				service("neutron", "network", base+"/network"),
+				service("cinder", "block-storage", base+"/block-storage/v3"),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- Add provider-neutral `VolumeClass` inventory types and expose them through the common Region provider discovery contract. This covers STO-121.
- Implement OpenStack Cinder volume type discovery with public visibility filtering, Region selector filtering, metadata enrichment from STO-119 configuration, and provider-neutral conversion. This covers STO-122.
- Cache OpenStack block-storage inventory through the refreshable service-client state so repeated `VolumeClasses` calls reuse the Cinder volume-type cache while still refreshing on Region configuration or credential changes.
- Add Kubernetes and simulated provider implementations, regenerated provider mocks, provider docs, focused OpenStack tests, and the provider-contract OpenStack catalog fixture update.

## Scope

This intentionally stays provider-facing only. It does not add Volume CRDs, Volume lifecycle methods, server attach/detach contracts, controllers, handlers, storage-model integration, or public OpenAPI endpoints.

## Validation

- `make touch`
- `make license`
- `make validate`
- `make lint`
- `make generate`
- `git status --porcelain`
- `make test-unit`

Closes STO-121.
Closes STO-122.