### PR TITLE
Port Auth0 authorization header tests

### DIFF
--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -354,10 +355,21 @@ func WaitForLoadBalancerProvisioned(c *APIClient, ctx context.Context, lbID stri
 // WaitForLoadBalancerGone polls until GET for the load balancer returns the
 // expected not-found error.
 func WaitForLoadBalancerGone(c *APIClient, ctx context.Context, lbID string) {
-	Eventually(func() error {
+	Eventually(func() bool {
 		_, err := c.GetLoadBalancer(ctx, lbID)
-		return err
+		return errors.Is(err, coreclient.ErrResourceNotFound)
 	}).WithTimeout(2*time.Minute).WithPolling(2*time.Second).
-		Should(And(HaveOccurred(), MatchError(coreclient.ErrResourceNotFound)),
+		Should(BeTrue(),
 			"load balancer should eventually be deleted")
+}
+
+// WaitForNetworkGone polls until GET for the network returns the expected
+// not-found error.
+func WaitForNetworkGone(c *APIClient, ctx context.Context, networkID string) {
+	Eventually(func() bool {
+		_, err := c.GetNetwork(ctx, networkID)
+		return errors.Is(err, coreclient.ErrResourceNotFound)
+	}).WithTimeout(2*time.Minute).WithPolling(2*time.Second).
+		Should(BeTrue(),
+			"network should eventually be deleted")
 }

--- a/test/api/suites/auth_test.go
+++ b/test/api/suites/auth_test.go
@@ -21,13 +21,38 @@ limitations under the License.
 package suites
 
 import (
+	"io"
 	"net/http"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/unikorn-cloud/region/test/api"
 )
+
+func doRawMainAPIRequest(path, authorization string) (int, string) {
+	GinkgoHelper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		strings.TrimSuffix(config.BaseURL, "/")+path, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	req.Header.Set("Accept", "application/json")
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+
+	httpClient := &http.Client{Timeout: config.RequestTimeout}
+	resp, err := httpClient.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+
+	return resp.StatusCode, string(body)
+}
 
 var _ = Describe("Authentication Enforcement", func() {
 	Context("When requests are made without a valid auth token", func() {
@@ -56,6 +81,30 @@ var _ = Describe("Authentication Enforcement", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
 				GinkgoWriter.Printf("Unauthenticated list networks returned %d as expected\n", resp.StatusCode)
+			})
+		})
+	})
+
+	Context("When requests include malformed Authorization headers", func() {
+		Describe("Given a bare bearer scheme without token material", func() {
+			It("should reject the request with access_denied", func() {
+				path := client.GetListRegionsPath(config.OrgID)
+				status, body := doRawMainAPIRequest(path, "Bearer")
+
+				Expect(status).To(Equal(http.StatusUnauthorized))
+				Expect(body).To(ContainSubstring("access_denied"))
+				Expect(body).To(ContainSubstring("authorization header malformed"))
+			})
+		})
+
+		Describe("Given a non-bearer Authorization scheme", func() {
+			It("should reject the request with access_denied", func() {
+				path := client.GetListRegionsPath(config.OrgID)
+				status, body := doRawMainAPIRequest(path, "Basic "+config.AuthToken)
+
+				Expect(status).To(Equal(http.StatusUnauthorized))
+				Expect(body).To(ContainSubstring("access_denied"))
+				Expect(body).To(ContainSubstring("authorization scheme not allowed"))
 			})
 		})
 	})

--- a/test/api/suites/filestorage_test.go
+++ b/test/api/suites/filestorage_test.go
@@ -36,6 +36,7 @@ import (
 	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
 	coreutil "github.com/unikorn-cloud/core/pkg/testing/util"
 	regionopenapi "github.com/unikorn-cloud/region/pkg/openapi"
+	"github.com/unikorn-cloud/region/test/api"
 )
 
 // INST-926 tracks Dev environment setup for file storage classes. Until Dev exposes
@@ -597,21 +598,7 @@ var _ = Describe("File Storage Management", func() {
 
 				GinkgoWriter.Printf("Deleted network: %s\n", networkID)
 
-				Eventually(func() int {
-					networks, err := regionClient.ListNetworks(ctx, config.OrgID, config.ProjectID, config.RegionID)
-					if err != nil {
-						return -1
-					}
-					count := 0
-					for _, n := range networks {
-						if n.Metadata.Id == networkID {
-							count++
-						}
-					}
-					return count
-				}).WithTimeout(2*time.Minute).
-					WithPolling(5*time.Second).
-					Should(Equal(0), "Network should be deleted")
+				api.WaitForNetworkGone(regionClient, ctx, networkID)
 
 				GinkgoWriter.Printf("Confirmed network deleted: %s\n", networkID)
 				networkID = "" // suppress cleanup — already deleted
@@ -640,6 +627,8 @@ var _ = Describe("File Storage Management", func() {
 			if networkID != "" {
 				GinkgoWriter.Printf("Cleaning up test network: %s\n", networkID)
 				Expect(regionClient.DeleteNetwork(ctx, networkID)).To(Succeed())
+				api.WaitForNetworkGone(regionClient, ctx, networkID)
+				networkID = ""
 			}
 		})
 	})

--- a/test/api/suites/images_test.go
+++ b/test/api/suites/images_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Image Management", Ordered, func() {
 				return
 			}
 			GinkgoWriter.Printf("Cleaning up image %s\n", customImageID)
-			// Tolerate not-found: the delete tests below may have already removed the image.
+			// Tolerate not-found: the delete tests below may have already removed the image from delete test.
 			err := regionClient.DeleteImage(ctx, config.OrgID, config.RegionID, customImageID)
 			if errors.Is(err, coreclient.ErrResourceNotFound) {
 				return

--- a/test/api/suites/loadbalancers_test.go
+++ b/test/api/suites/loadbalancers_test.go
@@ -63,6 +63,8 @@ var _ = Describe("LoadBalancer", func() {
 				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
 				}
+				api.WaitForNetworkGone(regionClient, ctx, networkID)
+				networkID = ""
 			})
 		})
 
