### PR TITLE
Retry create only on terminal Nova errors

### DIFF
--- a/pkg/monitor/health/server/README.md
+++ b/pkg/monitor/health/server/README.md
@@ -17,6 +17,12 @@ status/telemetry model.
 
 - resolves provider and flavor context per region and caches it for a poll cycle
 - updates server status through provider `UpdateServerState(...)`
+- relies on the provider's monitor-owned `Healthy` condition projection to
+  distinguish in-flight provider work from confirmed provider failure. For
+  OpenStack, pre-launch Nova `ERROR` is first held as `Healthy/Degraded` and
+  only escalates to `Healthy/Errored` after the same provider server remains in
+  settled error for the debounce window; that escalation is what can wake the
+  server controller's bounded provider-create retry.
 - refines the server's live `Phase` from observed Nova + Ironic state. For OpenStack baremetal servers in Nova `BUILD`, an Ironic node lookup distinguishes `Queued` (provider has accepted the create but hardware is not yet engaged — pre-deploy Ironic states) from `Building` (Ironic actively deploying, including transient deploy failures). VMs in Nova `BUILD` go straight to `Building`. Provisioning status itself stays purely condition-derived (provisioner-owned, one-shot): the monitor never writes it. Phase is the live readiness signal once provisioning status reaches `provisioned`.
 - latches `status.provisionedAt` from Nova `launched_at`, alongside `launchedAt`
   and ahead of the `BUILD` early-return, so it fires for VMs and baremetal alike

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -181,6 +181,13 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   provisioning health so the controller does not delete an instance Nova may
   still complete. Settled Nova errors include the Nova fault message in the
   condition when one is available.
+- Pre-launch settled Nova `ERROR` observations are debounced through the
+  existing `Healthy` condition. The first observation is written as
+  `Healthy/Degraded`; only a later observation of the same Nova server after the
+  debounce window escalates to `Healthy/Errored` and arms provider-create retry.
+  If the Nova server ID changes or Nova leaves the settled error state, the
+  condition changes and the debounce naturally restarts without an extra status
+  field.
 - Some OpenStack list APIs are not safe to treat as exact lookup, notably
   server, network, and Octavia load-balancer `name` filters:
   - `name` filters behave like prefix or regular-expression matches rather than

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -175,6 +175,12 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   the monitor logs the failure and falls back to the VM default `Building`
   Phase so API responses still see a coherent live signal rather than failing
   the monitor path.
