### PR TITLE
Implement VolumeClass API handler

### DIFF
--- a/pkg/handler/README.md
+++ b/pkg/handler/README.md
@@ -42,9 +42,9 @@ So this package should be understood primarily in `v2` terms:
 
 Most handler clients follow the same broad pattern:
 
-1. resolve logical scope and visibility — including region ACL enforcement via
-   `region.CheckAccess` for any operation that accepts a user-supplied region ID
-   (path parameter, query parameter, or request body field)
+1. resolve logical scope and visibility — direct Region references use
+   `region.CheckAccess`, while list selectors constrain an already
+   visibility-filtered working set and omit missing or inaccessible Regions
 2. load current state where mutation is involved
 3. convert API request shape into required stored or provider-facing shape
 4. merge system-owned metadata and derived context
@@ -239,6 +239,10 @@ but we do not have transactions.”
   SSH CA records with explicit reference-blocked deletion
 - [`storage`](./storage/README.md): quota-heavy stateful resource with saga-backed
   create/update and attachment validation
+- `VolumeClass`: read-only Region-scoped provider inventory. The v2 list handler
+  filters Regions through the canonical visibility policy, treats repeated
+  `regionID` values as selectors, and maps only provider-neutral discovery
+  fields. Missing and inaccessible Regions are omitted.
 
 ## Caveats
 
@@ -255,11 +259,11 @@ but we do not have transactions.”
 - Cross-object invariants are only best-effort. Owner references, finalizers,
   allocation records, and saga compensation improve consistency, but they do not
   turn the system into an ACID store.
-- `GET /api/v2/volumeclasses` is currently a contract-only route. The narrow
-  `handler_v2_volumeclass_contract.go` method returns the canonical internal
-  server error so the generated router remains buildable; it does not perform
-  provider discovery, conversion, or authorization and should be replaced by
-  the dedicated implementation work.
+- `GET /api/v2/volumeclasses` is a live provider-backed inventory route rather
+  than a lifecycle resource surface. Missing and inaccessible Region selectors
+  are omitted, allowing empty or partial results. A provider failure from any
+  visible selected Region fails the whole request; the handler does not return
+  partial provider inventory after an attempted discovery fails.
 
 ## TODO
 

--- a/pkg/handler/conversion/README.md
+++ b/pkg/handler/conversion/README.md
@@ -18,12 +18,20 @@ API in a consistent form.
 
 Today the package is deliberately narrow.
 
-It currently provides shared conversion for provider-neutral flavor data:
+It currently provides shared conversion for provider-neutral flavor and
+VolumeClass data:
 
 - `types.Architecture` -> `openapi.Architecture`
 - `types.GPUVendor` -> `openapi.GpuVendor`
 - `types.Flavor` -> `openapi.Flavor`
 - `[]types.Flavor` -> `openapi.Flavors`
+- `types.VolumeClass` -> `openapi.VolumeClassV2Read`
+- `types.VolumeClassList` -> `openapi.VolumeClassListV2Read`
+
+VolumeClass uses the same core `staticResourceMetadata` shape as Flavor.
+The conversion maps provider-authored identity and display fields and, like
+Flavor, leaves the required creation timestamp at its zero value because the
+provider-neutral inventory has no creation-time source.
 
 That is why the package may look under-populated at first glance: the
 abstraction line is broader than the current amount of code, but the shape is
@@ -46,8 +54,8 @@ coherent.
 ## Caveats
 
 - The package name is broader than the current implementation. Right now this is
-  mostly a shared flavor-conversion package plus a small amount of supporting
-  enum translation.
+  the shared conversion boundary for flavor and VolumeClass inventory plus a
+  small amount of supporting enum translation.
 - That broad name is still defensible because the intended boundary is
   meaningful: shared non-CRD type conversion belongs here, while resource-local
   conversion belongs elsewhere.

--- a/pkg/handler/conversion/volumeclass.go
+++ b/pkg/handler/conversion/volumeclass.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversion
+
+import (
+	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	regionids "github.com/unikorn-cloud/region/pkg/ids"
+	"github.com/unikorn-cloud/region/pkg/openapi"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
+
+	"k8s.io/utils/ptr"
+)
+
+func ConvertVolumeClasses(regionID regionids.RegionID, in types.VolumeClassList) openapi.VolumeClassListV2Read {
+	out := make(openapi.VolumeClassListV2Read, len(in))
+
+	for i := range in {
+		out[i] = *convertVolumeClass(regionID, &in[i])
+	}
+
+	return out
+}
+
+func convertVolumeClass(regionID regionids.RegionID, in *types.VolumeClass) *openapi.VolumeClassV2Read {
+	out := &openapi.VolumeClassV2Read{
+		Metadata: coreapi.StaticResourceMetadata{
+			Id:   in.ID,
+			Name: in.Name,
+		},
+		Spec: openapi.VolumeClassV2Spec{
+			RegionId:  regionID,
+			Encrypted: in.Encrypted,
+		},
+	}
+
+	if in.Description != "" {
+		out.Metadata.Description = ptr.To(in.Description)
+	}
+
+	if in.Media != "" {
+		out.Spec.Media = ptr.To(openapi.VolumeClassV2Media(in.Media))
+	}
+
+	if in.Performance != nil {
+		out.Spec.Performance = &openapi.VolumeClassV2Performance{
+			MaxIOPS:            in.Performance.MaxIOPS,
+			MaxThroughputMiBps: in.Performance.MaxThroughput,
+		}
+	}
+
+	return out
+}

