### PR TITLE
Port Auth0 authorization header tests

### DIFF
--- a/test/api/suites/auth_test.go
+++ b/test/api/suites/auth_test.go
@@ -21,13 +21,38 @@ limitations under the License.
 package suites
 
 import (
+	"io"
 	"net/http"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/unikorn-cloud/region/test/api"
 )
+
+func doRawMainAPIRequest(path, authorization string) (int, string) {
+	GinkgoHelper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		strings.TrimSuffix(config.BaseURL, "/")+path, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	req.Header.Set("Accept", "application/json")
+	if authorization != "" {
+		req.Header.Set("Authorization", authorization)
+	}
+
+	httpClient := &http.Client{Timeout: config.RequestTimeout}
+	resp, err := httpClient.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+
+	return resp.StatusCode, string(body)
+}
 
 var _ = Describe("Authentication Enforcement", func() {
 	Context("When requests are made without a valid auth token", func() {
@@ -56,6 +81,30 @@ var _ = Describe("Authentication Enforcement", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
 				GinkgoWriter.Printf("Unauthenticated list networks returned %d as expected\n", resp.StatusCode)
+			})
+		})
+	})
+
+	Context("When requests include malformed Authorization headers", func() {
+		Describe("Given a bare bearer scheme without token material", func() {
+			It("should reject the request with access_denied", func() {
+				path := client.GetListRegionsPath(config.OrgID)
+				status, body := doRawMainAPIRequest(path, "Bearer")
+
+				Expect(status).To(Equal(http.StatusUnauthorized))
+				Expect(body).To(ContainSubstring("access_denied"))
+				Expect(body).To(ContainSubstring("authorization header malformed"))
+			})
+		})
+
+		Describe("Given a non-bearer Authorization scheme", func() {
+			It("should reject the request with access_denied", func() {
+				path := client.GetListRegionsPath(config.OrgID)
+				status, body := doRawMainAPIRequest(path, "Basic "+config.AuthToken)
+
+				Expect(status).To(Equal(http.StatusUnauthorized))
+				Expect(body).To(ContainSubstring("access_denied"))
+				Expect(body).To(ContainSubstring("authorization scheme not allowed"))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary
- Ports the passing Auth0 malformed Authorization header coverage into the Uni region Go integration suite.
- Adds a raw request helper so malformed/non-bearer `Authorization` headers are sent exactly as authored, instead of going through the generated client auth path.
- Covers bare `Bearer` and non-bearer `Basic` scheme rejection with the expected `access_denied` response fragments.

## Auth0 source verification
- Passed before porting: `1.2 malformed Authorization header is rejected`.
- Passed before porting: `1.3 non-bearer Authorization scheme is rejected`.
- Not ported here: `1.1a` was treated as log-only/duplicate coverage for this iteration.
- Excluded per porting review: invalid AI Proxy/direct-passport and multi-org `X-Organization-Id` cases.

## Testing
- `gofmt -w test/api/suites/auth_test.go`
- `go test -tags=integration ./test/api/... -run '^$'`
- `git diff --check`

@claude please review this draft PR, especially whether the raw request helper and expected error assertions match the region API auth contract.