### PR TITLE
Make OpenStack volume class selection fail closed

### DIFF
--- a/charts/region/crds/region.unikorn-cloud.org_regions.yaml
+++ b/charts/region/crds/region.unikorn-cloud.org_regions.yaml
@@ -197,8 +197,9 @@ spec:
                       volumeClasses:
                         description: |-
                           VolumeClasses defines which provider volume classes are eligible for Region
-                          inventory export and what user-facing metadata is attached to them. If not
-                          defined, then all provider volume classes are eligible.
+                          inventory export and what user-facing metadata is attached to them. Provider
+                          volume classes are excluded unless their IDs are explicitly selected. If this
+                          configuration is not defined, no provider volume classes are eligible.
                         properties:
                           metadata:
                             description: |-
@@ -253,13 +254,14 @@ spec:
                             x-kubernetes-list-type: map
                           selector:
                             description: |-
-                              Selector allows provider volume classes to be manually selected for inclusion.
-                              The selected set is a boolean intersection of all defined filters in the selector.
+                              Selector explicitly selects provider volume classes for inclusion. If the
+                              selector is not defined, or its IDs are nil or empty, no provider volume
+                              classes are selected.
                             properties:
                               ids:
                                 description: |-
-                                  IDs is an explicit list of allowed provider volume class IDs. If not
-                                  specified, then all provider volume classes are considered.
+                                  IDs is an explicit allowlist of provider volume class IDs. If nil or empty,
+                                  no provider volume classes are selected.
                                 items:
                                   type: string
                                 type: array

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -44,7 +44,11 @@ stored objects rely on for linkage, migration, and operational coordination.
   inventory should be enriched; it does not create a project-owned
   `VolumeClass` CRD or any user-managed lifecycle resource. OpenStack maps this
   inventory to Cinder volume types internally, but the Region storage and