--- a/pkg/handler/handler_v2_volumeclass.go
+++ b/pkg/handler/handler_v2_volumeclass.go
@@ -18,17 +18,22 @@ limitations under the License.
 package handler
 
 import (
-	"errors"
 	"net/http"
 
-	servererrors "github.com/unikorn-cloud/core/pkg/server/errors"
+	"github.com/unikorn-cloud/core/pkg/server/errors"
+	"github.com/unikorn-cloud/core/pkg/server/util"
+	"github.com/unikorn-cloud/region/pkg/handler/region"
 	"github.com/unikorn-cloud/region/pkg/openapi"
 )
 
-var errVolumeClassListNotImplemented = errors.New("volume class list handler is not implemented")
+// GetApiV2Volumeclasses returns provider-neutral inventory from Regions visible
+// to the caller.
+func (h *Handler) GetApiV2Volumeclasses(w http.ResponseWriter, r *http.Request, params openapi.GetApiV2VolumeclassesParams) {
+	result, err := region.NewClient(h.ClientArgs).ListVolumeClasses(r.Context(), params)
+	if err != nil {
+		errors.HandleError(w, r, err)
+		return
+	}
 
-// GetApiV2Volumeclasses keeps the generated server interface buildable while
-// provider-backed VolumeClass discovery remains a separate implementation task.
-func (*Handler) GetApiV2Volumeclasses(w http.ResponseWriter, r *http.Request, _ openapi.GetApiV2VolumeclassesParams) {
-	servererrors.HandleError(w, r, errVolumeClassListNotImplemented)
+	util.WriteJSONResponse(w, r, http.StatusOK, result)
 }

--- a/pkg/handler/handler_v2_volumeclass_test.go
+++ b/pkg/handler/handler_v2_volumeclass_test.go
@@ -1,0 +1,490 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:testpackage
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/handler/common"
+	"github.com/unikorn-cloud/region/pkg/openapi"
+	mockproviders "github.com/unikorn-cloud/region/pkg/providers/mock"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
+	mockprovider "github.com/unikorn-cloud/region/pkg/providers/types/mock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// errVolumeClassProvider is returned by provider mocks to exercise error handling.
+var errVolumeClassProvider = errors.New("volume class provider failed")
+
+const (
+	volumeClassTestNamespace       = "volume-class-test"
+	volumeClassReadEndpoint        = "region:volumeclasses:v2"
+	volumeClassTestOrganizationID  = "10101010-1010-4010-a010-101010101010"
+	volumeClassOtherOrganizationID = "20202020-2020-4020-a020-202020202020"
+)
+
+func volumeClassReadContext(ctx context.Context) context.Context {
+	return newOrganisationACLBuilder(volumeClassTestOrganizationID).
+		addEndpoint(volumeClassReadEndpoint, identityapi.Read).
+		buildContext(ctx)
+}
+
+type volumeClassV2TestFixture struct {
+	t         *testing.T
+	ctrl      *gomock.Controller
+	providers *mockproviders.MockProviders
+	handler   *Handler
+}
+
+func newVolumeClassV2TestFixture(t *testing.T, regions ...*regionv1.Region) *volumeClassV2TestFixture {
+	t.Helper()
+
+	objects := make([]client.Object, len(regions))
+	for i := range regions {
+		objects[i] = regions[i]
+	}
+
+	ctrl := gomock.NewController(t)
+	providers := mockproviders.NewMockProviders(ctrl)
+
+	return &volumeClassV2TestFixture{
+		t:         t,
+		ctrl:      ctrl,
+		providers: providers,
+		handler: &Handler{
+			ClientArgs: common.ClientArgs{
+				Client:    fakeClientWithSchema(t, objects...),
+				Namespace: volumeClassTestNamespace,
+				Providers: providers,
+			},
+		},
+	}
+}
+
+func newVolumeClassTestSecurity(organizationIDs ...string) *regionv1.RegionSecuritySpec {
+	organizations := make([]regionv1.RegionSecurityOrganizationSpec, len(organizationIDs))
+	for i := range organizationIDs {
+		organizations[i].ID = organizationIDs[i]
+	}
+
+	return &regionv1.RegionSecuritySpec{
+		Organizations: organizations,
+	}
+}
+
+func newVolumeClassTestRegion(regionID string, security *regionv1.RegionSecuritySpec) *regionv1.Region {
+	return &regionv1.Region{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      regionID,
+			Namespace: volumeClassTestNamespace,
+		},
+		Spec: regionv1.RegionSpec{
+			Security: security,
+		},
+	}
+}
+
+func (f *volumeClassV2TestFixture) expectVolumeClasses(regionID string, result types.VolumeClassList, err error) {
+	f.t.Helper()
+
+	provider := mockprovider.NewMockCommonProvider(f.ctrl)
+	provider.EXPECT().VolumeClasses(gomock.Any()).Return(result, err)
+	f.providers.EXPECT().LookupCommon(regionID).Return(provider, nil)
+}
+
+func (f *volumeClassV2TestFixture) expectProviderLookupError(regionID string, err error) {
+	f.t.Helper()
+
+	f.providers.EXPECT().LookupCommon(regionID).Return(nil, err)
+}
+
+func (f *volumeClassV2TestFixture) get(ctx context.Context, params openapi.GetApiV2VolumeclassesParams) *httptest.ResponseRecorder {
+	f.t.Helper()
+
+	request := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v2/volumeclasses", nil)
+	response := httptest.NewRecorder()
+
+	f.handler.GetApiV2Volumeclasses(response, request, params)
+
+	return response
+}
+
+func requireVolumeClassListResponse(t *testing.T, response *httptest.ResponseRecorder) openapi.VolumeClassListV2Response {
+	t.Helper()
+
+	require.Equal(t, http.StatusOK, response.Code)
+
+	var result openapi.VolumeClassListV2Response
+
+	requireDeserialiseBody(t, response.Body, &result)
+	require.NotNil(t, result)
+
+	return result
+}
+
+func requireVolumeClassErrorResponse(t *testing.T, response *httptest.ResponseRecorder) coreapi.Error {
+	t.Helper()
+
+	require.Equal(t, http.StatusInternalServerError, response.Code)
+
+	var result coreapi.Error
+
+	requireDeserialiseBody(t, response.Body, &result)
+
+	return result
+}
+
+func TestVolumeClassV2ReturnsEmptyListWithoutRegions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		context func(context.Context) context.Context
+	}{
+		{
+			name:    "with endpoint permission",
+			context: volumeClassReadContext,
+		},
+		{
+			name: "without endpoint permission",
+			context: newOrganisationACLBuilder(volumeClassTestOrganizationID).
+				buildContext,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newVolumeClassV2TestFixture(t)
+			response := fixture.get(test.context(t.Context()), openapi.GetApiV2VolumeclassesParams{})
+			result := requireVolumeClassListResponse(t, response)
+
+			require.Empty(t, result)
+		})
+	}
+}
+
+func TestVolumeClassV2ReturnsServerErrorForProviderFailures(t *testing.T) {
+	t.Parallel()
+
+	const regionID = "88888888-8888-4888-a888-888888888888"
+
+	tests := []struct {
+		name  string
+		setup func(*volumeClassV2TestFixture)
+	}{
+		{
+			name: "provider lookup fails",
+			setup: func(fixture *volumeClassV2TestFixture) {
+				fixture.expectProviderLookupError(regionID, errVolumeClassProvider)
+			},
+		},
+		{
+			name: "provider inventory fails",
+			setup: func(fixture *volumeClassV2TestFixture) {
+				fixture.expectVolumeClasses(regionID, nil, errVolumeClassProvider)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newVolumeClassV2TestFixture(t, newVolumeClassTestRegion(regionID, nil))
+			test.setup(fixture)
+
+			response := fixture.get(volumeClassReadContext(t.Context()), openapi.GetApiV2VolumeclassesParams{})
+			result := requireVolumeClassErrorResponse(t, response)
+
+			require.Equal(t, coreapi.ServerError, result.Error)
+		})
+	}
+}
+
+func TestVolumeClassV2MapsProviderInventory(t *testing.T) {
+	t.Parallel()
+
+	const (
+		regionID      = "11111111-1111-4111-a111-111111111111"
+		volumeClassID = "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
+	)
+
+	maxIOPS := 25000
+	maxThroughput := 500
+	fixture := newVolumeClassV2TestFixture(t, newVolumeClassTestRegion(regionID, nil))
+	fixture.expectVolumeClasses(regionID, types.VolumeClassList{
+		{
+			ID:          volumeClassID,
+			Name:        "fast-nvme",
+			Description: "Latency-sensitive encrypted block storage",
+			Media:       types.VolumeClassMediaNVMe,
+			Performance: &types.VolumeClassPerformance{
+				MaxIOPS:       &maxIOPS,
+				MaxThroughput: &maxThroughput,
+			},
+			Encrypted: true,
+		},
+	}, nil)
+
+	response := fixture.get(volumeClassReadContext(t.Context()), openapi.GetApiV2VolumeclassesParams{})
+	result := requireVolumeClassListResponse(t, response)
+
+	require.Len(t, result, 1)
+	require.Equal(t, volumeClassID, result[0].Metadata.Id)
+	require.Equal(t, "fast-nvme", result[0].Metadata.Name)
+	require.NotNil(t, result[0].Metadata.Description)
+	require.Equal(t, "Latency-sensitive encrypted block storage", *result[0].Metadata.Description)
+	require.Equal(t, regionID, result[0].Spec.RegionId.String())
+	require.NotNil(t, result[0].Spec.Media)
+	require.Equal(t, openapi.VolumeClassV2MediaNvme, *result[0].Spec.Media)
+	require.NotNil(t, result[0].Spec.Performance)
+	require.Equal(t, &maxIOPS, result[0].Spec.Performance.MaxIOPS)
+	require.Equal(t, &maxThroughput, result[0].Spec.Performance.MaxThroughputMiBps)
+	require.True(t, result[0].Spec.Encrypted)
+}
+
+func TestVolumeClassV2ReturnsEmptyListForFilteredRegions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		inaccessibleRegionID = "22222222-2222-4222-a222-222222222222"
+		missingRegionID      = "23232323-2323-4232-a323-232323232323"
+		globalPermissionID   = "30303030-3030-4030-a030-303030303030"
+	)
+
+	globalVolumeClassReadContext := func(ctx context.Context) context.Context {
+		return rbac.NewContext(ctx, &identityapi.Acl{
+			Global: &identityapi.AclEndpoints{
+				{
+					Name:       volumeClassReadEndpoint,
+					Operations: identityapi.AclOperations{identityapi.Read},
+				},
+			},
+		})
+	}
+
+	tests := []struct {
+		name     string
+		context  func(context.Context) context.Context
+		regionID string
+		regions  []*regionv1.Region
+	}{
+		{
+			name:     "explicit Region is inaccessible",
+			context:  volumeClassReadContext,
+			regionID: inaccessibleRegionID,
+			regions: []*regionv1.Region{
+				newVolumeClassTestRegion(
+					inaccessibleRegionID,
+					newVolumeClassTestSecurity(volumeClassOtherOrganizationID),
+				),
+			},
+		},
+		{
+			name:     "explicit Region does not exist",
+			context:  volumeClassReadContext,
+			regionID: missingRegionID,
+		},
+		{
+			name:     "global endpoint permission does not bypass Region visibility",
+			context:  globalVolumeClassReadContext,
+			regionID: globalPermissionID,
+			regions: []*regionv1.Region{
+				newVolumeClassTestRegion(
+					globalPermissionID,
+					newVolumeClassTestSecurity(volumeClassOtherOrganizationID),
+				),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newVolumeClassV2TestFixture(t, test.regions...)
+			params := openapi.GetApiV2VolumeclassesParams{
+				RegionID: ptr.To(openapi.RegionIDQueryParameter{test.regionID}),
+			}
+			response := fixture.get(test.context(t.Context()), params)
+			result := requireVolumeClassListResponse(t, response)
+
+			require.Empty(t, result)
+		})
+	}
+}
+
+func TestVolumeClassV2ReturnsEmptyProviderInventory(t *testing.T) {
+	t.Parallel()
+
+	const regionID = "25252525-2525-4252-a525-252525252525"
+
+	fixture := newVolumeClassV2TestFixture(t, newVolumeClassTestRegion(regionID, nil))
+	fixture.expectVolumeClasses(regionID, nil, nil)
+
+	response := fixture.get(volumeClassReadContext(t.Context()), openapi.GetApiV2VolumeclassesParams{})
+	result := requireVolumeClassListResponse(t, response)
+
+	require.Empty(t, result)
+}
+
+func TestVolumeClassV2SkipsProviderDiscoveryWithoutEndpointPermission(t *testing.T) {
+	t.Parallel()
+
+	const (
+		organizationID = "24242424-2424-4242-a424-242424242424"
+		regionID       = "25252525-2525-4252-a525-252525252525"
+	)
+
+	tests := []struct {
+		name     string
+		params   openapi.GetApiV2VolumeclassesParams
+		security *regionv1.RegionSecuritySpec
+	}{
+		{
+			name: "unrestricted Region",
+		},
+		{
+			name: "Region restricted to caller organization",
+			params: openapi.GetApiV2VolumeclassesParams{
+				RegionID: ptr.To(openapi.RegionIDQueryParameter{regionID}),
+			},
+			security: newVolumeClassTestSecurity(organizationID),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newVolumeClassV2TestFixture(t, newVolumeClassTestRegion(regionID, test.security))
+			fixture.providers.EXPECT().LookupCommon(regionID).Times(0)
+
+			ctx := newOrganisationACLBuilder(organizationID).buildContext(t.Context())
+			response := fixture.get(ctx, test.params)
+			result := requireVolumeClassListResponse(t, response)
+
+			require.Empty(t, result)
+		})
+	}
+}
+
+func TestVolumeClassV2FiltersInaccessibleRegions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		accessibleRegionID = "33333333-3333-4333-a333-333333333333"
+		restrictedRegionID = "44444444-4444-4444-a444-444444444444"
+		volumeClassID      = "bbbbbbbb-bbbb-4bbb-abbb-bbbbbbbbbbbb"
+	)
+
+	fixture := newVolumeClassV2TestFixture(
+		t,
+		newVolumeClassTestRegion(accessibleRegionID, nil),
+		newVolumeClassTestRegion(
+			restrictedRegionID,
+			newVolumeClassTestSecurity(volumeClassOtherOrganizationID),
+		),
+	)
+	fixture.expectVolumeClasses(accessibleRegionID, types.VolumeClassList{
+		{
+			ID:   volumeClassID,
+			Name: "visible-class",
+		},
+	}, nil)
+
+	response := fixture.get(volumeClassReadContext(t.Context()), openapi.GetApiV2VolumeclassesParams{})
+	result := requireVolumeClassListResponse(t, response)
+
+	require.Len(t, result, 1)
+	require.Equal(t, volumeClassID, result[0].Metadata.Id)
+	require.Equal(t, accessibleRegionID, result[0].Spec.RegionId.String())
+}
+
+func TestVolumeClassV2FiltersAndDeduplicatesExplicitRegions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		unselectedRegion = "55555555-5555-4555-a555-555555555555"
+		selectedRegion   = "66666666-6666-4666-a666-666666666666"
+	)
+
+	fixture := newVolumeClassV2TestFixture(
+		t,
+		newVolumeClassTestRegion(unselectedRegion, nil),
+		newVolumeClassTestRegion(
+			selectedRegion,
+			newVolumeClassTestSecurity(volumeClassTestOrganizationID),
+		),
+	)
+	fixture.expectVolumeClasses(selectedRegion, types.VolumeClassList{
+		{ID: "cccccccc-cccc-4ccc-accc-cccccccccccc", Name: "selected-class"},
+	}, nil)
+
+	params := openapi.GetApiV2VolumeclassesParams{
+		RegionID: ptr.To(openapi.RegionIDQueryParameter{
+			"98989898-9898-4989-a989-989898989898",
+			selectedRegion,
+			selectedRegion,
+		}),
+	}
+
+	response := fixture.get(volumeClassReadContext(t.Context()), params)
+	result := requireVolumeClassListResponse(t, response)
+
+	require.Len(t, result, 1)
+	require.Equal(t, selectedRegion, result[0].Spec.RegionId.String())
+}
+
+func TestVolumeClassV2SortsProviderInventoryByNameThenID(t *testing.T) {
+	t.Parallel()
+
+	const regionID = "aaaaaaaa-1111-4111-a111-111111111111"
+
+	fixture := newVolumeClassV2TestFixture(t, newVolumeClassTestRegion(regionID, nil))
+	fixture.expectVolumeClasses(regionID, types.VolumeClassList{
+		{ID: "dddddddd-dddd-4ddd-addd-dddddddddddd", Name: "zonal"},
+		{ID: "ffffffff-ffff-4fff-afff-ffffffffffff", Name: "balanced"},
+		{ID: "eeeeeeee-eeee-4eee-aeee-eeeeeeeeeeee", Name: "balanced"},
+	}, nil)
+
+	response := fixture.get(volumeClassReadContext(t.Context()), openapi.GetApiV2VolumeclassesParams{})
+	result := requireVolumeClassListResponse(t, response)
+
+	require.Len(t, result, 3)
+	require.Equal(t, "eeeeeeee-eeee-4eee-aeee-eeeeeeeeeeee", result[0].Metadata.Id)
+	require.Equal(t, "ffffffff-ffff-4fff-afff-ffffffffffff", result[1].Metadata.Id)
+	require.Equal(t, "dddddddd-dddd-4ddd-addd-dddddddddddd", result[2].Metadata.Id)
+}