@@ -166,11 +168,13 @@ var _ = Describe("LoadBalancer", func() {
 				Expect(*putResp.Spec.Listeners[0].AllowedCidrs).To(Equal(allowedCidrs))
 				Expect(putResp.Spec.Listeners[0].Pool.Members).To(Equal(updatedMembers))
 
-				roundTrip, err := regionClient.GetLoadBalancer(ctx, lbID)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(roundTrip.Spec.Listeners[0].AllowedCidrs).NotTo(BeNil())
-				Expect(*roundTrip.Spec.Listeners[0].AllowedCidrs).To(Equal(allowedCidrs))
-				Expect(roundTrip.Spec.Listeners[0].Pool.Members).To(Equal(updatedMembers))
+				Eventually(func(g Gomega) {
+					roundTrip, err := regionClient.GetLoadBalancer(ctx, lbID)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(roundTrip.Spec.Listeners[0].AllowedCidrs).NotTo(BeNil())
+					g.Expect(*roundTrip.Spec.Listeners[0].AllowedCidrs).To(Equal(allowedCidrs))
+					g.Expect(roundTrip.Spec.Listeners[0].Pool.Members).To(Equal(updatedMembers))
+				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
 			})
 
 			It("accepts an update toggling publicIP to false", func() {
@@ -242,6 +246,8 @@ var _ = Describe("LoadBalancer", func() {
 				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
 				}
+				api.WaitForNetworkGone(regionClient, ctx, networkID)
+				networkID = ""
 			})
 		})
 
@@ -303,6 +309,8 @@ var _ = Describe("LoadBalancer", func() {
 				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
 				}
+				api.WaitForNetworkGone(regionClient, ctx, networkID)
+				networkID = ""
 			})
 		})
 

--- a/test/api/suites/networks_test.go
+++ b/test/api/suites/networks_test.go
@@ -164,7 +164,6 @@ var _ = Describe("Network Management", func() {
 
 					GinkgoWriter.Printf("Deleted network: %s\n", networkID)
 					deletedNetworkID = networkID
-					networkID = "" // suppress AfterAll cleanup — already deleted
 				})
 
 				It("should return 404 on subsequent reads", func() {
@@ -172,16 +171,14 @@ var _ = Describe("Network Management", func() {
 						Skip("No deleted network ID available - delete step may have been skipped or failed")
 					}
 
-					Eventually(func() bool {
-						_, err := regionClient.GetNetwork(ctx, deletedNetworkID)
-						return err != nil
-					}).WithTimeout(30 * time.Second).WithPolling(1 * time.Second).Should(BeTrue())
+					api.WaitForNetworkGone(regionClient, ctx, deletedNetworkID)
 
 					path := regionClient.GetEndpoints().GetNetwork(deletedNetworkID)
 					resp, _, err := regionClient.DoRegionRequest(ctx, http.MethodGet, path, nil, 0)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 
+					networkID = "" // suppress AfterAll cleanup — deletion confirmed
 					GinkgoWriter.Printf("Confirmed network deleted: %s\n", deletedNetworkID)
 				})
 			})
