### PR TITLE
Implement OpenStack Volume create and delete

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -20,8 +20,9 @@ The useful way to read it is not as a directory tree, but as one system:
 - monitors project observed provider truth back into status and metrics
 - providers bind the region model to real or simulated clouds
 - `Volume` is an internal Region storage model today: a network-anchored,
-  quota-carrying block storage resource whose public API, controller, and
-  provider behavior are deliberately introduced by later tickets
+  quota-carrying block storage resource. OpenStack create/delete provider
+  behavior exists, while its public API, controller, and observed-state
+  projection remain later lifecycle slices
 - `Server` now carries the internal attach-existing-only block volume intent
   and observed per-volume attachment rows; public API projection and provider
   reconciliation remain separate follow-up work

--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -59,6 +59,16 @@ packages are the concrete provider implementations.
     the real backing resources
   - mirrored provider-state records are not the preferred answer unless the
     state cannot be reconstructed safely enough by other means
+- `types.Volume` is currently a focused create/delete capability implemented
+  by OpenStack, separate from the full `types.Provider` composition while the
+  Volume controller and other backends do not consume that lifecycle:
+  - lifecycle intent is the native Region `Volume` CRD
+  - provider implementations rediscover their backing object internally before
+    create or delete; rediscovery is not a public existence-only contract
+  - provider-neutral observation belongs to the later read-side slice, once
+    monitor and controller consumers can exercise its shape
+  - VolumeClass inventory remains on `CommonProvider`, and server
+    attach/detach is a separate capability
 - Provider `Delete*` methods must be idempotent and must tolerate an unrealized
   identity as a no-op. Callers delegate unconditionally; the provider
   self-gates on realized identity rather than the caller gating on readiness or

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -254,10 +254,29 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   re-find cloud-side resources. This is a convention-heavy contract, not magic:
   - identity-scoped resources use fixed generated names
   - network lookups rely on deterministic names
+  - Cinder volumes use `volume-{Region Volume UUID}` inside the service
+    principal's project; create and delete both rediscover that exact name
   - server metadata is written deliberately as both a control-plane lookup aid
     and an in-guest linkage surface exposed through the metadata service
   - legacy camelCase server metadata keys remain frozen for backwards
     compatibility while newer namespaced keys provide the upgrade path
+- Cinder Volume create/delete is a project-scoped lifecycle slice:
+  - the native Region `Volume` CRD supplies the requested size and
+    `VolumeClassID`, which becomes the Cinder volume type
+  - create lists by the stable generated name and exact-matches the result
+    before submitting a create, so controller retries adopt an existing volume
+    rather than duplicating it
+  - user tags are translated with the package's normal namespaced metadata
+    convention; namespaced system linkage keys are written last so user input
+    cannot override identity, organization, project, region, network, or Volume
+    IDs; Volume metadata does not emit the legacy camelCase compatibility keys
+    retained by older resource types
+  - delete uses the same rediscovery path, treats a missing Cinder volume as
+    success, and treats an absent or not-yet-project-backed
+    `OpenstackIdentity` as proof that no provider volume could have been
+    created
+  - observed size/status mapping, VolumeClass inventory, and Nova
+    attach/detach are intentionally outside this lifecycle slice
 - Flavor export is a hybrid model: OpenStack discovers the flavor inventory, but
   region configuration can enrich or override user-facing flavor metadata such
   as architecture, baremetal status, and GPU semantics. The baremetal flag is
@@ -292,7 +311,7 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   The package assumes and applies a managed-role model, including default role
   names such as `manager`, `member`, and `load-balancer_member`, unless region
   configuration overrides parts of that behaviour.
-- Network, security group, and server resources are re-found in OpenStack by
+- Network, security group, server, and Volume resources are re-found in OpenStack by
   deterministic lookup rather than relying on mirrored `OpenstackNetwork`,
   `OpenstackSecurityGroup`, or `OpenstackServer` CRDs as authoritative state.
 - Baremetal server progress uses Ironic as an additional provider truth source

--- a/pkg/providers/internal/openstack/blockstorage.go
+++ b/pkg/providers/internal/openstack/blockstorage.go
@@ -27,14 +27,20 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/availabilityzones"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/quotasets"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/unikorn-cloud/core/pkg/util/cache"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
-	"github.com/unikorn-cloud/region/pkg/providers/types"
 
 	"k8s.io/utils/ptr"
 )