--- a/pkg/handler/region/README.md
+++ b/pkg/handler/region/README.md
@@ -11,6 +11,7 @@ mutating user-owned lifecycle resources. Its job is to expose:
 - visible regions
 - region detail
 - provider-derived flavor inventory
+- provider-derived VolumeClass inventory
 - provider-derived external network inventory
 
 So this package is where the service turns stored region configuration and
@@ -20,11 +21,11 @@ provider capability discovery into user-visible region catalogue data.
 
 - region visibility is filtered against region security constraints and the
   caller's organization scope
-- flavor and external-network reads cross the provider boundary rather than
-  reading from CRD-backed child resources
-- flavor conversion passes through the shared
-  [`conversion`](../conversion/README.md) package because flavor is a provider
-  concept rather than a first-class CRD
+- flavor, VolumeClass, and external-network reads cross the provider boundary
+  rather than reading from CRD-backed child resources
+- flavor and VolumeClass conversion passes through the shared
+  [`conversion`](../conversion/README.md) package because both are provider
+  concepts rather than first-class CRDs
 
 ## Invariants And Guard Rails
 
@@ -33,13 +34,24 @@ provider capability discovery into user-visible region catalogue data.
 - Provider-derived capability reads must resolve the correct provider for the
   selected region rather than trusting client-supplied assumptions.
 - Flavor ordering is intentionally stable and user-facing.