+- Nova `ERROR` only becomes `Healthy/Errored` after Nova reports no active
+  `OS-EXT-STS:task_state`. An `ERROR` observation with a non-empty task state is
+  still in flight from Region's perspective and remains non-terminal
+  provisioning health so the controller does not delete an instance Nova may
+  still complete. Settled Nova errors include the Nova fault message in the
+  condition when one is available.
 - Some OpenStack list APIs are not safe to treat as exact lookup, notably
   server, network, and Octavia load-balancer `name` filters:
   - `name` filters behave like prefix or regular-expression matches rather than

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -97,6 +97,8 @@ const (
 
 	// These ones are well defined openstack image properties.
 	imageArchitectureProperty = "architecture"
+
+	novaServerErrorDebounce = time.Minute
 )
 
 var tagKeyRegex = regexp.MustCompile(
@@ -2135,31 +2137,84 @@ func (p *Provider) DeleteSecurityGroup(ctx context.Context, identity *unikornv1.
 	return nil
 }
 
+func novaServerErrorMessage(server *servers.Server) string {
+	if server.Fault.Message != "" {
+		return "server is in an error state: " + server.Fault.Message
+	}
+
+	return "server is in an error state"
+}
+
+func novaServerStableID(server *servers.Server) string {
+	switch {
+	case server.ID != "":
+		return server.ID
+	case server.Name != "":
+		return server.Name
+	default:
+		return "unknown"
+	}
+}
+
+func pendingNovaServerErrorMessage(server *servers.Server) string {
+	return fmt.Sprintf("provider server %s is in settled ERROR; waiting to confirm before retry", novaServerStableID(server))
+}
+
+func serverHasLaunched(server *unikornv1.Server, openstackServer *servers.Server) bool {
+	if openstackServer != nil && !openstackServer.LaunchedAt.IsZero() {
+		return true
+	}
+
+	return server != nil && (server.Status.LaunchedAt != nil || server.Status.ProvisionedAt != nil)
+}
+
+func confirmedPendingNovaServerError(server *unikornv1.Server, message string, now time.Time) bool {
+	if server == nil {
+		return false
+	}
+
+	condition, err := server.StatusConditionRead(unikornv1core.ConditionHealthy)
+	if err != nil {
+		return false
+	}
+
+	if condition.Status != corev1.ConditionFalse ||
+		condition.Reason != unikornv1core.ConditionReasonDegraded ||
+		condition.Message != message {
+		return false
+	}
+
+	return !condition.LastTransitionTime.Time.Add(novaServerErrorDebounce).After(now)
+}
+
 // convertServerHealthStatus translates from an OpenStack server status into a Kubernetes one.
 // See the following for all possible states (currently).
 // https://docs.openstack.org/api-guide/compute/server_concepts.html
-func convertServerHealthStatus(server *servers.Server) (corev1.ConditionStatus, unikornv1core.ConditionReason, string) {
-	if server == nil {
+func convertServerHealthStatus(server *unikornv1.Server, openstackServer *servers.Server, now time.Time) (corev1.ConditionStatus, unikornv1core.ConditionReason, string) {
+	if openstackServer == nil {
 		return corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "unable to determine server status"
 	}
 
-	switch server.Status {
+	switch openstackServer.Status {
 	case "ACTIVE":
 		return corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "server is healthy"
 	case "ERROR":
-		if server.TaskState != "" {
-			return corev1.ConditionUnknown, unikornv1core.ConditionReasonProvisioning, fmt.Sprintf("server reports ERROR while task_state=%s; waiting for task to settle", server.TaskState)
+		if openstackServer.TaskState != "" {
+			return corev1.ConditionUnknown, unikornv1core.ConditionReasonProvisioning, fmt.Sprintf("server reports ERROR while task_state=%s; waiting for task to settle", openstackServer.TaskState)
 		}
 
-		if server.Fault.Message != "" {
-			return corev1.ConditionFalse, unikornv1core.ConditionReasonErrored, "server is in an error state: " + server.Fault.Message
+		if !serverHasLaunched(server, openstackServer) {
+			message := pendingNovaServerErrorMessage(openstackServer)
+			if !confirmedPendingNovaServerError(server, message, now) {
+				return corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, message
+			}
 		}
 
-		return corev1.ConditionFalse, unikornv1core.ConditionReasonErrored, "server is in an error state"
+		return corev1.ConditionFalse, unikornv1core.ConditionReasonErrored, novaServerErrorMessage(openstackServer)
 	case "UNKNOWN":
 		return corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "unable to determine server status"
 	default:
-		return corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "server is in state " + server.Status
+		return corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "server is in state " + openstackServer.Status
 	}
 }
 
@@ -2205,7 +2260,7 @@ func logNovaServerState(ctx context.Context, operation string, server *servers.S
 
 // SetServerHealthStatus attaches the healt status condition to a server.
 func setServerHealthStatus(server *unikornv1.Server, openstackserver *servers.Server) {
-	status, reason, message := convertServerHealthStatus(openstackserver)
+	status, reason, message := convertServerHealthStatus(server, openstackserver, time.Now())
 
 	server.StatusConditionWrite(unikornv1core.ConditionHealthy, status, reason, message)
 }

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -2147,6 +2147,14 @@ func convertServerHealthStatus(server *servers.Server) (corev1.ConditionStatus, 
 	case "ACTIVE":
 		return corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "server is healthy"
 	case "ERROR":
+		if server.TaskState != "" {
+			return corev1.ConditionUnknown, unikornv1core.ConditionReasonProvisioning, fmt.Sprintf("server reports ERROR while task_state=%s; waiting for task to settle", server.TaskState)
+		}
+
+		if server.Fault.Message != "" {
+			return corev1.ConditionFalse, unikornv1core.ConditionReasonErrored, "server is in an error state: " + server.Fault.Message
+		}
+
 		return corev1.ConditionFalse, unikornv1core.ConditionReasonErrored, "server is in an error state"
 	case "UNKNOWN":
 		return corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "unable to determine server status"

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -2155,6 +2155,46 @@ func convertServerHealthStatus(server *servers.Server) (corev1.ConditionStatus, 
 	}
 }
 
+func novaServerLogValues(server *servers.Server) []any {
+	if server == nil {
+		return []any{
+			"novaServerID", "",
+			"novaServerName", "",
+			"novaServerStatus", "",
+			"novaServerVMState", "",
+			"novaServerTaskState", "",
+			"novaServerPowerState", "",
+			"novaServerLaunchedAt", time.Time{},
+			"novaServerFaultCode", 0,
+			"novaServerFaultMessage", "",
+		}
+	}
+
+	return []any{
+		"novaServerID", server.ID,
+		"novaServerName", server.Name,
+		"novaServerStatus", server.Status,
+		"novaServerVMState", server.VmState,
+		"novaServerTaskState", server.TaskState,
+		"novaServerPowerState", server.PowerState.String(),
+		"novaServerLaunchedAt", server.LaunchedAt,
+		"novaServerFaultCode", server.Fault.Code,
+		"novaServerFaultMessage", server.Fault.Message,
+	}
+}
+
+func logNovaServerState(ctx context.Context, operation string, server *servers.Server) {
+	values := []any{"operation", operation}
+	values = append(values, novaServerLogValues(server)...)
+
+	logger := log.FromContext(ctx)
+	if server == nil || server.Status != "ERROR" {
+		logger = logger.V(1)
+	}
+
+	logger.Info("observed nova server state", values...)
+}
+
 // SetServerHealthStatus attaches the healt status condition to a server.
 func setServerHealthStatus(server *unikornv1.Server, openstackserver *servers.Server) {
 	status, reason, message := convertServerHealthStatus(openstackserver)
@@ -2519,6 +2559,7 @@ func (p *Provider) reconcileServer(ctx context.Context, client ServerInterface, 
 	openstackServer, err := client.GetServer(ctx, server)
 	if err == nil {
 		log.V(1).Info("server already exists")
+		logNovaServerState(ctx, "lookup", openstackServer)
 
 		return openstackServer, nil
 	}
@@ -2575,6 +2616,7 @@ func (p *Provider) reconcileServer(ctx context.Context, client ServerInterface, 
 		return nil, err
 	}
 
+	logNovaServerState(ctx, "create", openstackServer)
 	setServerHealthStatus(server, openstackServer)
 	// No Ironic lookup at create time — the live monitor's UpdateServerState
 	// refines Phase from observed Ironic state on each poll.
@@ -2838,6 +2880,7 @@ func (p *Provider) updateServerStateWithClients(
 		return err
 	}
 
+	logNovaServerState(ctx, "update", openstackServer)
 	setServerHealthStatus(server, openstackServer)
 	setServerMACAddress(ctx, server, openstackServer)
 

--- a/pkg/providers/internal/openstack/provisioning_status_test.go
+++ b/pkg/providers/internal/openstack/provisioning_status_test.go
@@ -20,18 +20,24 @@ package openstack
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/remoteconsoles"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servergroups"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
 	"github.com/stretchr/testify/require"
 
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
 	idstest "github.com/unikorn-cloud/region/pkg/ids/idstest"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,6 +53,87 @@ const (
 )
 
 var errIronicUnavailable = errors.New("ironic unavailable")
+
+type captureSink struct {
+	entries   *[]map[string]any
+	presetKVs []any
+}
+
+func newCaptureSink() *captureSink {
+	entries := make([]map[string]any, 0)
+
+	return &captureSink{entries: &entries}
+}
+
+var _ logr.LogSink = (*captureSink)(nil)
+
+func (s *captureSink) Init(logr.RuntimeInfo)        {}
+func (s *captureSink) Enabled(int) bool             { return true }
+func (s *captureSink) Error(error, string, ...any)  {}
+func (s *captureSink) WithName(string) logr.LogSink { return s }
+
+func (s *captureSink) WithValues(kvs ...any) logr.LogSink {
+	c := *s
+	c.presetKVs = append(append([]any{}, s.presetKVs...), kvs...)
+
+	return &c
+}
+
+func (s *captureSink) Info(_ int, msg string, keysAndValues ...any) {
+	entry := map[string]any{"_msg": msg}
+
+	for i := 0; i+1 < len(s.presetKVs); i += 2 {
+		entry[fmt.Sprint(s.presetKVs[i])] = s.presetKVs[i+1]
+	}
+
+	for i := 0; i+1 < len(keysAndValues); i += 2 {
+		entry[fmt.Sprint(keysAndValues[i])] = keysAndValues[i+1]
+	}
+
+	*s.entries = append(*s.entries, entry)
+}
+
+func (s *captureSink) entriesWithMsg(msg string) []map[string]any {
+	var out []map[string]any
+
+	for _, e := range *s.entries {
+		if e["_msg"] == msg {
+			out = append(out, e)
+		}
+	}
+
+	return out
+}
+
+func novaErrorServerFixture(launchedAt time.Time) *servers.Server {
+	return &servers.Server{
+		ID:         "nova-id",
+		Name:       "nova-name",
+		Status:     "ERROR",
+		VmState:    "error",
+		TaskState:  "spawning",
+		PowerState: servers.NOSTATE,
+		LaunchedAt: launchedAt,
+		Fault:      servers.Fault{Code: 500, Message: "No valid host found"},
+	}
+}
+
+func requireNovaStateLog(t *testing.T, sink *captureSink, operation string, openstackServer *servers.Server) {
+	t.Helper()
+
+	entries := sink.entriesWithMsg("observed nova server state")
+	require.Len(t, entries, 1)
+	require.Equal(t, operation, entries[0]["operation"])
+	require.Equal(t, openstackServer.ID, entries[0]["novaServerID"])
+	require.Equal(t, openstackServer.Name, entries[0]["novaServerName"])
+	require.Equal(t, openstackServer.Status, entries[0]["novaServerStatus"])
+	require.Equal(t, openstackServer.VmState, entries[0]["novaServerVMState"])
+	require.Equal(t, openstackServer.TaskState, entries[0]["novaServerTaskState"])
+	require.Equal(t, openstackServer.PowerState.String(), entries[0]["novaServerPowerState"])
+	require.Equal(t, openstackServer.LaunchedAt, entries[0]["novaServerLaunchedAt"])
+	require.Equal(t, openstackServer.Fault.Code, entries[0]["novaServerFaultCode"])
+	require.Equal(t, openstackServer.Fault.Message, entries[0]["novaServerFaultMessage"])
+}
 
 func TestBaremetalBuildPhase(t *testing.T) {
 	t.Parallel()
@@ -272,6 +359,8 @@ func TestUpdateServerStateWithClientsRecordsMACAddress(t *testing.T) {
 
 type stubComputeClient struct {
 	server          *servers.Server
+	getServerErr    error
+	createdServer   *servers.Server
 	requestedServer *unikornv1.Server
 }
 
@@ -285,11 +374,14 @@ func (c *stubComputeClient) DeleteServerGroup(context.Context, string) error { r
 func (c *stubComputeClient) UpdateQuotas(context.Context, string) error      { return nil }
 func (c *stubComputeClient) GetServer(_ context.Context, server *unikornv1.Server) (*servers.Server, error) {
 	c.requestedServer = server
+	if c.getServerErr != nil {
+		return nil, c.getServerErr
+	}
 
 	return c.server, nil
 }
 func (c *stubComputeClient) CreateServer(context.Context, *unikornv1.Server, string, []servers.Network, *string, map[string]string) (*servers.Server, error) {
-	return nil, nil //nolint:nilnil // unused stub method
+	return c.createdServer, nil
 }
 func (c *stubComputeClient) DeleteServer(context.Context, string) error       { return nil }
 func (c *stubComputeClient) RebootServer(context.Context, string, bool) error { return nil }
@@ -303,6 +395,71 @@ func (c *stubComputeClient) ShowConsoleOutput(context.Context, string, *int) (st
 }
 func (c *stubComputeClient) CreateImageFromServer(context.Context, string, *servers.CreateImageOpts) (string, error) {
 	return "", nil
+}
+
+func TestReconcileServerLogsCreatedNovaServerState(t *testing.T) {
+	t.Parallel()
+
+	launchedAt := time.Date(2026, time.July, 22, 10, 11, 12, 0, time.UTC)
+	openstackServer := novaErrorServerFixture(launchedAt)
+	compute := &stubComputeClient{
+		getServerErr:  coreerrors.ErrResourceNotFound,
+		createdServer: openstackServer,
+	}
+	server := &unikornv1.Server{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "server-id",
+			Labels: map[string]string{
+				coreconstants.OrganizationLabel: "org-id",
+				coreconstants.ProjectLabel:      "project-id",
+				constants.RegionLabel:           "region-id",
+			},
+		},
+	}
+	port := &ports.Port{ID: "port-id", NetworkID: "network-id"}
+	sink := newCaptureSink()
+	ctx := logr.NewContext(t.Context(), logr.New(sink))
+
+	provider := &Provider{}
+
+	_, err := provider.reconcileServer(ctx, compute, server, port, "", nil)
+	require.NoError(t, err)
+
+	requireNovaStateLog(t, sink, "create", openstackServer)
+}
+
+func TestUpdateServerStateWithClientsLogsNovaServerState(t *testing.T) {
+	t.Parallel()
+
+	launchedAt := time.Date(2026, time.July, 22, 10, 11, 12, 0, time.UTC)
+	openstackServer := novaErrorServerFixture(launchedAt)
+	compute := &stubComputeClient{server: openstackServer}
+	identity := &unikornv1.Identity{}
+	server := &unikornv1.Server{Spec: unikornv1.ServerSpec{FlavorID: idstest.MustParseFlavorID(flavorVMID)}}
+	sink := newCaptureSink()
+	ctx := logr.NewContext(t.Context(), logr.New(sink))
+
+	provider := &Provider{openstack: &openStackClients{
+		_region: &unikornv1.Region{
+			Spec: unikornv1.RegionSpec{
+				Openstack: &unikornv1.RegionOpenstackSpec{
+					Compute: &unikornv1.RegionOpenstackComputeSpec{
+						Flavors: &unikornv1.OpenstackFlavorsSpec{
+							Metadata: []unikornv1.FlavorMetadata{{ID: flavorVMID, Baremetal: false}},
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	err := provider.updateServerStateWithClients(ctx, identity, server, compute,
+		func(context.Context, *unikornv1.Identity) (BaremetalInterface, error) {
+			return nil, errIronicUnavailable
+		})
+	require.NoError(t, err)
+
+	requireNovaStateLog(t, sink, "update", openstackServer)
 }
 
 type recordingBaremetalClient struct {

--- a/pkg/providers/internal/openstack/provisioning_status_test.go
+++ b/pkg/providers/internal/openstack/provisioning_status_test.go
@@ -140,20 +140,91 @@ func requireNovaStateLog(t *testing.T, sink *captureSink, operation string, open
 func TestConvertServerHealthStatusTreatsActiveTaskAsProvisioning(t *testing.T) {
 	t.Parallel()
 
-	status, reason, message := convertServerHealthStatus(&servers.Server{Status: "ERROR", TaskState: "spawning"})
+	now := time.Date(2026, time.July, 22, 10, 11, 12, 0, time.UTC)
+
+	status, reason, message := convertServerHealthStatus(&unikornv1.Server{}, &servers.Server{Status: "ERROR", TaskState: "spawning"}, now)
 
 	require.Equal(t, corev1.ConditionUnknown, status)
 	require.Equal(t, unikornv1core.ConditionReasonProvisioning, reason)
 	require.Contains(t, message, "task_state=spawning")
 }
 
-func TestConvertServerHealthStatusSettledErrorIncludesFault(t *testing.T) {
+func TestConvertServerHealthStatusSettledErrorWaitsForDebounce(t *testing.T) {
 	t.Parallel()
 
-	status, reason, message := convertServerHealthStatus(&servers.Server{
+	now := time.Date(2026, time.July, 22, 10, 11, 12, 0, time.UTC)
+	openstackServer := &servers.Server{
+		ID:     "nova-id",
 		Status: "ERROR",
 		Fault:  servers.Fault{Message: "No valid host found"},
-	})
+	}
+
+	status, reason, message := convertServerHealthStatus(&unikornv1.Server{}, openstackServer, now)
+
+	require.Equal(t, corev1.ConditionFalse, status)
+	require.Equal(t, unikornv1core.ConditionReasonDegraded, reason)
+	require.Equal(t, pendingNovaServerErrorMessage(openstackServer), message)
+}
+
+func TestConvertServerHealthStatusSettledErrorEscalatesAfterDebounce(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 22, 10, 11, 12, 0, time.UTC)
+	openstackServer := &servers.Server{
+		ID:     "nova-id",
+		Status: "ERROR",
+		Fault:  servers.Fault{Message: "No valid host found"},
+	}
+	server := &unikornv1.Server{}
+	server.Status.Conditions = []unikornv1core.Condition{{
+		Type:               unikornv1core.ConditionHealthy,
+		Status:             corev1.ConditionFalse,
+		Reason:             unikornv1core.ConditionReasonDegraded,
+		Message:            pendingNovaServerErrorMessage(openstackServer),
+		LastTransitionTime: metav1.NewTime(now.Add(-novaServerErrorDebounce - time.Second)),
+	}}
+
+	status, reason, message := convertServerHealthStatus(server, openstackServer, now)
+
+	require.Equal(t, corev1.ConditionFalse, status)
+	require.Equal(t, unikornv1core.ConditionReasonErrored, reason)
+	require.Contains(t, message, "No valid host found")
+}
+
+func TestConvertServerHealthStatusSettledErrorResetsForDifferentProviderServer(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 22, 10, 11, 12, 0, time.UTC)
+	oldOpenstackServer := &servers.Server{ID: "old-nova-id", Status: "ERROR"}
+	newOpenstackServer := &servers.Server{ID: "new-nova-id", Status: "ERROR"}
+	server := &unikornv1.Server{}
+	server.Status.Conditions = []unikornv1core.Condition{{
+		Type:               unikornv1core.ConditionHealthy,
+		Status:             corev1.ConditionFalse,
+		Reason:             unikornv1core.ConditionReasonDegraded,
+		Message:            pendingNovaServerErrorMessage(oldOpenstackServer),
+		LastTransitionTime: metav1.NewTime(now.Add(-novaServerErrorDebounce - time.Second)),
+	}}
+
+	status, reason, message := convertServerHealthStatus(server, newOpenstackServer, now)
+
+	require.Equal(t, corev1.ConditionFalse, status)
+	require.Equal(t, unikornv1core.ConditionReasonDegraded, reason)
+	require.Equal(t, pendingNovaServerErrorMessage(newOpenstackServer), message)
+}
+
+func TestConvertServerHealthStatusLaunchedErrorBypassesDebounce(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 22, 10, 11, 12, 0, time.UTC)
+	openstackServer := &servers.Server{
+		ID:         "nova-id",
+		Status:     "ERROR",
+		LaunchedAt: now.Add(-time.Minute),
+		Fault:      servers.Fault{Message: "No valid host found"},
+	}
+
+	status, reason, message := convertServerHealthStatus(&unikornv1.Server{}, openstackServer, now)
 
 	require.Equal(t, corev1.ConditionFalse, status)
 	require.Equal(t, unikornv1core.ConditionReasonErrored, reason)

--- a/pkg/providers/internal/openstack/provisioning_status_test.go
+++ b/pkg/providers/internal/openstack/provisioning_status_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
 	"github.com/stretchr/testify/require"
 
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
 	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
 	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
@@ -40,6 +41,7 @@ import (
 	"github.com/unikorn-cloud/region/pkg/constants"
 	idstest "github.com/unikorn-cloud/region/pkg/ids/idstest"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -133,6 +135,29 @@ func requireNovaStateLog(t *testing.T, sink *captureSink, operation string, open
 	require.Equal(t, openstackServer.LaunchedAt, entries[0]["novaServerLaunchedAt"])
 	require.Equal(t, openstackServer.Fault.Code, entries[0]["novaServerFaultCode"])
 	require.Equal(t, openstackServer.Fault.Message, entries[0]["novaServerFaultMessage"])
+}
+
+func TestConvertServerHealthStatusTreatsActiveTaskAsProvisioning(t *testing.T) {
+	t.Parallel()
+
+	status, reason, message := convertServerHealthStatus(&servers.Server{Status: "ERROR", TaskState: "spawning"})
+
+	require.Equal(t, corev1.ConditionUnknown, status)
+	require.Equal(t, unikornv1core.ConditionReasonProvisioning, reason)
+	require.Contains(t, message, "task_state=spawning")
+}
+
+func TestConvertServerHealthStatusSettledErrorIncludesFault(t *testing.T) {
+	t.Parallel()
+
+	status, reason, message := convertServerHealthStatus(&servers.Server{
+		Status: "ERROR",
+		Fault:  servers.Fault{Message: "No valid host found"},
+	})
+
+	require.Equal(t, corev1.ConditionFalse, status)
+	require.Equal(t, unikornv1core.ConditionReasonErrored, reason)
+	require.Contains(t, message, "No valid host found")
 }
 
 func TestBaremetalBuildPhase(t *testing.T) {

--- a/pkg/provisioners/managers/server/README.md
+++ b/pkg/provisioners/managers/server/README.md
@@ -45,10 +45,10 @@ This is the clearest controller-side expression of the lifecycle DAG model:
   predicate, shared with the controller watch predicate
   (`pkg/managers/server`) so the trigger and the action cannot drift. It fails
   closed: a rebuild destroys data, so any signal that the server has ever booted
-  blocks it. The provider must first project a settled provider create failure
-  as `Healthy/Errored`; in-flight provider work remains non-terminal and does
-  not arm the rebuild path. In steady state the load-bearing guard is
-  `launchedAt` (mirrored
+  blocks it. The provider must first project a confirmed, settled provider
+  create failure as `Healthy/Errored`; in-flight provider work and first-seen
+  settled failures remain non-terminal and do not arm the rebuild path. In
+  steady state the load-bearing guard is `launchedAt` (mirrored
   from Nova `launched_at`, which Nova sets at first boot and never clears).
   `Server.status.provisionedAt` is a durable, write-once copy of that same Nova
   signal that the retry reset never clears; it closes the one window `launchedAt`

--- a/pkg/provisioners/managers/server/README.md
+++ b/pkg/provisioners/managers/server/README.md
@@ -45,7 +45,10 @@ This is the clearest controller-side expression of the lifecycle DAG model:
   predicate, shared with the controller watch predicate
   (`pkg/managers/server`) so the trigger and the action cannot drift. It fails
   closed: a rebuild destroys data, so any signal that the server has ever booted
-  blocks it. In steady state the load-bearing guard is `launchedAt` (mirrored
+  blocks it. The provider must first project a settled provider create failure
+  as `Healthy/Errored`; in-flight provider work remains non-terminal and does
+  not arm the rebuild path. In steady state the load-bearing guard is
+  `launchedAt` (mirrored
   from Nova `launched_at`, which Nova sets at first boot and never clears).
   `Server.status.provisionedAt` is a durable, write-once copy of that same Nova
   signal that the retry reset never clears; it closes the one window `launchedAt`

--- a/pkg/provisioners/managers/server/provisioner_retry_test.go
+++ b/pkg/provisioners/managers/server/provisioner_retry_test.go
@@ -102,6 +102,10 @@ func withProviderCreateInFlightError(server *regionv1.Server) {
 	server.StatusConditionWrite(unikornv1core.ConditionHealthy, corev1.ConditionUnknown, unikornv1core.ConditionReasonProvisioning, "server reports ERROR while task_state=spawning; waiting for task to settle")
 }
 
+func withProviderCreatePendingError(server *regionv1.Server) {
+	server.StatusConditionWrite(unikornv1core.ConditionHealthy, corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "provider server nova-id is in settled ERROR; waiting to confirm before retry")
+}
+
 func withProviderCreateRetrying(server *regionv1.Server) {
 	server.Status.ProviderCreateFailures = 1
 	server.Status.ProviderCreateRetrying = true
@@ -192,6 +196,14 @@ func TestProviderCreateFailureInFlightErrorDoesNotRetry(t *testing.T) {
 	t.Parallel()
 
 	server := retryServer(withProviderCreateInFlightError)
+
+	require.False(t, serverprovisioner.ProviderCreateFailure(server))
+}
+
+func TestProviderCreateFailurePendingErrorDoesNotRetry(t *testing.T) {
+	t.Parallel()
+
+	server := retryServer(withProviderCreatePendingError)
 
 	require.False(t, serverprovisioner.ProviderCreateFailure(server))
 }

--- a/pkg/provisioners/managers/server/provisioner_retry_test.go
+++ b/pkg/provisioners/managers/server/provisioner_retry_test.go
@@ -98,6 +98,10 @@ func withProviderCreateFailure(server *regionv1.Server) {
 	server.StatusConditionWrite(unikornv1core.ConditionHealthy, corev1.ConditionFalse, unikornv1core.ConditionReasonErrored, "server is in an error state")
 }
 
+func withProviderCreateInFlightError(server *regionv1.Server) {
+	server.StatusConditionWrite(unikornv1core.ConditionHealthy, corev1.ConditionUnknown, unikornv1core.ConditionReasonProvisioning, "server reports ERROR while task_state=spawning; waiting for task to settle")
+}
+
 func withProviderCreateRetrying(server *regionv1.Server) {
 	server.Status.ProviderCreateFailures = 1
 	server.Status.ProviderCreateRetrying = true
@@ -182,6 +186,14 @@ func TestProvision_ProviderCreateFailureDeletesAndYields(t *testing.T) {
 
 	requireEvent(t, recorder, corev1.EventTypeNormal, "ProviderCreateRetrying", "attempt 1/3")
 	requireEvent(t, recorder, corev1.EventTypeNormal, "ProviderCreateRetryReady", "attempt 1/3")
+}
+
+func TestProviderCreateFailureInFlightErrorDoesNotRetry(t *testing.T) {
+	t.Parallel()
+
+	server := retryServer(withProviderCreateInFlightError)
+
+	require.False(t, serverprovisioner.ProviderCreateFailure(server))
 }
 
 func TestProvision_ProviderCreateRetryKeepsDeleting(t *testing.T) {


### PR DESCRIPTION
The substance of this is the middle commit:

> Nova can expose an ERROR status while a task_state is still present
> (i.e., things are still happening which might move it out of an error
> state). At present, the create retry will delete and retry as soon as
> it sees the error state.
> 
> Instead, treat ERROR with an active task as in-flight provider work,
> instead of a settled create failure; so the server controller does not
> delete a build that Nova may yet complete. Settled Nova ERROR
> responses still surface as Errored, now with the Nova fault message
> when available.

The other commits blunt some of the sharp edges around retries, by
 - logging error reports from Nova; and,
 - giving the error state a grace period before retrying. 

Addresses INST-1148.