-  public/domain vocabulary remains `VolumeClass`.
+  public/domain vocabulary remains `VolumeClass`. Selection is fail-closed:
+  only provider IDs explicitly listed in
+  `openstack.blockStorage.volumeClasses.selector.ids` are eligible. Missing
+  `volumeClasses` configuration, a missing selector, or nil/empty IDs exports
+  no VolumeClasses.
 - Namespaced Kubernetes storage scope and platform tenancy scope are separate
   concerns. These objects are namespaced, but their logical visibility and
   authorization are often organization-, project-, identity-, or region-scoped

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -296,14 +296,16 @@ type RegionOpenstackNetworkSpec struct {
 
 type RegionOpenstackBlockStorageSpec struct {
 	// VolumeClasses defines which provider volume classes are eligible for Region
-	// inventory export and what user-facing metadata is attached to them. If not
-	// defined, then all provider volume classes are eligible.
+	// inventory export and what user-facing metadata is attached to them. Provider
+	// volume classes are excluded unless their IDs are explicitly selected. If this
+	// configuration is not defined, no provider volume classes are eligible.
 	VolumeClasses *OpenstackVolumeClassesSpec `json:"volumeClasses,omitempty"`
 }
 
 type OpenstackVolumeClassesSpec struct {
-	// Selector allows provider volume classes to be manually selected for inclusion.
-	// The selected set is a boolean intersection of all defined filters in the selector.
+	// Selector explicitly selects provider volume classes for inclusion. If the
+	// selector is not defined, or its IDs are nil or empty, no provider volume
+	// classes are selected.
 	Selector *VolumeClassSelector `json:"selector,omitempty"`
 	// Metadata allows provider volume classes to be explicitly augmented with
 	// user-facing metadata. OpenStack stores these internally as Cinder volume types,
@@ -316,8 +318,8 @@ type OpenstackVolumeClassesSpec struct {
 }
 
 type VolumeClassSelector struct {
-	// IDs is an explicit list of allowed provider volume class IDs. If not
-	// specified, then all provider volume classes are considered.
+	// IDs is an explicit allowlist of provider volume class IDs. If nil or empty,
+	// no provider volume classes are selected.
 	IDs []string `json:"ids,omitempty"`
 }
 

--- a/pkg/providers/internal/openstack/ADMIN.md
+++ b/pkg/providers/internal/openstack/ADMIN.md
@@ -158,6 +158,13 @@ provide the user-facing metadata because encryption and QoS/performance limits
 are often configured natively on the storage backend and may not be reliably
 derivable from Cinder volume type metadata.
 
+VolumeClass selection is fail-closed. Only Cinder volume type IDs explicitly
+listed in `spec.openstack.blockStorage.volumeClasses.selector.ids` are exported.
+Missing `volumeClasses` configuration, a missing selector, or nil/empty IDs
+exports no VolumeClasses. Before rolling out a release with these semantics, add
+the curated production volume type IDs to every affected production `Region`
+resource or its VolumeClass inventory will become empty.
+
 The resulting `Region` shape is equivalent to:
 
 ```yaml

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -266,18 +266,21 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   can distinguish `Queued` (waiting on hardware) from `Building` (provider
   actively deploying).
 - VolumeClass configuration follows the same inventory pattern for block
-  storage: Region configuration under
-  `openstack.blockStorage.volumeClasses` selects which provider volume classes
-  are eligible for export and enriches them with user-facing metadata such as
-  media, maximum performance caps, and encryption signals. The provider
-  discovers Cinder volume types and converts the selected/enriched result into
-  provider-neutral `VolumeClass` values. Maximum performance metadata records
-  caps rather than guaranteed reservations. `VolumeClass` is
+  storage. Region configuration under
+  `openstack.blockStorage.volumeClasses.selector.ids` is a strict allowlist:
+  only Cinder volume type IDs explicitly listed there are eligible for export.
+  Missing `volumeClasses` configuration, a missing selector, or nil/empty IDs
+  exports no VolumeClasses. Selected classes can be enriched with user-facing
+  metadata such as media, maximum performance caps, and encryption signals. The
+  provider discovers Cinder volume types and converts the selected/enriched
+  result into provider-neutral `VolumeClass` values. Maximum performance
+  metadata records caps rather than guaranteed reservations. `VolumeClass` is
   Region-scoped inventory configuration, not a project-owned resource or
   lifecycle object. The block-storage service client is cached with the other
   OpenStack service clients so Cinder volume-type inventory cache survives
   repeated provider calls and is refreshed only when Region configuration or
-  credentials change.
+  credentials change. Production Region CRs must contain their curated IDs
+  before this fail-closed behavior is rolled out.
 - Image handling is a first-class contract surface here:
   - OpenStack image properties are validated against a schema
   - public images can additionally be signature-verified

--- a/pkg/providers/internal/openstack/blockstorage.go
+++ b/pkg/providers/internal/openstack/blockstorage.go
@@ -117,8 +117,8 @@ func (c *BlockStorageClient) GetVolumeTypes(ctx context.Context) ([]volumetypes.
 		}
 
 		config := openstackVolumeClassesConfig(c.options)
-		if config == nil || config.Selector == nil || len(config.Selector.IDs) == 0 {
-			return false
+		if config == nil || config.Selector == nil {
+			return true
 		}
 
 		return !slices.Contains(config.Selector.IDs, volumeType.ID)

--- a/pkg/providers/internal/openstack/blockstorage_test.go
+++ b/pkg/providers/internal/openstack/blockstorage_test.go
@@ -111,22 +111,76 @@ func TestGetVolumeTypesAppliesSelectorVisibilityAndCache(t *testing.T) {
 	require.Equal(t, 1, requests)
 }
 
-func TestProviderVolumeClassesReusesBlockStorageClientCacheWithDefaultSelector(t *testing.T) {
+func TestProviderVolumeClassesAppliesFailClosedSelectorAndReusesBlockStorageClientCache(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name         string
 		blockStorage *unikornv1.RegionOpenstackBlockStorageSpec
+		expected     types.VolumeClassList
 	}{
+		{
+			name:         "WithoutBlockStorageConfig",
+			blockStorage: nil,
+			expected:     types.VolumeClassList{},
+		},
 		{
 			name:         "WithoutVolumeClassesConfig",
 			blockStorage: &unikornv1.RegionOpenstackBlockStorageSpec{},
+			expected:     types.VolumeClassList{},
 		},
 		{
-			name: "WithEmptySelector",
+			name: "WithoutSelector",
+			blockStorage: &unikornv1.RegionOpenstackBlockStorageSpec{
+				VolumeClasses: &unikornv1.OpenstackVolumeClassesSpec{},
+			},
+			expected: types.VolumeClassList{},
+		},
+		{
+			name: "WithNilSelectorIDs",
 			blockStorage: &unikornv1.RegionOpenstackBlockStorageSpec{
 				VolumeClasses: &unikornv1.OpenstackVolumeClassesSpec{
 					Selector: &unikornv1.VolumeClassSelector{},
+				},
+			},
+			expected: types.VolumeClassList{},
+		},
+		{
+			name: "WithEmptySelectorIDs",
+			blockStorage: &unikornv1.RegionOpenstackBlockStorageSpec{
+				VolumeClasses: &unikornv1.OpenstackVolumeClassesSpec{
+					Selector: &unikornv1.VolumeClassSelector{
+						IDs: []string{},
+					},
+				},
+			},
+			expected: types.VolumeClassList{},
+		},
+		{
+			name: "WithUnmatchedSelectorIDs",
+			blockStorage: &unikornv1.RegionOpenstackBlockStorageSpec{
+				VolumeClasses: &unikornv1.OpenstackVolumeClassesSpec{
+					Selector: &unikornv1.VolumeClassSelector{
+						IDs: []string{"unmatched"},
+					},
+				},
+			},
+			expected: types.VolumeClassList{},
+		},
+		{
+			name: "WithExplicitSelectorIDs",
+			blockStorage: &unikornv1.RegionOpenstackBlockStorageSpec{
+				VolumeClasses: &unikornv1.OpenstackVolumeClassesSpec{
+					Selector: &unikornv1.VolumeClassSelector{
+						IDs: []string{"fast"},
+					},
+				},
+			},
+			expected: types.VolumeClassList{
+				{
+					ID:          "fast",
+					Name:        "fast-nvme",
+					Description: "Latency sensitive",
 				},
 			},
 		},
@@ -177,18 +231,7 @@ func TestProviderVolumeClassesReusesBlockStorageClientCacheWithDefaultSelector(t
 			second, err := provider.VolumeClasses(t.Context())
 			require.NoError(t, err)
 
-			require.Equal(t, types.VolumeClassList{
-				{
-					ID:          "slow",
-					Name:        "slow-hdd",
-					Description: "Bulk capacity",
-				},
-				{
-					ID:          "fast",
-					Name:        "fast-nvme",
-					Description: "Latency sensitive",
-				},
-			}, first)
+			require.Equal(t, test.expected, first)
 			require.Equal(t, first, second)
 			require.Equal(t, int64(1), ks.volumeTypeRequests.Load())
 		})

--- a/pkg/providers/types/interfaces.go
+++ b/pkg/providers/types/interfaces.go
@@ -124,7 +124,7 @@ type CommonProvider interface {
 	Region(ctx context.Context) (*unikornv1.Region, error)
 	// Flavors list all available flavors.
 	Flavors(ctx context.Context) (FlavorList, error)
-	// VolumeClasses lists all available block-storage volume classes.
+	// VolumeClasses lists the block-storage volume classes exposed by the Region.
 	VolumeClasses(ctx context.Context) (VolumeClassList, error)
 }
 


### PR DESCRIPTION
## Summary

- Return only public Cinder volume types whose provider IDs are explicitly listed in `spec.openstack.blockStorage.volumeClasses.selector.ids`.
- Return an empty VolumeClass inventory when the VolumeClass configuration, selector, or selector IDs are missing or empty.
- Document the fail-closed behavior and rollout prerequisite, and regenerate the Region CRD descriptions.

## Why

OpenStack VolumeClass discovery previously failed open when selector configuration was absent or empty. That could expose newly discovered provider volume types without an operator explicitly curating them.

This change makes the Region selector a strict allowlist so inventory exposure always requires operator intent.

## Impact

Curated provider IDs must be added to affected production Region CRs before rollout, otherwise their VolumeClass inventory will become empty.

There are no OpenAPI, Helm template, structural schema, Volume lifecycle, Volume CRUD, or server attachment changes.

## Validation

- `make touch`
- `make license`
- `make validate`
- `make lint`
- `make generate`
- `make test-unit`
- Focused OpenStack VolumeClass regression tests
- Standards and STO-150 scope reviews: no findings

Linear: [STO-150](https://linear.app/nscale-workspace/issue/STO-150/uni-region-make-openstack-volumeclass-selector-fail-closed)