+- VolumeClass inventory is ordered by Region, class name, and class ID. Empty
+  provider inventory remains a non-nil empty API list.
+- VolumeClass listing applies the canonical Region visibility filter before
+  provider discovery. Explicit `regionID` values then act as selectors over
+  that visible set. Repeated selectors do not duplicate results, and missing or
+  inaccessible Regions are omitted so the response can be empty or partial.
+- VolumeClass access preserves the existing Region visibility distinction:
+  a nil organization allowlist is unrestricted, while a configured but empty
+  allowlist permits no organizations.
+- VolumeClass provider discovery requires `region:volumeclasses:v2/read` in at
+  least one organization visible to the caller. Requests without that grant
+  omit the selected Regions without performing provider lookups.
 - Region ACL checking is enforced in two places:
   - **List responses** (`FilterRegions`) — removes regions the caller cannot see
-    before building the response.
-  - **User-supplied region IDs** (`CheckAccess`) — called at the top of any
-    handler or client method that accepts a region ID as input (path parameter,
-    query parameter, or request body field). This prevents a caller who knows a
-    restricted region's ID from using it without authorization.
+    before building the response or applying list selectors such as the
+    VolumeClass `regionID` query.
+  - **Direct Region references** (`CheckAccess`) — used by read or mutation
+    operations that address or depend on one specific Region.
 - `CheckAccess` returns `HTTPNotFound` rather than `HTTPForbidden` to avoid
   confirming the existence of regions the caller cannot see.
 