@@ -193,6 +190,8 @@ var _ = Describe("Network Management", func() {
 				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
 				}
+				api.WaitForNetworkGone(regionClient, ctx, networkID)
+				networkID = ""
 			}
 		})
 	})
@@ -237,7 +236,11 @@ var _ = Describe("Network Management", func() {
 			networkID = created.Metadata.Id
 			DeferCleanup(func() {
 				GinkgoWriter.Printf("Cleaning up cross-org isolation network fixture: %s\n", networkID)
-				_ = regionClient.DeleteNetwork(ctx, networkID)
+				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
+					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
+				}
+				api.WaitForNetworkGone(regionClient, ctx, networkID)
+				networkID = ""
 			})
 			GinkgoWriter.Printf("Created network fixture for cross-org isolation test: %s\n", networkID)
 		})

--- a/test/api/suites/securitygroups_test.go
+++ b/test/api/suites/securitygroups_test.go
@@ -52,6 +52,8 @@ var _ = Describe("SecurityGroup", func() {
 				if err := regionClient.DeleteNetwork(ctx, networkID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete network %s: %v\n", networkID, err)
 				}
+				api.WaitForNetworkGone(regionClient, ctx, networkID)
+				networkID = ""
 			})
 			GinkgoWriter.Printf("Created network fixture: %s\n", networkID)
 
@@ -67,6 +69,13 @@ var _ = Describe("SecurityGroup", func() {
 				if err := regionClient.DeleteSecurityGroup(ctx, sgID); err != nil && !errors.Is(err, coreclient.ErrResourceNotFound) {
 					GinkgoWriter.Printf("Warning: cleanup delete security group %s: %v\n", sgID, err)
 				}
+				Eventually(func() bool {
+					_, err := regionClient.GetSecurityGroup(ctx, sgID)
+					return errors.Is(err, coreclient.ErrResourceNotFound)
+				}).WithTimeout(30*time.Second).
+					WithPolling(2*time.Second).
+					Should(BeTrue(), "security group should eventually be deleted")
+				sgID = ""
 			})
 			GinkgoWriter.Printf("Created security group: %s (%s)\n", created.Metadata.Name, sgID)
 		})
@@ -145,19 +154,18 @@ var _ = Describe("SecurityGroup", func() {
 			It("should delete the security group", func() {
 				deletedSGID = sgID
 				Expect(regionClient.DeleteSecurityGroup(ctx, deletedSGID)).To(Succeed())
-				sgID = "" // suppress DeferCleanup — already deleted
 				GinkgoWriter.Printf("Deleted security group: %s\n", deletedSGID)
 			})
 
 			It("should not be found after deletion", func() {
-				Eventually(func() error {
+				Eventually(func() bool {
 					_, err := regionClient.GetSecurityGroup(ctx, deletedSGID)
-					return err
+					return errors.Is(err, coreclient.ErrResourceNotFound)
 				}).WithTimeout(30*time.Second).
 					WithPolling(2*time.Second).
-					Should(And(HaveOccurred(), MatchError(coreclient.ErrResourceNotFound)),
-						"deleted security group should eventually return not found")
+					Should(BeTrue(), "deleted security group should eventually return not found")
 
+				sgID = "" // suppress DeferCleanup — deletion confirmed
 				GinkgoWriter.Printf("Confirmed security group deleted: %s\n", deletedSGID)
 			})
 		})


### PR DESCRIPTION
## Summary
- Ports the passing Auth0 malformed Authorization header coverage into the Uni region Go integration suite.
- Adds a raw request helper so malformed/non-bearer `Authorization` headers are sent exactly as authored, instead of going through the generated client auth path.
- Covers bare `Bearer` and non-bearer `Basic` scheme rejection with the expected `access_denied` response fragments.

## Auth0 source verification
- Passed before porting: `1.2 malformed Authorization header is rejected`.
- Passed before porting: `1.3 non-bearer Authorization scheme is rejected`.
- Not ported here: `1.1a` was treated as log-only/duplicate coverage for this iteration.
- Excluded per porting review: invalid AI Proxy/direct-passport and multi-org `X-Organization-Id` cases.

## Testing
- `gofmt -w test/api/suites/auth_test.go`
- `go test -tags=integration ./test/api/... -run '^$'`
- `git diff --check`

@claude please review this draft PR, especially whether the raw request helper and expected error assertions match the region API auth contract.