+
+func volumeName(volume *unikornv1.Volume) string {
+	return "volume-" + volume.Name
+}
 
 // BlockStorageClient wraps the generic client because gophercloud is unsafe.
 type BlockStorageClient struct {
@@ -90,6 +96,55 @@ func (c *BlockStorageClient) AvailabilityZones(ctx context.Context) ([]availabil
 	}
 
 	return filtered, nil
+}
+
+func (c *BlockStorageClient) GetVolume(ctx context.Context, volume *unikornv1.Volume) (*volumes.Volume, error) {
+	_, span := traceStart(ctx, "GET /block-storage/v3/volumes/detail")
+	defer span.End()
+
+	name := volumeName(volume)
+
+	pages, err := volumes.List(c.client, &volumes.ListOpts{
+		Name: name,
+	}).AllPages(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := volumes.ExtractVolumes(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	return findExactResource(result, name, "volume", func(resource *volumes.Volume) string {
+		return resource.Name
+	})
+}
+
+func (c *BlockStorageClient) CreateVolume(ctx context.Context, volume *unikornv1.Volume, metadata map[string]string) (*volumes.Volume, error) {
+	_, span := traceStart(ctx, "POST /block-storage/v3/volumes")
+	defer span.End()
+
+	opts := &volumes.CreateOpts{
+		Name:        volumeName(volume),
+		Description: "unikorn managed block storage volume",
+		Size:        int(volume.Spec.Size.Value() / (1 << 30)),
+		VolumeType:  volume.Spec.VolumeClassID,
+		Metadata:    metadata,
+	}
+
+	return volumes.Create(ctx, c.client, opts, nil).Extract()
+}
+
+func (c *BlockStorageClient) DeleteVolume(ctx context.Context, id string) error {
+	spanAttributes := trace.WithAttributes(
+		attribute.String("block_storage.volume.id", id),
+	)
+
+	_, span := traceStart(ctx, "DELETE /block-storage/v3/volumes/{id}", spanAttributes)
+	defer span.End()
+
+	return volumes.Delete(ctx, c.client, id, nil).ExtractErr()
 }
 
 func (c *BlockStorageClient) GetVolumeTypes(ctx context.Context) ([]volumetypes.VolumeType, error) {
@@ -148,52 +203,6 @@ func (c *BlockStorageClient) UpdateQuotas(ctx context.Context, projectID string)
 	return quotasets.Update(ctx, c.client, projectID, opts).Err
 }
 
-func (p *Provider) VolumeClasses(ctx context.Context) (types.VolumeClassList, error) {
-	blockStorage, err := p.openstack.blockStorage(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	resources, err := blockStorage.GetVolumeTypes(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	region, _ := p.openstack.regionSnapshot()
-
-	return convertVolumeClasses(region, resources), nil
-}
-
-func convertVolumeClasses(region *unikornv1.Region, resources []volumetypes.VolumeType) types.VolumeClassList {
-	var config *unikornv1.OpenstackVolumeClassesSpec
-	if region != nil && region.Spec.Openstack != nil {
-		config = openstackVolumeClassesConfig(region.Spec.Openstack.BlockStorage)
-	}
-
-	result := make(types.VolumeClassList, 0, len(resources))
-
-	for i := range resources {
-		resource := &resources[i]
-
-		class := types.VolumeClass{
-			ID:          resource.ID,
-			Name:        resource.Name,
-			Description: resource.Description,
-		}
-
-		if metadata := volumeClassMetadata(config, resource.ID); metadata != nil {
-			class.Media = types.VolumeClassMedia(metadata.Media)
-			class.Encrypted = metadata.Encrypted
-
-			class.Performance = convertVolumeClassPerformance(metadata.Performance)
-		}
-
-		result = append(result, class)
-	}
-
-	return result
-}
-
 func volumeTypeIsPublic(volumeType volumetypes.VolumeType) bool {
 	return volumeType.IsPublic || volumeType.PublicAccess
 }
@@ -204,37 +213,4 @@ func openstackVolumeClassesConfig(blockStorage *unikornv1.RegionOpenstackBlockSt
 	}
 
 	return blockStorage.VolumeClasses
-}
-
-func volumeClassMetadata(config *unikornv1.OpenstackVolumeClassesSpec, id string) *unikornv1.VolumeClassMetadata {
-	if config == nil {
-		return nil
-	}
-
-	i := slices.IndexFunc(config.Metadata, func(metadata unikornv1.VolumeClassMetadata) bool {
-		return id == metadata.ID
-	})
-	if i < 0 {
-		return nil
-	}
-
-	return &config.Metadata[i]
-}
-
-func convertVolumeClassPerformance(in *unikornv1.VolumeClassPerformanceSpec) *types.VolumeClassPerformance {
-	if in == nil {
-		return nil
-	}
-
-	out := &types.VolumeClassPerformance{}
-
-	if in.MaxIOPS != nil {
-		out.MaxIOPS = ptr.To(*in.MaxIOPS)
-	}
-
-	if in.MaxThroughput != nil {
-		out.MaxThroughput = ptr.To(*in.MaxThroughput)
-	}
-
-	return out
 }

--- a/pkg/providers/internal/openstack/blockstorage_test.go
+++ b/pkg/providers/internal/openstack/blockstorage_test.go
@@ -17,22 +17,157 @@ limitations under the License.
 package openstack_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
+
+func TestCreateVolumeUsesRegionIntentAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	volume := &unikornv1.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "11111111-1111-1111-1111-111111111111",
+		},
+		Spec: unikornv1.VolumeSpec{
+			VolumeClassID: "fast",
+			Size:          resource.MustParse("20Gi"),
+		},
+	}
+	metadata := map[string]string{
+		"region:volume_id": volume.Name,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/volumes", r.URL.Path)
+
+		var body map[string]any
+
+		decoder := json.NewDecoder(r.Body)
+		decoder.UseNumber()
+
+		if !assert.NoError(t, decoder.Decode(&body)) {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+
+			return
+		}
+
+		volumeBody, ok := body["volume"].(map[string]any)
+		if !assert.True(t, ok) {
+			http.Error(w, "missing volume body", http.StatusBadRequest)
+
+			return
+		}
+
+		assert.Equal(t, "volume-"+volume.Name, volumeBody["name"])
+		assert.Equal(t, json.Number("20"), volumeBody["size"])
+		assert.Equal(t, volume.Spec.VolumeClassID, volumeBody["volume_type"])
+		assert.Equal(t, map[string]any{
+			"region:volume_id": volume.Name,
+		}, volumeBody["metadata"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprintf(w, `{"volume":{"id":"provider-id","name":"volume-%s"}}`, volume.Name)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := openstack.NewTestBlockStorageClient(srv.URL+"/", nil)
+
+	result, err := client.CreateVolume(t.Context(), volume, metadata)
+	require.NoError(t, err)
+	require.Equal(t, "provider-id", result.ID)
+}
+
+func TestDeleteVolumeUsesProviderID(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/volumes/provider-id", r.URL.Path)
+
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := openstack.NewTestBlockStorageClient(srv.URL+"/", nil)
+
+	require.NoError(t, client.DeleteVolume(t.Context(), "provider-id"))
+}
+
+func TestGetVolumeUsesStableNameAndExactMatch(t *testing.T) {
+	t.Parallel()
+
+	volume := &unikornv1.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "11111111-1111-1111-1111-111111111111",
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/volumes/detail", r.URL.Path)
+		assert.Equal(t, "volume-"+volume.Name, r.URL.Query().Get("name"))
+
+		w.Header().Set("Content-Type", "application/json")
+
+		fmt.Fprintf(w, `{"volumes":[
+			{"id":"prefix","name":"volume-%s-extra"},
+			{"id":"exact","name":"volume-%s"}
+		]}`, volume.Name, volume.Name)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := openstack.NewTestBlockStorageClient(srv.URL+"/", nil)
+
+	result, err := client.GetVolume(t.Context(), volume)
+	require.NoError(t, err)
+	require.Equal(t, &volumes.Volume{
+		ID:   "exact",
+		Name: "volume-" + volume.Name,
+	}, result)
+}
+
+func TestGetVolumeReturnsResourceNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		fmt.Fprint(w, `{"volumes":[]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := openstack.NewTestBlockStorageClient(srv.URL+"/", nil)
+	volume := &unikornv1.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "11111111-1111-1111-1111-111111111111",
+		},
+	}
+
+	result, err := client.GetVolume(t.Context(), volume)
+	require.Nil(t, result)
+	require.ErrorIs(t, err, coreerrors.ErrResourceNotFound)
+}
 
 func TestGetVolumeTypesAppliesSelectorVisibilityAndCache(t *testing.T) {
 	t.Parallel()

--- a/pkg/providers/internal/openstack/export_test.go
+++ b/pkg/providers/internal/openstack/export_test.go
@@ -249,6 +249,14 @@ func ReconcileNetwork(ctx context.Context, p *Provider, client NetworkInterface,
 	return p.reconcileNetwork(ctx, client, network)
 }
 
+func ReconcileVolume(ctx context.Context, client VolumeInterface, identity *unikornv1.Identity, volume *unikornv1.Volume) error {
+	return reconcileVolume(ctx, client, identity, volume)
+}
+
+func DeleteVolumeWithClient(ctx context.Context, client VolumeInterface, volume *unikornv1.Volume) error {
+	return deleteVolume(ctx, client, volume)
+}
+
 func ReconcileSubnet(ctx context.Context, p *Provider, client SubnetInterface, network *unikornv1.Network, openstackNetwork *NetworkExt) (*subnets.Subnet, error) {
 	return p.reconcileSubnet(ctx, client, network, openstackNetwork)
 }

--- a/pkg/providers/internal/openstack/interfaces.go
+++ b/pkg/providers/internal/openstack/interfaces.go
@@ -23,6 +23,7 @@ import (
 	"context"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/remoteconsoles"
@@ -198,6 +199,12 @@ type PlacementInterface interface {
 
 type VolumeTypeInterface interface {
 	GetVolumeTypes(ctx context.Context) ([]volumetypes.VolumeType, error)
+}
+
+type VolumeInterface interface {
+	GetVolume(ctx context.Context, volume *unikornv1.Volume) (*volumes.Volume, error)
+	CreateVolume(ctx context.Context, volume *unikornv1.Volume, metadata map[string]string) (*volumes.Volume, error)
+	DeleteVolume(ctx context.Context, id string) error
 }
 
 // BaremetalInterface lets the live monitor look up the Ironic node bound to a

--- a/pkg/providers/internal/openstack/mock/interfaces.go
+++ b/pkg/providers/internal/openstack/mock/interfaces.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	nodes "github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	volumes "github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
 	volumetypes "github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
 	flavors "github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	remoteconsoles "github.com/gophercloud/gophercloud/v2/openstack/compute/v2/remoteconsoles"
@@ -2504,6 +2505,73 @@ func (m *MockVolumeTypeInterface) GetVolumeTypes(ctx context.Context) ([]volumet
 func (mr *MockVolumeTypeInterfaceMockRecorder) GetVolumeTypes(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeTypes", reflect.TypeOf((*MockVolumeTypeInterface)(nil).GetVolumeTypes), ctx)
+}
+
+// MockVolumeInterface is a mock of VolumeInterface interface.
+type MockVolumeInterface struct {
+	ctrl     *gomock.Controller
+	recorder *MockVolumeInterfaceMockRecorder
+}
+
+// MockVolumeInterfaceMockRecorder is the mock recorder for MockVolumeInterface.
+type MockVolumeInterfaceMockRecorder struct {
+	mock *MockVolumeInterface
+}
+
+// NewMockVolumeInterface creates a new mock instance.
+func NewMockVolumeInterface(ctrl *gomock.Controller) *MockVolumeInterface {
+	mock := &MockVolumeInterface{ctrl: ctrl}
+	mock.recorder = &MockVolumeInterfaceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockVolumeInterface) EXPECT() *MockVolumeInterfaceMockRecorder {
+	return m.recorder
+}
+
+// CreateVolume mocks base method.
+func (m *MockVolumeInterface) CreateVolume(ctx context.Context, volume *v1alpha1.Volume, metadata map[string]string) (*volumes.Volume, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVolume", ctx, volume, metadata)
+	ret0, _ := ret[0].(*volumes.Volume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVolume indicates an expected call of CreateVolume.
+func (mr *MockVolumeInterfaceMockRecorder) CreateVolume(ctx, volume, metadata any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockVolumeInterface)(nil).CreateVolume), ctx, volume, metadata)
+}
+
+// DeleteVolume mocks base method.
+func (m *MockVolumeInterface) DeleteVolume(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVolume", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVolume indicates an expected call of DeleteVolume.
+func (mr *MockVolumeInterfaceMockRecorder) DeleteVolume(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockVolumeInterface)(nil).DeleteVolume), ctx, id)
+}
+
+// GetVolume mocks base method.
+func (m *MockVolumeInterface) GetVolume(ctx context.Context, volume *v1alpha1.Volume) (*volumes.Volume, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolume", ctx, volume)
+	ret0, _ := ret[0].(*volumes.Volume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolume indicates an expected call of GetVolume.
+func (mr *MockVolumeInterfaceMockRecorder) GetVolume(ctx, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolume", reflect.TypeOf((*MockVolumeInterface)(nil).GetVolume), ctx, volume)
 }
 
 // MockBaremetalInterface is a mock of BaremetalInterface interface.

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"net"
 	"net/http"
@@ -33,6 +34,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/roles"
 	"github.com/gophercloud/gophercloud/v2/openstack/image/v2/images"
@@ -140,7 +142,10 @@ type Provider struct {
 	imageCache *cache.RefreshAheadCache[types.Image, *types.Image]
 }
 
-var _ types.Provider = &Provider{}
+var (
+	_ types.Provider = &Provider{}
+	_ types.Volume   = &Provider{}
+)
 
 type Options struct {
 	// WarmImageCache enables startup-time image cache initialization.
@@ -375,6 +380,24 @@ func (p *Provider) networkFromServicePrincipal(ctx context.Context, identity *un
 	return client, nil
 }
 
+// blockStorageFromServicePrincipal gets a block storage client scoped to the
+// service principal's project.
+func (p *Provider) blockStorageFromServicePrincipal(ctx context.Context, identity *unikornv1.Identity) (VolumeInterface, error) {
+	provider, err := p.getProviderFromServicePrincipal(ctx, identity)
+	if err != nil {
+		return nil, err
+	}
+
+	region, _ := p.openstack.regionSnapshot()
+
+	client, err := NewBlockStorageClient(ctx, provider, region.Spec.Openstack.BlockStorage)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
 // privilegedNetworkFromServicePrincipal gets a network client scoped to the service principal's
 // project but with "manager" credentials.
 func (p *Provider) privilegedNetworkFromServicePrincipal(ctx context.Context, identity *unikornv1.Identity) (NetworkingInterface, error) {
@@ -487,6 +510,85 @@ func (p *Provider) Flavors(ctx context.Context) (types.FlavorList, error) {
 	}
 
 	return result, nil
+}
+
+func (p *Provider) VolumeClasses(ctx context.Context) (types.VolumeClassList, error) {
+	blockStorage, err := p.openstack.blockStorage(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resources, err := blockStorage.GetVolumeTypes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	region, _ := p.openstack.regionSnapshot()
+
+	return convertVolumeClasses(region, resources), nil
+}
+
+func convertVolumeClasses(region *unikornv1.Region, resources []volumetypes.VolumeType) types.VolumeClassList {
+	var config *unikornv1.OpenstackVolumeClassesSpec
+	if region != nil && region.Spec.Openstack != nil {
+		config = openstackVolumeClassesConfig(region.Spec.Openstack.BlockStorage)
+	}
+
+	result := make(types.VolumeClassList, 0, len(resources))
+
+	for i := range resources {
+		resource := &resources[i]
+
+		class := types.VolumeClass{
+			ID:          resource.ID,
+			Name:        resource.Name,
+			Description: resource.Description,
+		}
+
+		if metadata := volumeClassMetadata(config, resource.ID); metadata != nil {
+			class.Media = types.VolumeClassMedia(metadata.Media)
+			class.Encrypted = metadata.Encrypted
+
+			class.Performance = convertVolumeClassPerformance(metadata.Performance)
+		}
+
+		result = append(result, class)
+	}
+
+	return result
+}
+
+func volumeClassMetadata(config *unikornv1.OpenstackVolumeClassesSpec, id string) *unikornv1.VolumeClassMetadata {
+	if config == nil {
+		return nil
+	}
+
+	i := slices.IndexFunc(config.Metadata, func(metadata unikornv1.VolumeClassMetadata) bool {
+		return id == metadata.ID
+	})
+	if i < 0 {
+		return nil
+	}
+
+	return &config.Metadata[i]
+}
+
+func convertVolumeClassPerformance(in *unikornv1.VolumeClassPerformanceSpec) *types.VolumeClassPerformance {
+	if in == nil {
+		return nil
+	}
+
+	out := &types.VolumeClassPerformance{}
+
+	if in.MaxIOPS != nil {
+		out.MaxIOPS = ptr.To(*in.MaxIOPS)
+	}
+
+	if in.MaxThroughput != nil {
+		out.MaxThroughput = ptr.To(*in.MaxThroughput)
+	}
+
+	return out
 }
 
 // imageOS extracts the image OS from the image properties.
@@ -1858,6 +1960,98 @@ func (p *Provider) deleteNetwork(ctx context.Context, networking NetworkingInter
 	}
 
 	return nil
+}
+
+func volumeMetadata(identity *unikornv1.Identity, volume *unikornv1.Volume) map[string]string {
+	namespacedSystemMetadata := map[string]string{
+		"region:volume_id":         volume.Name,
+		"identity:organization_id": volume.Labels[coreconstants.OrganizationLabel],
+		"identity:project_id":      volume.Labels[coreconstants.ProjectLabel],
+		"region:region_id":         volume.Labels[constants.RegionLabel],
+		"region:network_id":        volume.Spec.NetworkID,
+		"region:identity_id":       identity.Name,
+	}
+
+	metadata := make(map[string]string, len(volume.Spec.Tags)+len(namespacedSystemMetadata))
+
+	for _, tag := range volume.Spec.Tags {
+		if key, ok := metadataKey(tag.Name); ok {
+			metadata[key] = tag.Value
+		}
+	}
+
+	maps.Copy(metadata, namespacedSystemMetadata)
+
+	return metadata
+}
+
+func reconcileVolume(ctx context.Context, blockStorage VolumeInterface, identity *unikornv1.Identity, volume *unikornv1.Volume) error {
+	logger := log.FromContext(ctx)
+
+	_, err := blockStorage.GetVolume(ctx, volume)
+	if err == nil {
+		logger.V(1).Info("volume already exists")
+
+		return nil
+	}
+
+	if !errors.Is(err, coreerrors.ErrResourceNotFound) {
+		return err
+	}
+
+	logger.V(1).Info("creating volume")
+
+	_, err = blockStorage.CreateVolume(ctx, volume, volumeMetadata(identity, volume))
+
+	return err
+}
+
+func (p *Provider) CreateVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error {
+	blockStorage, err := p.blockStorageFromServicePrincipal(ctx, identity)
+	if err != nil {
+		return err
+	}
+
+	return reconcileVolume(ctx, blockStorage, identity, volume)
+}
+
+func deleteVolume(ctx context.Context, blockStorage VolumeInterface, volume *unikornv1.Volume) error {
+	logger := log.FromContext(ctx)
+
+	openstackVolume, err := blockStorage.GetVolume(ctx, volume)
+	if err != nil {
+		if errors.Is(err, coreerrors.ErrResourceNotFound) {
+			return nil
+		}
+
+		return err
+	}
+
+	logger.V(1).Info("deleting volume")
+
+	if err := blockStorage.DeleteVolume(ctx, openstackVolume.ID); err != nil && !gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provider) DeleteVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error {
+	provisioned, err := p.openstackIdentityProvisioned(ctx, identity)
+	if err != nil {
+		return err
+	}
+
+	if !provisioned {
+		return nil
+	}
+
+	blockStorage, err := p.blockStorageFromServicePrincipal(ctx, identity)
+	if err != nil {
+		return err
+	}
+
+	return deleteVolume(ctx, blockStorage, volume)
 }
 
 // securityGroupRulePortRange expands a security group port into a start-end range as

--- a/pkg/providers/internal/openstack/provider_test.go
+++ b/pkg/providers/internal/openstack/provider_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/v2/openstack/image/v2/images"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/listeners"
@@ -56,6 +57,7 @@ import (
 	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack/mock"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -632,6 +634,19 @@ func TestDeleteServerNoopsWhenIdentityUnrealized(t *testing.T) {
 	require.NoError(t, p.DeleteServer(t.Context(), identity, server))
 }
 
+func TestDeleteVolumeNoopsWhenIdentityUnrealized(t *testing.T) {
+	t.Parallel()
+
+	region := providerNetworkRegionFixture()
+	identity := identityFixture()
+	volume := volumeFixture()
+
+	k8sClient := getClient(t, []client.Object{unrealizedOpenstackIdentityFixture(identity)})
+	p := openstack.NewTestProvider(k8sClient, region)
+
+	require.NoError(t, p.DeleteVolume(t.Context(), identity, volume))
+}
+
 // TestDeleteLoadBalancerNoopsWhenIdentityUnrealized verifies the delete is a
 // clean no-op when the backing identity has no project allocated yet.
 func TestDeleteLoadBalancerNoopsWhenIdentityUnrealized(t *testing.T) {
@@ -819,6 +834,35 @@ func withNetwork(network *regionv1.Network) func(*regionv1.Server) {
 func withTags(tags ...corev1.Tag) func(*regionv1.Server) {
 	return func(s *regionv1.Server) {
 		s.Spec.Tags = append(s.Spec.Tags, tags...)
+	}
+}
+
+func volumeFixture() *regionv1.Volume {
+	return &regionv1.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      string(uuid.NewUUID()),
+			Labels: map[string]string{
+				coreconstants.OrganizationLabel: organizationID,
+				coreconstants.ProjectLabel:      projectID,
+				constants.RegionLabel:           regionID,
+			},
+		},
+		Spec: regionv1.VolumeSpec{
+			Tags: corev1.TagList{
+				{
+					Name:  "example.unikorn-cloud.org/owner",
+					Value: "storage-team",
+				},
+				{
+					Name:  "region.unikorn-cloud.org/volume-id",
+					Value: "must-be-overwritten",
+				},
+			},
+			NetworkID:     "22222222-2222-2222-2222-222222222222",
+			VolumeClassID: "fast",
+			Size:          resource.MustParse("20Gi"),
+		},
 	}
 }
 
@@ -1799,6 +1843,91 @@ func TestReconcileLoadBalancerFloatingIP(t *testing.T) {
 		err := openstack.ReconcileLoadBalancerFloatingIP(t.Context(), p, networking, lb, vipPortID)
 		require.ErrorIs(t, err, coreerrors.ErrConsistency)
 		require.Nil(t, lb.Status.PublicIP)
+	})
+}
+
+func TestReconcileVolume(t *testing.T) {
+	t.Parallel()
+
+	identity := identityFixture()
+	volume := volumeFixture()
+	openstackVolume := &volumes.Volume{
+		ID:   "provider-volume-id",
+		Name: "volume-" + volume.Name,
+	}
+	metadata := map[string]string{
+		"example:owner":            "storage-team",
+		"region:volume_id":         volume.Name,
+		"identity:organization_id": organizationID,
+		"identity:project_id":      projectID,
+		"region:region_id":         regionID,
+		"region:network_id":        volume.Spec.NetworkID,
+		"region:identity_id":       identity.Name,
+	}
+
+	t.Run("ItDoesNotExist", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(nil, coreerrors.ErrResourceNotFound)
+		blockStorage.EXPECT().CreateVolume(t.Context(), volume, metadata).Return(openstackVolume, nil)
+
+		require.NoError(t, openstack.ReconcileVolume(t.Context(), blockStorage, identity, volume))
+	})
+
+	t.Run("ItExists", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(openstackVolume, nil)
+
+		require.NoError(t, openstack.ReconcileVolume(t.Context(), blockStorage, identity, volume))
+	})
+}
+
+func TestDeleteVolumeWithClient(t *testing.T) {
+	t.Parallel()
+
+	volume := volumeFixture()
+	openstackVolume := &volumes.Volume{
+		ID:   "provider-volume-id",
+		Name: "volume-" + volume.Name,
+	}
+
+	t.Run("ItDoesNotExist", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(nil, coreerrors.ErrResourceNotFound)
+
+		require.NoError(t, openstack.DeleteVolumeWithClient(t.Context(), blockStorage, volume))
+	})
+
+	t.Run("ItExists", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(openstackVolume, nil)
+		blockStorage.EXPECT().DeleteVolume(t.Context(), openstackVolume.ID).Return(nil)
+
+		require.NoError(t, openstack.DeleteVolumeWithClient(t.Context(), blockStorage, volume))
+	})
+
+	t.Run("ItDisappearsBeforeDelete", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(openstackVolume, nil)
+		blockStorage.EXPECT().DeleteVolume(t.Context(), openstackVolume.ID).Return(gophercloud.ErrUnexpectedResponseCode{
+			Actual: http.StatusNotFound,
+		})
+
+		require.NoError(t, openstack.DeleteVolumeWithClient(t.Context(), blockStorage, volume))
 	})
 }
 

--- a/pkg/providers/types/README.md
+++ b/pkg/providers/types/README.md
@@ -49,6 +49,11 @@ continue to be passed directly through many provider interface methods.
   resource. It carries the immutable provider identifier and user-facing
   metadata that Region configuration can filter or enrich before a public API
   exposes the inventory.
+- `Volume` is a focused create/delete capability that accepts the native
+  `unikornv1.Volume` lifecycle intent. It is deliberately separate from the
+  full `Provider` composition during the staged rollout, and it does not expose
+  discovery, observed state, VolumeClass inventory, or server attachment
+  operations.
 - `ServerCreateOptions` carries launch-time derived inputs without forcing them
   into the persisted `Server` CRD shape.
 - Exported errors such as `ErrImageNotReadyForUpload` and

--- a/pkg/providers/types/interfaces.go
+++ b/pkg/providers/types/interfaces.go
@@ -91,6 +91,14 @@ type LoadBalancer interface {
 	DeleteLoadBalancer(ctx context.Context, identity *unikornv1.Identity, loadBalancer *unikornv1.LoadBalancer) error
 }
 
+// Volume manages provider-backed block-storage volume lifecycle.
+type Volume interface {
+	// CreateVolume creates the provider volume described by the Region Volume.
+	CreateVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error
+	// DeleteVolume idempotently deletes the provider volume described by the Region Volume.
+	DeleteVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error
+}
+
 type Server interface {
 	// CreateServer creates a new server.
 	CreateServer(ctx context.Context, identity *unikornv1.Identity, server *unikornv1.Server, options *ServerCreateOptions) error

--- a/pkg/providers/types/mock/interfaces.go
+++ b/pkg/providers/types/mock/interfaces.go
@@ -435,6 +435,57 @@ func (mr *MockLoadBalancerMockRecorder) DeleteLoadBalancer(ctx, identity, loadBa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancer", reflect.TypeOf((*MockLoadBalancer)(nil).DeleteLoadBalancer), ctx, identity, loadBalancer)
 }
 
+// MockVolume is a mock of Volume interface.
+type MockVolume struct {
+	ctrl     *gomock.Controller
+	recorder *MockVolumeMockRecorder
+}
+
+// MockVolumeMockRecorder is the mock recorder for MockVolume.
+type MockVolumeMockRecorder struct {
+	mock *MockVolume
+}
+
+// NewMockVolume creates a new mock instance.
+func NewMockVolume(ctrl *gomock.Controller) *MockVolume {
+	mock := &MockVolume{ctrl: ctrl}
+	mock.recorder = &MockVolumeMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockVolume) EXPECT() *MockVolumeMockRecorder {
+	return m.recorder
+}
+
+// CreateVolume mocks base method.
+func (m *MockVolume) CreateVolume(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVolume", ctx, identity, volume)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateVolume indicates an expected call of CreateVolume.
+func (mr *MockVolumeMockRecorder) CreateVolume(ctx, identity, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockVolume)(nil).CreateVolume), ctx, identity, volume)
+}
+
+// DeleteVolume mocks base method.
+func (m *MockVolume) DeleteVolume(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVolume", ctx, identity, volume)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVolume indicates an expected call of DeleteVolume.
+func (mr *MockVolumeMockRecorder) DeleteVolume(ctx, identity, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockVolume)(nil).DeleteVolume), ctx, identity, volume)
+}
+
 // MockServer is a mock of Server interface.
 type MockServer struct {
 	ctrl     *gomock.Controller

--- a/pkg/providers/types/volume_test.go
+++ b/pkg/providers/types/volume_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types_test
+
+import (
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
+	"github.com/unikorn-cloud/region/pkg/providers/types/mock"
+)
+
+func TestVolumeMockExercisesLifecycleContract(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+	provider := mock.NewMockVolume(controller)
+	identity := &unikornv1.Identity{}
+	volume := &unikornv1.Volume{}
+
+	provider.EXPECT().CreateVolume(t.Context(), identity, volume).Return(nil)
+	provider.EXPECT().DeleteVolume(t.Context(), identity, volume).Return(nil)
+
+	var capability types.Volume = provider
+
+	if err := capability.CreateVolume(t.Context(), identity, volume); err != nil {
+		t.Fatalf("CreateVolume() error = %v", err)
+	}
+
+	if err := capability.DeleteVolume(t.Context(), identity, volume); err != nil {
+		t.Fatalf("DeleteVolume() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add a focused provider-facing Volume capability for create and delete using the native `unikornv1.Volume` lifecycle intent
- implement project-scoped Cinder volume rediscovery, creation, metadata linkage, and idempotent deletion
- use the stable `volume-<Region Volume UUID>` name and exact-match filtered Cinder results
- regenerate provider mocks and update the affected provider package documentation

## Scope

This is the first implementation-backed Volume lifecycle slice from STO-139. Provider observation/status mapping, VolumeClass inventory changes, and server attach/detach operations remain outside this PR.

## Validation

- `make touch`
- `make license`
- `make validate`
- `make lint`
- `make generate`
- generated-code status audit
- `make test-unit`
- `git diff --check`

Linear: STO-139