@@ -57,7 +69,7 @@ provider capability discovery into user-visible region catalogue data.
 
 - [../README.md](../README.md) explains why provider-backed capability reads sit
   alongside CRD-backed handler logic in this layer
-- [../conversion](../conversion/README.md) covers the shared flavor conversion
-  boundary
+- [../conversion](../conversion/README.md) covers the shared flavor and
+  VolumeClass conversion boundary
 - [../../providers](../../providers/README.md) documents the provider capability
   contracts consumed here

--- a/pkg/handler/region/region.go
+++ b/pkg/handler/region/region.go
@@ -86,18 +86,27 @@ func checkAccess(ctx context.Context, resource *unikornv1.Region) error {
 	return errors.HTTPNotFound()
 }
 
-// CheckAccess fetches the region by ID and verifies the caller's organization is
-// allowed to use it.  Returns HTTPNotFound for both missing and inaccessible regions
-// to avoid confirming region existence to unauthorized callers.
-func (c *Client) CheckAccess(ctx context.Context, regionID regionids.RegionID) error {
+func (c *Client) getRegion(ctx context.Context, regionID regionids.RegionID) (*unikornv1.Region, error) {
 	resource := &unikornv1.Region{}
 
 	if err := c.Client.Get(ctx, client.ObjectKey{Namespace: c.Namespace, Name: regionID.String()}, resource); err != nil {
 		if kerrors.IsNotFound(err) {
-			return errors.HTTPNotFound().WithError(err)
+			return nil, errors.HTTPNotFound().WithError(err)
 		}
 
-		return fmt.Errorf("%w: unable to lookup region", err)
+		return nil, fmt.Errorf("%w: unable to lookup region", err)
+	}
+
+	return resource, nil
+}
+
+// CheckAccess fetches the region by ID and verifies the caller's organization is
+// allowed to use it.  Returns HTTPNotFound for both missing and inaccessible regions
+// to avoid confirming region existence to unauthorized callers.
+func (c *Client) CheckAccess(ctx context.Context, regionID regionids.RegionID) error {
+	resource, err := c.getRegion(ctx, regionID)
+	if err != nil {
+		return err
 	}
 
 	return checkAccess(ctx, resource)
@@ -109,7 +118,9 @@ func FilterRegions(ctx context.Context, regions *unikornv1.RegionList) {
 	})
 }
 
