### PR TITLE
test(contracts): verify OpenStack image listing with a mock cloud

### DIFF
--- a/test/contracts/provider/common/states.go
+++ b/test/contracts/provider/common/states.go
@@ -135,6 +135,12 @@ func NewStateManager(client client.Client) *StateManager {
 	}
 }
 
+// SetOpenstackEndpoint sets the Keystone endpoint for OpenStack regions created
+// during state setup, letting tests point them at a mock OpenStack server.
+func (sm *StateManager) SetOpenstackEndpoint(endpoint string) {
+	sm.regionManager.openstackEndpoint = endpoint
+}
+
 // getTestNamespace returns the namespace for test resources.
 func getTestNamespace() string {
 	if ns := os.Getenv("TEST_NAMESPACE"); ns != "" {
@@ -200,7 +206,7 @@ func (b *RegionBuilder) withOpenStack(endpoint, secretName string) *RegionBuilde
 }
 
 // withKubernetes configures the region as Kubernetes type.
-func (b *RegionBuilder) withKubernetes(kubeconfigSecret string) *RegionBuilder{
+func (b *RegionBuilder) withKubernetes(kubeconfigSecret string) *RegionBuilder {
 	b.region.Spec.Provider = unikornv1.ProviderKubernetes
 	b.region.Spec.Kubernetes = &unikornv1.RegionKubernetesSpec{
 		KubeconfigSecret: &unikornv1.NamespacedObject{

--- a/test/contracts/provider/common/states_region.go
+++ b/test/contracts/provider/common/states_region.go
@@ -41,6 +41,10 @@ import (
 type RegionStateManager struct {
 	client    client.Client
 	namespace string
+
+	// openstackEndpoint, when set, is the Keystone endpoint of OpenStack regions
+	// created for contract verification (a mock OpenStack server).
+	openstackEndpoint string
 }
 
 // NewRegionStateManager creates a new region state manager.
@@ -162,6 +166,7 @@ func (rm *RegionStateManager) setupRegionWithOrg(ctx context.Context, regionName
 		Spec: unikornv1.RegionSpec{
 			Provider: unikornv1.ProviderOpenstack,
 			Openstack: &unikornv1.RegionOpenstackSpec{
+				Endpoint: rm.openstackEndpoint,
 				ServiceAccountSecret: &unikornv1.NamespacedObject{
 					Namespace: rm.namespace,
 					Name:      "openstack-service-account",
@@ -203,6 +208,7 @@ func (rm *RegionStateManager) setupOpenstackRegion(ctx context.Context, regionNa
 		Spec: unikornv1.RegionSpec{
 			Provider: unikornv1.ProviderOpenstack,
 			Openstack: &unikornv1.RegionOpenstackSpec{
+				Endpoint: rm.openstackEndpoint,
 				ServiceAccountSecret: &unikornv1.NamespacedObject{
 					Namespace: rm.namespace,
 					Name:      "openstack-service-account",

--- a/test/contracts/provider/compute/openstack_mock_test.go
+++ b/test/contracts/provider/compute/openstack_mock_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compute_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+)
+
+// newOpenStackMock emulates the slice of the OpenStack API the region service
+// touches when listing images (Keystone auth, service catalog, Glance version
+// discovery and image list), so the verifier can exercise the real provider
+// path without a live cloud. Its URL (with "/v3") is set via
+// StateManager.SetOpenstackEndpoint.
+func newOpenStackMock() *httptest.Server {
+	// Captured by the handler so responses can reference the server's own URL.
+	var server *httptest.Server
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimSuffix(r.URL.Path, "/")
+
+		switch {
+		case r.URL.Path == "/v3/auth/tokens":
+			writeKeystoneToken(w, server.URL)
+		case strings.HasSuffix(path, "/images"):
+			writeGlanceImages(w)
+		case strings.HasSuffix(path, "/image"): // Glance version discovery.
+			writeVersions(w, "v2.15", server.URL+"/image/v2/")
+		case strings.HasSuffix(path, "/network"): // Neutron version discovery.
+			writeVersions(w, "v2.0", server.URL+"/network/v2.0/")
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	server = httptest.NewServer(handler)
+
+	return server
+}
+
+func writeKeystoneToken(w http.ResponseWriter, base string) {
+	w.Header().Set("X-Subject-Token", "mock-subject-token")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+
+	// The provider builds identity, compute, image and network clients on auth,
+	// so all four must resolve from the catalog.
+	service := func(id, svcType, url string) map[string]any {
+		return map[string]any{
+			"id":   id,
+			"type": svcType,
+			"name": id,
+			"endpoints": []map[string]any{
+				{
+					"id":        id + "-public",
+					"interface": "public",
+					"region":    "RegionOne",
+					"region_id": "RegionOne",
+					"url":       url,
+				},
+			},
+		}
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"token": map[string]any{
+			"expires_at": "2099-01-01T00:00:00.000000Z",
+			"catalog": []map[string]any{
+				service("keystone", "identity", base+"/v3"),
+				service("nova", "compute", base+"/compute/v2.1"),
+				service("glance", "image", base+"/image"),
+				service("neutron", "network", base+"/network"),
+			},
+		},
+	})
+}
+
+func writeVersions(w http.ResponseWriter, id, selfHref string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"versions": []map[string]any{
+			{
+				"id":     id,
+				"status": "CURRENT",
+				"links": []map[string]any{
+					{"rel": "self", "href": selfHref},
+				},
+			},
+		},
+	})
+}
+
+func writeGlanceImages(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"schema": "/v2/schemas/images",
+		"first":  "/image/v2/images",
+		"images": []map[string]any{
+			{
+				"id":               "f7e8d9c0-1234-4567-89ab-cdef01234567",
+				"name":             "Ubuntu 22.04",
+				"status":           "active",
+				"visibility":       "public",
+				"protected":        false,
+				"container_format": "bare",
+				"disk_format":      "qcow2",
+				"min_disk":         20,
+				"min_ram":          2048,
+				"virtual_size":     21474836480,
+				"created_at":       "2026-01-01T00:00:00Z",
+				"updated_at":       "2026-01-01T00:00:00Z",
+				// Properties required by the image validation schema.
+				"unikorn:os:kernel":      "linux",
+				"unikorn:os:family":      "debian",
+				"unikorn:os:distro":      "ubuntu",
+				"unikorn:os:version":     "22.04",
+				"unikorn:virtualization": "any",
+			},
+		},
+	})
+}

--- a/test/contracts/provider/compute/verify_test.go
+++ b/test/contracts/provider/compute/verify_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -77,6 +78,7 @@ var _ = Describe("Region Provider Verification", func() {
 		cancel         context.CancelFunc
 		k8sClient      client.Client
 		stateManager   *commonstate.StateManager
+		openstackMock  *httptest.Server
 		pactBrokerURL  string
 		brokerUsername string
 		brokerPassword string
@@ -115,6 +117,10 @@ var _ = Describe("Region Provider Verification", func() {
 		// Initialize state manager
 		stateManager = commonstate.NewStateManager(k8sClient)
 
+		// Point OpenStack regions at a mock so the image contract can be verified.
+		openstackMock = newOpenStackMock()
+		stateManager.SetOpenstackEndpoint(openstackMock.URL + "/v3")
+
 		// Find an available port
 		listener, err := net.Listen("tcp", "127.0.0.1:0")
 		Expect(err).NotTo(HaveOccurred())
@@ -151,6 +157,9 @@ var _ = Describe("Region Provider Verification", func() {
 			if err := testServer.Shutdown(shutdownCtx); err != nil {
 				fmt.Printf("failed to shutdown server: %v\n", err)
 			}
+		}
+		if openstackMock != nil {
+			openstackMock.Close()
 		}
 		cancel()
 	})
@@ -340,7 +349,7 @@ func buildRouter(schema *helpers.Schema, corsOpts *cors.Options) *chi.Mux {
 	router.Use(cors.Middleware)
 
 	// Mock ACL middleware allows all organizations for contract testing
-	router.Use(MockACLMiddleware(nil))              // Inject mock ACL for contract testing
+	router.Use(MockACLMiddleware(nil))                // Inject mock ACL for contract testing
 	router.Use(commonstate.RegionSortingMiddleware()) // Sort regions for Pact contract testing
 	router.NotFound(http.HandlerFunc(handler.NotFound))
 	router.MethodNotAllowed(http.HandlerFunc(handler.MethodNotAllowed))


### PR DESCRIPTION
## Summary

Adds a mock OpenStack server so the compute provider contract verifier can verify the image-listing interaction from [uni-compute#311](https://github.com/nscaledev/uni-compute/pull/311) against the **real** provider code path, without a live cloud.

## Background

This is the third and final piece unblocking uni-compute#311's `can-i-deploy`:

1. #606 — registered the `region has images` provider-state handler for the compute verifier.
2. #608 — wired the cloud `Providers` registry into the compute verifier's handler (fixed a nil-pointer panic).
3. **This PR** — makes the OpenStack image path actually return an image.

With #608 the handler no longer panics, but the interaction uses `regionType: openstack`, and `ListImages` reaches the OpenStack provider, which authenticates to Keystone and lists images from Glance. With no cloud behind it the request returned **HTTP 500**, and because the interaction is a *pending* pact the verification job still reported success while publishing a **failure** result — which kept `can-i-deploy` red.

## Change

- `test/contracts/provider/compute/openstack_mock_test.go` — a mock OpenStack server emulating the slice the region service touches: Keystone v3 password auth + service catalog (identity/compute/image/network), Glance/Neutron version discovery, and a Glance v2 image list returning one ready, public image with the `unikorn:*` properties the image schema requires.
- `StateManager.SetOpenstackEndpoint(...)` + an `openstackEndpoint` field on the region state manager, so OpenStack regions created during state setup point their Keystone endpoint at the mock.
- The compute verifier starts the mock in `BeforeEach` and tears it down in `AfterEach`.

The verifier now exercises the genuine path — auth → catalog lookup → Glance version discovery → image list → schema validation → API response — and the interaction verifies with a 200 and a ready image.

## Validation

- `make license`, `make lint` (0 issues).
- Verified locally against a kind cluster:
  `make test-contracts-provider-local PACT_FILE=<images pact>` → `has status code 200 (OK)`, `has a matching body (OK)`.

## Follow-up

After merge: re-run uni-region provider verification (publishes a passing result for the pending pact), then re-run uni-compute#311's `CanIDeploy` — it should finally go green.