### PR TITLE
Add provider-neutral Volume lifecycle contracts

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -20,8 +20,10 @@ The useful way to read it is not as a directory tree, but as one system:
 - monitors project observed provider truth back into status and metrics
 - providers bind the region model to real or simulated clouds
 - `Volume` is an internal Region storage model today: a network-anchored,
-  quota-carrying block storage resource whose public API, controller, and
-  provider behavior are deliberately introduced by later tickets
+  quota-carrying block storage resource. Its provider-facing create, find,
+  observe, and delete contract is defined, while concrete provider behavior,
+  public API, controller, and monitor integration are introduced by later
+  tickets
 - `Server` now carries the internal attach-existing-only block volume intent
   and observed per-volume attachment rows; public API projection and provider
   reconciliation remain separate follow-up work

--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -47,6 +47,14 @@ packages are the concrete provider implementations.
 - `types.Provider` extends that common base with the broader image, identity,
   network, security-group, load-balancer, server, console, and snapshot
   lifecycle surfaces.
+- `types.Volume` is the block-storage lifecycle capability boundary:
+  - create and delete receive the native Region `unikornv1.Volume` intent
+  - find rediscovers provider resources through stable Region naming and
+    metadata rather than mirrored provider-state records
+  - observe returns provider-neutral `types.VolumeState` size and lifecycle
+    status for controller and monitor consumers
+  - the capability remains separate from the composite `types.Provider` until
+    concrete provider lifecycle implementations are introduced
 - The provider abstraction is intentionally mixed:
   - CRD-backed lifecycle operations still speak in repo-native
     `pkg/apis/unikorn/v1alpha1` resource types
@@ -128,6 +136,9 @@ packages are the concrete provider implementations.
 - Credential handling remains one of the sharpest edges in this layer. Some
   current flows still rely on service-managed secret material and delegated
   application credentials that the wider platform would ideally stop exposing.
+- Volume lifecycle is currently a contract only. Concrete provider behavior,
+  controller/monitor integration, and server attachment operations are separate
+  implementation surfaces.
 - Some provider-specific compensating mechanisms are valuable but architectural
   debt at the same time. Caches, local allocators, and compatibility bridges are
   signs that the substrate contract is imperfect, not proof that those patterns

--- a/pkg/providers/types/README.md
+++ b/pkg/providers/types/README.md
@@ -49,6 +49,14 @@ continue to be passed directly through many provider interface methods.
   resource. It carries the immutable provider identifier and user-facing
   metadata that Region configuration can filter or enrich before a public API
   exposes the inventory.
+- `Volume` is a standalone provider capability for block-storage lifecycle.
+  Its create, find, observe, and idempotent delete operations take the native
+  Region `unikornv1.Volume` resource so desired lifecycle intent retains the
+  stable CRD shape and metadata conventions.
+- `VolumeState` is the provider-neutral observed projection returned by that
+  capability. It exposes the provider-reported capacity and a normalized
+  lifecycle status without leaking OpenStack/Cinder resource types to controller
+  or monitor consumers.
 - `ServerCreateOptions` carries launch-time derived inputs without forcing them
   into the persisted `Server` CRD shape.
 - Exported errors such as `ErrImageNotReadyForUpload` and
@@ -74,6 +82,9 @@ continue to be passed directly through many provider interface methods.
 - Not every concrete provider is guaranteed to support every concept equally
   well. This package standardizes the contract surface, but concrete behaviour
   still depends on provider implementation choices and limitations.
+- The `Volume` capability is intentionally not embedded in the composite
+  `Provider` yet. This keeps the contract addition independent from concrete
+  provider lifecycle work and avoids placeholder backend behavior.
 - There is stale historical scar tissue in the interface layer, especially
   around old network-detail propagation commentary. That comment block is now a
   cleanup problem more than a live contract.