-func (c *Client) List(ctx context.Context) (openapi.Regions, error) {
+// listRegions returns Regions in the configured namespace that are visible to
+// the caller.
+func (c *Client) listRegions(ctx context.Context) (*unikornv1.RegionList, error) {
 	regions := &unikornv1.RegionList{}
 
 	if err := c.Client.List(ctx, regions, &client.ListOptions{Namespace: c.Namespace}); err != nil {
@@ -117,6 +128,15 @@ func (c *Client) List(ctx context.Context) (openapi.Regions, error) {
 	}
 
 	FilterRegions(ctx, regions)
+
+	return regions, nil
+}
+
+func (c *Client) List(ctx context.Context) (openapi.Regions, error) {
+	regions, err := c.listRegions(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	return convertList(regions), nil
 }
@@ -169,6 +189,72 @@ func (c *Client) ListFlavors(ctx context.Context, organizationID identityids.Org
 	})
 
 	return conversion.ConvertFlavors(result), nil
+}
+
+const volumeClassReadEndpoint = "region:volumeclasses:v2"
+
+func hasVolumeClassReadAccess(ctx context.Context) bool {
+	for _, value := range rbac.OrganizationIDs(ctx) {
+		organizationID, err := identityids.ParseOrganizationID(value)
+		if err != nil {
+			continue
+		}
+
+		if rbac.AllowOrganizationScopeID(ctx, volumeClassReadEndpoint, identityapi.Read, organizationID) == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *Client) ListVolumeClasses(ctx context.Context, params openapi.GetApiV2VolumeclassesParams) (openapi.VolumeClassListV2Read, error) {
+	regions, err := c.listRegions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if params.RegionID != nil {
+		// Filter regions based on the query parameter
+		regions.Items = slices.DeleteFunc(regions.Items, func(region unikornv1.Region) bool {
+			return !slices.Contains(*params.RegionID, region.Name)
+		})
+	}
+
+	result := openapi.VolumeClassListV2Read{}
+
+	for _, region := range regions.Items {
+		if !hasVolumeClassReadAccess(ctx) {
+			continue
+		}
+
+		provider, err := c.Providers.LookupCommon(region.Name)
+		if err != nil {
+			return nil, providers.ProviderToServerError(err)
+		}
+
+		volumeClasses, err := provider.VolumeClasses(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("%w: failed to list volume classes", err)
+		}
+
+		regionID, err := regionids.ParseRegionID(region.Name)
+		if err != nil {
+			continue
+		}
+
+		result = append(result, conversion.ConvertVolumeClasses(regionID, volumeClasses)...)
+	}
+
+	slices.SortStableFunc(result, func(a, b openapi.VolumeClassV2Read) int {
+		return cmp.Or(
+			cmp.Compare(a.Spec.RegionId.String(), b.Spec.RegionId.String()),
+			cmp.Compare(a.Metadata.Name, b.Metadata.Name),
+			cmp.Compare(a.Metadata.Id, b.Metadata.Id),
+		)
+	})
+
+	return result, nil
 }
 
 func convertExternalNetwork(in types.ExternalNetwork) openapi.ExternalNetwork {

--- a/pkg/handler/region/region_test.go
+++ b/pkg/handler/region/region_test.go
@@ -187,6 +187,27 @@ func TestRegionFilteringNoPrivate(t *testing.T) {
 	require.Equal(t, globalRegionName, regions.Items[0].Name)
 }
 
+func TestRegionFilteringEmptyOrganizationAllowlist(t *testing.T) {
+	t.Parallel()
+
+	ctx := aclFixture(t, organizationID1)
+	regions := &regionv1.RegionList{
+		Items: []regionv1.Region{
+			{
+				Spec: regionv1.RegionSpec{
+					Security: &regionv1.RegionSecuritySpec{
+						Organizations: []regionv1.RegionSecurityOrganizationSpec{},
+					},
+				},
+			},
+		},
+	}
+
+	region.FilterRegions(ctx, regions)
+
+	require.Empty(t, regions.Items)
+}
+
 // TestRegionFilteringGlobalScope tests that platform admins and services with global
 // scope see all regions including private ones.
 func TestRegionFilteringGlobalScope(t *testing.T) {

--- a/pkg/openapi/README.md
+++ b/pkg/openapi/README.md
@@ -241,9 +241,13 @@ fully encoded here:
 - some `v2` resources are clearly documented for publication, while others such
   as many server operations remain hidden; readers should not assume version
   number alone determines visibility
-- the published VolumeClass route currently defines the wire contract only;
-  provider-backed discovery and successful list handling are implemented
-  separately
+- the published VolumeClass route is backed by provider-neutral Region
+  discovery; repeated Region filters act as selectors over the visible Region
+  set, so missing or inaccessible Regions are omitted and the response can be
+  empty or partial;
+  its metadata uses core's `staticResourceMetadata`, matching Flavor inventory;
+  because the provider model supplies no creation time, the generated response
+  retains the same zero-value timestamp behaviour as Flavor
 - the main value of `v2` is not just shorter paths. It is the shift toward a
   relationship-driven API shape where surrounding tenancy and placement context
   can often be inferred from the addressed resource graph

--- a/pkg/openapi/schema.go
+++ b/pkg/openapi/schema.go
@@ -372,10 +372,11 @@ var swaggerSpec = []string{
 	"LtBNuEA2nKFsQddly2mE90Z4/wbSdNyfrNufQJLXERYb0fZaSX4Dwu4113NDu19aMo5dEO6GdrUyiikx",
 	"7M9ZEIfgBViIIo1fKQciqXLToRBLjgM0Dph303GVdGxvhOeYBKYkB2chsrl30ZwIor6UzDia4yAA3kUv",
 	"QcSBFM52RzHn7BZ81YxRQIyjkHFwo1TaDwpW+Ebv68yurN56IsDGF95F8KM/laaNEvCqLmadiNvVl6wW",
-	"PQefYF1jyNZEwtRTc0UCYa5mkDGn4CNGgwW6nQFFUTwOiJilpYbMWOVc803u6LbNabwTY8I8hbY6j4aj",
-	"/g1NCAYHUIqPjsG9yf+Q0TFMQbACg7+pM4DGMQn8pG4YoZqOpCWKsrf9mFOh6SffW0gcKhGHUEv37jlh",
-	"TCjmC4SlKzcwopKE0DYZxVQLLyCmHBj10dkFmmJpcvfPgZPJAsEd9qSmYuLNkpoFRIyoD1HAFiYpWSEN",
-	"WwBsQ3KbHbqt3GAn/ExE8/Xc2wo/3OG5qhcOk7KYbb95Zw3sbtt2ZGNp//jx/w8AAP//eOkS21e6AgA=",
+	"PSdCEDpFuiIR1qm29aRuEZgDYiGREvw2EgwJa1Ew8Ig482NPi0oQRnKhhokwlwQHKCBCdtFz8AnWNYxs",
+	"zSVMPbWXyAzNQcacgo8YDRbodgYURfE4IGKWljIySynnym9yqLFtzuSdGCvm6Wmq82449t/QRGFwAKX4",
+	"6Bjom/wPGR3GFBwreFAwdQzQOCaBn9QlI1TTkbREUeY7EHMqNP3kewuJQyVCEWr5inuuGBOK+QJh6coZ",
+	"jKgkIbRNxjLVwguIKTdGfXR2gaZYmtoAc+BkskBwhz2pqZh4s6QmAhEj6kMUsIVJelZIwxYA25DcZodu",
+	"K0PYCT8T0Xw9coHCD3d4rqqGw6QsZttv3lkDvtu2HdlY8j9+/P8DAAD//7xp/9u3ugIA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/openapi/server.spec.yaml
+++ b/pkg/openapi/server.spec.yaml
@@ -1787,7 +1787,7 @@ paths:
       Lists provider-neutral block-storage classes available from Regions visible to the caller. Results can be narrowed to one or more Regions.
     get:
       description: |-
-        Lists provider-neutral VolumeClasses from Regions visible to the caller. Repeat the regionID query parameter to narrow results to one or more Regions. Media and performance caps are returned only when published by the Region.
+        Lists provider-neutral VolumeClasses from Regions visible to the caller. Repeat the regionID query parameter to narrow results to one or more Regions. Missing or inaccessible Regions are omitted, so selectors can produce an empty or partial list. Media and performance caps are returned only when published by the Region.
       summary: List volume classes
       tags:
       - Volume classes

--- a/pkg/openapi/volumeclass_contract_test.go
+++ b/pkg/openapi/volumeclass_contract_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapi_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/region/pkg/openapi"
+)
+
+func TestVolumeClassListDoesNotDeclareNotFoundForRegionSelectors(t *testing.T) {
+	t.Parallel()
+
+	swagger, err := openapi.GetSwagger()
+	require.NoError(t, err)
+
+	path := swagger.Paths.Find("/api/v2/volumeclasses")
+	require.NotNil(t, path)
+	require.NotNil(t, path.Get)
+	require.Nil(t, path.Get.Responses.Value("404"))
+}
+
+func TestVolumeClassMetadataUsesStaticResourceMetadata(t *testing.T) {
+	t.Parallel()
+
+	swagger, err := openapi.GetSwagger()
+	require.NoError(t, err)
+
+	resource := swagger.Components.Schemas["volumeClassV2Read"]
+	require.NotNil(t, resource)
+	require.NotNil(t, resource.Value)
+
+	flavor := swagger.Components.Schemas["flavor"]
+	require.NotNil(t, flavor)
+	require.NotNil(t, flavor.Value)
+	require.Equal(t, flavor.Value.Properties["metadata"].Ref, resource.Value.Properties["metadata"].Ref)
+}


### PR DESCRIPTION
## Summary

- implement the read-only v2 VolumeClass inventory handler over the provider-neutral discovery interface
- list only Regions visible to the caller and treat repeated `regionID` values as selectors, omitting missing or inaccessible Regions
- map provider-neutral metadata, media, performance, and encryption fields without exposing provider-specific details
- return deterministic results ordered by Region, class name, and class ID
- return empty lists for empty Region configuration, unmatched filters, and empty provider inventories while failing the request on provider errors
- update the OpenAPI contract, package documentation, generated clients, and unit coverage

## Why

Callers need a provider-independent way to discover block-storage capabilities before creating storage resources. Keeping filtering aligned with other v2 list endpoints allows clients to request several Regions and receive the visible subset without turning the operation into a sequence of resource lookups.

## Stack

Depends on #618 (`feat/STO-145-publish-volumeclass-openapi-contract`).

Linear: https://linear.app/nscale-workspace/issue/STO-146/uni-region-implement-volumeclass-api-handler

## Validation

- `make touch`
- `make license`
- `make validate`
- `make lint`
- `make generate`
- clean generated worktree check
- `make test-unit`
- `go build ./...`