--- a/pkg/providers/types/interfaces.go
+++ b/pkg/providers/types/interfaces.go
@@ -91,6 +91,22 @@ type LoadBalancer interface {
 	DeleteLoadBalancer(ctx context.Context, identity *unikornv1.Identity, loadBalancer *unikornv1.LoadBalancer) error
 }
 
+// Volume manages provider-backed block-storage volumes.
+type Volume interface {
+	// CreateVolume creates the provider volume described by the Region Volume.
+	CreateVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error
+	// FindVolume reports whether the provider volume described by the Region
+	// Volume exists. Implementations rediscover it using stable Region naming
+	// and metadata conventions.
+	FindVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) (bool, error)
+	// ObserveVolume returns the provider-neutral observed state of the provider
+	// volume described by the Region Volume.
+	ObserveVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) (*VolumeState, error)
+	// DeleteVolume idempotently deletes the provider volume described by the
+	// Region Volume.
+	DeleteVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error
+}
+
 type Server interface {
 	// CreateServer creates a new server.
 	CreateServer(ctx context.Context, identity *unikornv1.Identity, server *unikornv1.Server, options *ServerCreateOptions) error

--- a/pkg/providers/types/mock/interfaces.go
+++ b/pkg/providers/types/mock/interfaces.go
@@ -435,6 +435,87 @@ func (mr *MockLoadBalancerMockRecorder) DeleteLoadBalancer(ctx, identity, loadBa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancer", reflect.TypeOf((*MockLoadBalancer)(nil).DeleteLoadBalancer), ctx, identity, loadBalancer)
 }
 
+// MockVolume is a mock of Volume interface.
+type MockVolume struct {
+	ctrl     *gomock.Controller
+	recorder *MockVolumeMockRecorder
+}
+
+// MockVolumeMockRecorder is the mock recorder for MockVolume.
+type MockVolumeMockRecorder struct {
+	mock *MockVolume
+}
+
+// NewMockVolume creates a new mock instance.
+func NewMockVolume(ctrl *gomock.Controller) *MockVolume {
+	mock := &MockVolume{ctrl: ctrl}
+	mock.recorder = &MockVolumeMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockVolume) EXPECT() *MockVolumeMockRecorder {
+	return m.recorder
+}
+
+// CreateVolume mocks base method.
+func (m *MockVolume) CreateVolume(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVolume", ctx, identity, volume)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateVolume indicates an expected call of CreateVolume.
+func (mr *MockVolumeMockRecorder) CreateVolume(ctx, identity, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockVolume)(nil).CreateVolume), ctx, identity, volume)
+}
+
+// DeleteVolume mocks base method.
+func (m *MockVolume) DeleteVolume(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVolume", ctx, identity, volume)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVolume indicates an expected call of DeleteVolume.
+func (mr *MockVolumeMockRecorder) DeleteVolume(ctx, identity, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockVolume)(nil).DeleteVolume), ctx, identity, volume)
+}
+
+// FindVolume mocks base method.
+func (m *MockVolume) FindVolume(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindVolume", ctx, identity, volume)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindVolume indicates an expected call of FindVolume.
+func (mr *MockVolumeMockRecorder) FindVolume(ctx, identity, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindVolume", reflect.TypeOf((*MockVolume)(nil).FindVolume), ctx, identity, volume)
+}
+
+// ObserveVolume mocks base method.
+func (m *MockVolume) ObserveVolume(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) (*types.VolumeState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ObserveVolume", ctx, identity, volume)
+	ret0, _ := ret[0].(*types.VolumeState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ObserveVolume indicates an expected call of ObserveVolume.
+func (mr *MockVolumeMockRecorder) ObserveVolume(ctx, identity, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObserveVolume", reflect.TypeOf((*MockVolume)(nil).ObserveVolume), ctx, identity, volume)
+}
+
 // MockServer is a mock of Server interface.
 type MockServer struct {
 	ctrl     *gomock.Controller

--- a/pkg/providers/types/types.go
+++ b/pkg/providers/types/types.go
@@ -124,6 +124,26 @@ type VolumeClassPerformance struct {
 // VolumeClassList is a list of provider volume classes.
 type VolumeClassList []VolumeClass
 
+// VolumeStatus describes provider-observed block-storage lifecycle state.
+type VolumeStatus string
+
+const (
+	VolumeStatusUnknown   VolumeStatus = "unknown"
+	VolumeStatusCreating  VolumeStatus = "creating"
+	VolumeStatusAvailable VolumeStatus = "available"
+	VolumeStatusInUse     VolumeStatus = "in-use"
+	VolumeStatusDeleting  VolumeStatus = "deleting"
+	VolumeStatusError     VolumeStatus = "error"
+)
+
+// VolumeState is the provider-neutral observed state of a block-storage volume.
+type VolumeState struct {
+	// Size is the capacity currently reported by the provider.
+	Size resource.Quantity
+	// Status is the provider-neutral lifecycle state.
+	Status VolumeStatus
+}
+
 type ImageVirtualization string
 
 const (

--- a/pkg/providers/types/volume_contract_test.go
+++ b/pkg/providers/types/volume_contract_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types_test
+
+import (
+	"context"
+
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// volumeContract pins the lifecycle boundary consumed by the Volume controller
+// and monitor without coupling those consumers to provider SDK types.
+type volumeContract interface {
+	CreateVolume(context.Context, *unikornv1.Identity, *unikornv1.Volume) error
+	FindVolume(context.Context, *unikornv1.Identity, *unikornv1.Volume) (bool, error)
+	ObserveVolume(context.Context, *unikornv1.Identity, *unikornv1.Volume) (*types.VolumeState, error)
+	DeleteVolume(context.Context, *unikornv1.Identity, *unikornv1.Volume) error
+}
+
+var _ volumeContract = (types.Volume)(nil)
+
+var _ = types.VolumeState{
+	Size:   resource.MustParse("64Gi"),
+	Status: types.VolumeStatusAvailable,
+}

--- a/pkg/providers/types/volume_contract_test.go
+++ b/pkg/providers/types/volume_contract_test.go
@@ -28,10 +28,10 @@ import (
 // volumeContract pins the lifecycle boundary consumed by the Volume controller
 // and monitor without coupling those consumers to provider SDK types.
 type volumeContract interface {
-	CreateVolume(context.Context, *unikornv1.Identity, *unikornv1.Volume) error
-	FindVolume(context.Context, *unikornv1.Identity, *unikornv1.Volume) (bool, error)
-	ObserveVolume(context.Context, *unikornv1.Identity, *unikornv1.Volume) (*types.VolumeState, error)
-	DeleteVolume(context.Context, *unikornv1.Identity, *unikornv1.Volume) error
+	CreateVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error
+	FindVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) (bool, error)
+	ObserveVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) (*types.VolumeState, error)
+	DeleteVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error
 }
 
 var _ volumeContract = (types.Volume)(nil)


### PR DESCRIPTION
## Summary

- add a standalone provider capability for Volume create, find, observe, and idempotent delete behavior
- preserve native `unikornv1.Volume` lifecycle intent while returning provider-neutral observed size and status
- regenerate the provider mock and add a compile-time contract regression test
- document the mixed provider boundary and deliberately exclude VolumeClass inventory and server attach/detach operations

## Why

STO-139 establishes the provider boundary needed by the later OpenStack Volume primitives, controller, and monitor work without leaking Cinder resource types into provider consumers.

The Volume capability remains separate from the composite `types.Provider` until concrete provider lifecycle implementations are introduced.

## Review focus

- confirm whether `FindVolume` should return `(bool, error)` or use the repository's `ErrResourceNotFound` convention
- confirm the provider-neutral Volume status vocabulary before the OpenStack mapping is implemented

## Validation

- `make touch`
- `make license`
- `make validate`
- `make lint`
- `make generate`
- generated-code and working-tree audit
- `make test-unit`
- `git diff --check`

Linear: STO-139
