### PR TITLE
Implement OpenStack Volume attach/detach provider slice

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -20,12 +20,13 @@ The useful way to read it is not as a directory tree, but as one system:
 - monitors project observed provider truth back into status and metrics
 - providers bind the region model to real or simulated clouds
 - `Volume` is an internal Region storage model today: a network-anchored,
-  quota-carrying block storage resource. OpenStack create/delete provider
-  behavior exists, while its public API, controller, and observed-state
-  projection remain later lifecycle slices
+  quota-carrying block storage resource. OpenStack create/delete and server
+  attachment provider behavior exists, while its public API, controller, and
+  observed-state projection remain later lifecycle slices
 - `Server` now carries the internal attach-existing-only block volume intent
-  and observed per-volume attachment rows; public API projection and provider
-  reconciliation remain separate follow-up work
+  and observed per-volume attachment rows. The provider boundary and OpenStack
+  Nova attach/detach implementation exist; public API projection and
+  server-controller reconciliation remain separate follow-up work
 
 ## Recommended Reading Order
 

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -94,9 +94,11 @@ stored objects rely on for linkage, migration, and operational coordination.
   server-created volume templates are deliberately excluded from the first
   implementation. `Server.Status.Volumes` is keyed by the same Volume ID and
   reports per-volume attachment reconciliation state and the observed guest
-  device name for later controller and monitor work. This package only defines
-  the persisted shape; Nova calls, reference placement, and public API projection
-  live in later layers/tickets.
+  device name for later controller and monitor work. The provider layer now
+  supplies a server-owned attach/detach boundary and the OpenStack provider
+  realizes it with Nova, but this package still only owns the persisted shape;
+  reference placement, claim/locking behavior, controller reconciliation, and
+  public API projection live in later layers/tickets.
 - The `Network -> Volume` graph edge is declared as containment for future
   behavior: Network scope propagates to Volume; co-location is implicit; Volume
   holds a reverse deletion-blocking relationship to Network for its lifetime;

--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -47,7 +47,8 @@ packages are the concrete provider implementations.
     operator-authored capacity bounds
 - `types.Provider` extends that common base with the broader image, identity,
   network, security-group, load-balancer, server, console, and snapshot
-  lifecycle surfaces.
+  lifecycle surfaces. The server surface includes attaching and detaching an
+  existing Region `Volume`; attachment intent remains owned by the `Server`.
 - The provider abstraction is intentionally mixed:
   - CRD-backed lifecycle operations still speak in repo-native
     `pkg/apis/unikorn/v1alpha1` resource types
@@ -83,6 +84,12 @@ packages are the concrete provider implementations.
     consumers are gone: at delete time it is either realized-and-complete or
     never realized. Callers must therefore never gate a delete on identity
     readiness or recorded status — that belongs to this layer.
+- `DetachVolume` follows the same absent-means-converged teardown rule: a
+  missing provider server, volume, or attachment is success. `AttachVolume`
+  instead requires both backing resources and reports semantic not-found when
+  either is absent. Concrete provider conflicts are normalized to the shared
+  conflict sentinel; provider failures that are neither not-found nor conflict
+  remain available to callers for diagnosis.
 - Providers must tolerate changing backing credentials and region state rather
   than assuming client material is static for process lifetime.
   Credential rotation, secret refresh, and region configuration refresh are part
@@ -105,6 +112,8 @@ packages are the concrete provider implementations.
   - it implements the full `types.Provider` contract
   - it prefers deterministic lookup against OpenStack over broad mirrored CRD
     state
+  - it resolves existing Cinder volumes and realizes server-owned attachment
+    intent through Nova volume-attachment create/delete operations
   - it still carries a shrinking amount of persisted provider state via
     `OpenstackIdentity`
 - [./internal/kubernetes](./internal/kubernetes/README.md) currently implements
@@ -120,6 +129,7 @@ packages are the concrete provider implementations.
   - it exists to push broad integration coverage left
   - it is useful for deterministic load, race, and bottleneck testing at higher
     layers without requiring a real cloud deployment
+  - server volume attach/detach is currently explicit unsupported behavior
 
 ## Caveats
 

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -255,7 +255,8 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   - identity-scoped resources use fixed generated names
   - network lookups rely on deterministic names
   - Cinder volumes use `volume-{Region Volume UUID}` inside the service
-    principal's project; create and delete both rediscover that exact name
+    principal's project; create, delete, attach, and detach rediscover that
+    exact name
   - server metadata is written deliberately as both a control-plane lookup aid
     and an in-guest linkage surface exposed through the metadata service
   - legacy camelCase server metadata keys remain frozen for backwards
@@ -275,8 +276,9 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
     success, and treats an absent or not-yet-project-backed
     `OpenstackIdentity` as proof that no provider volume could have been
     created
-  - observed size/status mapping, VolumeClass inventory, and Nova
-    attach/detach are intentionally outside this lifecycle slice
+  - observed size/status mapping and VolumeClass inventory are intentionally
+    outside this lifecycle slice; Nova attach/detach is the separate
+    server-owned provider slice described below
 - Flavor export is a hybrid model: OpenStack discovers the flavor inventory, but
   region configuration can enrich or override user-facing flavor metadata such
   as architecture, baremetal status, and GPU semantics. Architecture resolves
@@ -307,6 +309,41 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   calls and is refreshed only when Region configuration or credentials change.
   Production Region CRs must contain their curated IDs before this fail-closed
   behavior is rolled out.
+- Existing-volume server attachments are a separate, project-scoped write path
+  from Region-scoped `VolumeClass` inventory. The provider creates ephemeral
+  compute and block-storage clients from the service principal, rediscovers the
+  Nova server and detailed Cinder volume, and uses Cinder's attachment rows as
+  the normal-path observation before calling Nova's volume-attachment
+  create/delete API. Cinder volume lifecycle observation is not part of this
+  slice. The Cinder name filter is treated as fuzzy and is post-filtered against
+  the exact stable name `volume-{Volume.Name}`; duplicate exact matches fail
+  closed with `ErrConsistency`. Only the optional guest device name crosses the
+  provider-neutral boundary; Nova and Cinder IDs and Gophercloud objects remain
+  internal.
+
+  Attachment behavior is deliberately asymmetric:
+  - attach requires both the server and volume; either missing resource maps to
+    `ErrResourceNotFound`
+  - a Cinder attachment already present on the requested server is successful
+    and returns its observed device without a Nova read
+  - an attachment to any other server maps to `ErrConflict`; Region does not
+    support multi-attach even when the Cinder volume is multiattach-capable
+  - when Cinder reports no attachment, attach calls Nova create directly; a
+    create `409 Conflict` is followed by one Nova attachment read so concurrent
+    creation of the same desired attachment becomes success, while an
+    unresolved conflict maps to `ErrConflict`
+  - detach calls Nova delete only when Cinder reports an attachment to the
+    requested server; a missing server, volume, requested-server attachment, or
+    Nova delete `404` is success because detached state already holds, including
+    when the volume remains attached only to another server
+  - a Nova delete `409 Conflict` maps to `ErrConflict`; other provider failures
+    are preserved
+  - detach also no-ops when the backing OpenStack identity was never realized,
+    matching the provider's other teardown contracts
+
+  Attachment intent and observed rows remain on `Server.Spec.Volumes` and
+  `Server.Status.Volumes`; this provider slice does not mirror attachments into
+  `Volume.Status`, claim volumes, or reconcile server controllers.
 - Image handling is a first-class contract surface here:
   - OpenStack image properties are validated against a schema
   - public images can additionally be signature-verified
@@ -360,7 +397,7 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   `Active` state so API responses still see a coherent live signal rather than
   failing the monitor path.
 - Some OpenStack list APIs are not safe to treat as exact lookup, notably
-  server, network, and Octavia load-balancer `name` filters:
+  server, network, Cinder volume, and Octavia load-balancer `name` filters:
   - `name` filters behave like prefix or regular-expression matches rather than
     strict equality
   - this package therefore re-checks exact names after listing to avoid aliasing

--- a/pkg/providers/internal/openstack/compute.go
+++ b/pkg/providers/internal/openstack/compute.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/remoteconsoles"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servergroups"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/volumeattach"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -266,6 +267,46 @@ func (c *ComputeClient) GetServer(ctx context.Context, server *unikornv1.Server)
 	}
 
 	return &result[index], nil
+}
+
+func (c *ComputeClient) GetVolumeAttachment(ctx context.Context, serverID, volumeID string) (*volumeattach.VolumeAttachment, error) {
+	spanAttributes := trace.WithAttributes(
+		attribute.String("compute.server.id", serverID),
+		attribute.String("block_storage.volume.id", volumeID),
+	)
+
+	_, span := traceStart(ctx, "GET /compute/v2/servers/{serverID}/os-volume_attachments/{volumeID}", spanAttributes)
+	defer span.End()
+
+	return volumeattach.Get(ctx, c.client, serverID, volumeID).Extract()
+}
+
+func (c *ComputeClient) CreateVolumeAttachment(ctx context.Context, serverID, volumeID string) (*volumeattach.VolumeAttachment, error) {
+	spanAttributes := trace.WithAttributes(
+		attribute.String("compute.server.id", serverID),
+		attribute.String("block_storage.volume.id", volumeID),
+	)
+
+	_, span := traceStart(ctx, "POST /compute/v2/servers/{serverID}/os-volume_attachments", spanAttributes)
+	defer span.End()
+
+	opts := volumeattach.CreateOpts{
+		VolumeID: volumeID,
+	}
+
+	return volumeattach.Create(ctx, c.client, serverID, opts).Extract()
+}
+
+func (c *ComputeClient) DeleteVolumeAttachment(ctx context.Context, serverID, volumeID string) error {
+	spanAttributes := trace.WithAttributes(
+		attribute.String("compute.server.id", serverID),
+		attribute.String("block_storage.volume.id", volumeID),
+	)
+
+	_, span := traceStart(ctx, "DELETE /compute/v2/servers/{serverID}/os-volume_attachments/{volumeID}", spanAttributes)
+	defer span.End()
+
+	return volumeattach.Delete(ctx, c.client, serverID, volumeID).ExtractErr()
 }
 
 func (c *ComputeClient) CreateServer(ctx context.Context, server *unikornv1.Server, keyName string, networks []servers.Network, serverGroupID *string, metadata map[string]string) (*servers.Server, error) {

--- a/pkg/providers/internal/openstack/compute_volume_attachment_test.go
+++ b/pkg/providers/internal/openstack/compute_volume_attachment_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack"
+)
+
+func TestComputeVolumeAttachmentOperations(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serverID = "server-id"
+		volumeID = "volume-id"
+		device   = "/dev/vdb"
+	)
+
+	var (
+		createBody map[string]any
+		requests   []string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/servers/"+serverID+"/os-volume_attachments":
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"volumeAttachment":{"device":%q,"volumeId":%q,"serverId":%q}}`, device, volumeID, serverID)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/servers/"+serverID+"/os-volume_attachments/"+volumeID:
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"volumeAttachment":{"device":%q,"volumeId":%q,"serverId":%q}}`, device, volumeID, serverID)
+
+		case r.Method == http.MethodDelete && r.URL.Path == "/servers/"+serverID+"/os-volume_attachments/"+volumeID:
+			w.WriteHeader(http.StatusAccepted)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := openstack.NewTestComputeClient(srv.URL + "/")
+
+	created, err := client.CreateVolumeAttachment(t.Context(), serverID, volumeID)
+	require.NoError(t, err)
+	require.Equal(t, device, created.Device)
+	require.Equal(t, volumeID, created.VolumeID)
+	require.Equal(t, serverID, created.ServerID)
+	require.Equal(t, map[string]any{
+		"volumeAttachment": map[string]any{
+			"volumeId": volumeID,
+		},
+	}, createBody)
+
+	found, err := client.GetVolumeAttachment(t.Context(), serverID, volumeID)
+	require.NoError(t, err)
+	require.Equal(t, created, found)
+
+	require.NoError(t, client.DeleteVolumeAttachment(t.Context(), serverID, volumeID))
+	require.Equal(t, []string{
+		"POST /servers/server-id/os-volume_attachments",
+		"GET /servers/server-id/os-volume_attachments/volume-id",
+		"DELETE /servers/server-id/os-volume_attachments/volume-id",
+	}, requests)
+}

--- a/pkg/providers/internal/openstack/export_test.go
+++ b/pkg/providers/internal/openstack/export_test.go
@@ -326,6 +326,14 @@ func CreateServerWithClients(ctx context.Context, p *Provider, networking Networ
 	return p.createServer(ctx, networking, compute, server, options, keyName, nil)
 }
 
+func AttachVolumeWithClients(ctx context.Context, compute ComputeInterface, blockStorage VolumeInterface, server *unikornv1.Server, volume *unikornv1.Volume) (*types.ServerVolumeAttachment, error) {
+	return attachVolume(ctx, compute, blockStorage, server, volume)
+}
+
+func DetachVolumeWithClients(ctx context.Context, compute ComputeInterface, blockStorage VolumeInterface, server *unikornv1.Server, volume *unikornv1.Volume) error {
+	return detachVolume(ctx, compute, blockStorage, server, volume)
+}
+
 func ResolveServerKeyName(server *unikornv1.Server, identity *unikornv1.OpenstackIdentity) string {
 	return resolveServerKeyName(server, identity)
 }

--- a/pkg/providers/internal/openstack/interfaces.go
+++ b/pkg/providers/internal/openstack/interfaces.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/remoteconsoles"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servergroups"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/volumeattach"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/monitors"
@@ -185,12 +186,19 @@ type ServerInterface interface {
 	CreateImageFromServer(ctx context.Context, id string, opts *servers.CreateImageOpts) (string, error)
 }
 
+type VolumeAttachmentInterface interface {
+	GetVolumeAttachment(ctx context.Context, serverID, volumeID string) (*volumeattach.VolumeAttachment, error)
+	CreateVolumeAttachment(ctx context.Context, serverID, volumeID string) (*volumeattach.VolumeAttachment, error)
+	DeleteVolumeAttachment(ctx context.Context, serverID, volumeID string) error
+}
+
 type ComputeInterface interface {
 	KeypairInterface
 	FlavorInterface
 	ServerGroupInterface
 	ComputeQuotaInterface
 	ServerInterface
+	VolumeAttachmentInterface
 }
 
 type PlacementInterface interface {

--- a/pkg/providers/internal/openstack/mock/interfaces.go
+++ b/pkg/providers/internal/openstack/mock/interfaces.go
@@ -19,6 +19,7 @@ import (
 	remoteconsoles "github.com/gophercloud/gophercloud/v2/openstack/compute/v2/remoteconsoles"
 	servergroups "github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servergroups"
 	servers "github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	volumeattach "github.com/gophercloud/gophercloud/v2/openstack/compute/v2/volumeattach"
 	listeners "github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/listeners"
 	loadbalancers "github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/loadbalancers"
 	monitors "github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/monitors"
@@ -2176,6 +2177,73 @@ func (mr *MockServerInterfaceMockRecorder) StopServer(ctx, id any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopServer", reflect.TypeOf((*MockServerInterface)(nil).StopServer), ctx, id)
 }
 
+// MockVolumeAttachmentInterface is a mock of VolumeAttachmentInterface interface.
+type MockVolumeAttachmentInterface struct {
+	ctrl     *gomock.Controller
+	recorder *MockVolumeAttachmentInterfaceMockRecorder
+}
+
+// MockVolumeAttachmentInterfaceMockRecorder is the mock recorder for MockVolumeAttachmentInterface.
+type MockVolumeAttachmentInterfaceMockRecorder struct {
+	mock *MockVolumeAttachmentInterface
+}
+
+// NewMockVolumeAttachmentInterface creates a new mock instance.
+func NewMockVolumeAttachmentInterface(ctrl *gomock.Controller) *MockVolumeAttachmentInterface {
+	mock := &MockVolumeAttachmentInterface{ctrl: ctrl}
+	mock.recorder = &MockVolumeAttachmentInterfaceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockVolumeAttachmentInterface) EXPECT() *MockVolumeAttachmentInterfaceMockRecorder {
+	return m.recorder
+}
+
+// CreateVolumeAttachment mocks base method.
+func (m *MockVolumeAttachmentInterface) CreateVolumeAttachment(ctx context.Context, serverID, volumeID string) (*volumeattach.VolumeAttachment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVolumeAttachment", ctx, serverID, volumeID)
+	ret0, _ := ret[0].(*volumeattach.VolumeAttachment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVolumeAttachment indicates an expected call of CreateVolumeAttachment.
+func (mr *MockVolumeAttachmentInterfaceMockRecorder) CreateVolumeAttachment(ctx, serverID, volumeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolumeAttachment", reflect.TypeOf((*MockVolumeAttachmentInterface)(nil).CreateVolumeAttachment), ctx, serverID, volumeID)
+}
+
+// DeleteVolumeAttachment mocks base method.
+func (m *MockVolumeAttachmentInterface) DeleteVolumeAttachment(ctx context.Context, serverID, volumeID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVolumeAttachment", ctx, serverID, volumeID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVolumeAttachment indicates an expected call of DeleteVolumeAttachment.
+func (mr *MockVolumeAttachmentInterfaceMockRecorder) DeleteVolumeAttachment(ctx, serverID, volumeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolumeAttachment", reflect.TypeOf((*MockVolumeAttachmentInterface)(nil).DeleteVolumeAttachment), ctx, serverID, volumeID)
+}
+
+// GetVolumeAttachment mocks base method.
+func (m *MockVolumeAttachmentInterface) GetVolumeAttachment(ctx context.Context, serverID, volumeID string) (*volumeattach.VolumeAttachment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeAttachment", ctx, serverID, volumeID)
+	ret0, _ := ret[0].(*volumeattach.VolumeAttachment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolumeAttachment indicates an expected call of GetVolumeAttachment.
+func (mr *MockVolumeAttachmentInterfaceMockRecorder) GetVolumeAttachment(ctx, serverID, volumeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeAttachment", reflect.TypeOf((*MockVolumeAttachmentInterface)(nil).GetVolumeAttachment), ctx, serverID, volumeID)
+}
+
 // MockComputeInterface is a mock of ComputeInterface interface.
 type MockComputeInterface struct {
 	ctrl     *gomock.Controller
@@ -2273,6 +2341,21 @@ func (mr *MockComputeInterfaceMockRecorder) CreateServerGroup(ctx, name any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServerGroup", reflect.TypeOf((*MockComputeInterface)(nil).CreateServerGroup), ctx, name)
 }
 
+// CreateVolumeAttachment mocks base method.
+func (m *MockComputeInterface) CreateVolumeAttachment(ctx context.Context, serverID, volumeID string) (*volumeattach.VolumeAttachment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVolumeAttachment", ctx, serverID, volumeID)
+	ret0, _ := ret[0].(*volumeattach.VolumeAttachment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVolumeAttachment indicates an expected call of CreateVolumeAttachment.
+func (mr *MockComputeInterfaceMockRecorder) CreateVolumeAttachment(ctx, serverID, volumeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolumeAttachment", reflect.TypeOf((*MockComputeInterface)(nil).CreateVolumeAttachment), ctx, serverID, volumeID)
+}
+
 // DeleteKeypair mocks base method.
 func (m *MockComputeInterface) DeleteKeypair(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
@@ -2315,6 +2398,20 @@ func (mr *MockComputeInterfaceMockRecorder) DeleteServerGroup(ctx, id any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServerGroup", reflect.TypeOf((*MockComputeInterface)(nil).DeleteServerGroup), ctx, id)
 }
 
+// DeleteVolumeAttachment mocks base method.
+func (m *MockComputeInterface) DeleteVolumeAttachment(ctx context.Context, serverID, volumeID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVolumeAttachment", ctx, serverID, volumeID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteVolumeAttachment indicates an expected call of DeleteVolumeAttachment.
+func (mr *MockComputeInterfaceMockRecorder) DeleteVolumeAttachment(ctx, serverID, volumeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolumeAttachment", reflect.TypeOf((*MockComputeInterface)(nil).DeleteVolumeAttachment), ctx, serverID, volumeID)
+}
+
 // GetFlavors mocks base method.
 func (m *MockComputeInterface) GetFlavors(ctx context.Context) ([]flavors.Flavor, error) {
 	m.ctrl.T.Helper()
@@ -2343,6 +2440,21 @@ func (m *MockComputeInterface) GetServer(ctx context.Context, server *v1alpha1.S
 func (mr *MockComputeInterfaceMockRecorder) GetServer(ctx, server any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServer", reflect.TypeOf((*MockComputeInterface)(nil).GetServer), ctx, server)
+}
+
+// GetVolumeAttachment mocks base method.
+func (m *MockComputeInterface) GetVolumeAttachment(ctx context.Context, serverID, volumeID string) (*volumeattach.VolumeAttachment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeAttachment", ctx, serverID, volumeID)
+	ret0, _ := ret[0].(*volumeattach.VolumeAttachment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolumeAttachment indicates an expected call of GetVolumeAttachment.
+func (mr *MockComputeInterfaceMockRecorder) GetVolumeAttachment(ctx, serverID, volumeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeAttachment", reflect.TypeOf((*MockComputeInterface)(nil).GetVolumeAttachment), ctx, serverID, volumeID)
 }
 
 // RebootServer mocks base method.

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -3498,10 +3498,10 @@ func (p *Provider) updateServerStateWithClients(
 	ctx context.Context,
 	identity *unikornv1.Identity,
 	server *unikornv1.Server,
-	compute ComputeInterface,
+	serverClient ServerInterface,
 	baremetalForPhase func(context.Context, *unikornv1.Identity) (BaremetalInterface, error),
 ) error {
-	openstackServer, err := compute.GetServer(ctx, server)
+	openstackServer, err := serverClient.GetServer(ctx, server)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/internal/openstack/provider_volume_attachment_test.go
+++ b/pkg/providers/internal/openstack/provider_volume_attachment_test.go
@@ -1,0 +1,401 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/volumeattach"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack"
+	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack/mock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	providerVolumeID = "provider-volume-id"
+	otherServerID    = "other-server-id"
+	volumeDevice     = "/dev/vdb"
+)
+
+var errVolumeAttachmentProvider = errors.New("nova unavailable")
+
+func volumeAttachmentVolumeFixture() *regionv1.Volume {
+	return &regionv1.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aaaaaaaa-0000-0000-0000-000000000001",
+		},
+	}
+}
+
+func cinderVolumeFixture(volume *regionv1.Volume) *volumes.Volume {
+	return &volumes.Volume{
+		ID:   providerVolumeID,
+		Name: "volume-" + volume.Name,
+	}
+}
+
+func cinderVolumeWithAttachment(volume *volumes.Volume, serverID string, multiattach bool) *volumes.Volume {
+	result := *volume
+	result.Multiattach = multiattach
+	result.Attachments = []volumes.Attachment{
+		{
+			AttachmentID: "provider-attachment-id",
+			Device:       volumeDevice,
+			ID:           volume.ID,
+			ServerID:     serverID,
+			VolumeID:     volume.ID,
+		},
+	}
+
+	return &result
+}
+
+func novaVolumeAttachmentFixture(server *servers.Server, volume *volumes.Volume) *volumeattach.VolumeAttachment {
+	return &volumeattach.VolumeAttachment{
+		Device:   volumeDevice,
+		VolumeID: volume.ID,
+		ServerID: server.ID,
+	}
+}
+
+func requireVolumeAttachment(t *testing.T, attachmentDevice *string) {
+	t.Helper()
+
+	require.NotNil(t, attachmentDevice)
+	require.Equal(t, volumeDevice, *attachmentDevice)
+}
+
+func TestAttachVolume(t *testing.T) {
+	t.Parallel()
+
+	server := serverFixture()
+	volume := volumeAttachmentVolumeFixture()
+	openstackServer := openstackServerFixture(server)
+	cinderVolume := cinderVolumeFixture(volume)
+	novaAttachment := novaVolumeAttachmentFixture(openstackServer, cinderVolume)
+	notFound := gophercloud.ErrUnexpectedResponseCode{Actual: http.StatusNotFound}
+
+	t.Run("AttachesExistingVolume", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
+		compute.EXPECT().CreateVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(novaAttachment, nil)
+
+		attachment, err := openstack.AttachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.NoError(t, err)
+		require.NotNil(t, attachment)
+		requireVolumeAttachment(t, attachment.Device)
+	})
+
+	t.Run("AlreadyAttachedIsIdempotent", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		attachedVolume := cinderVolumeWithAttachment(cinderVolume, openstackServer.ID, false)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(attachedVolume, nil)
+
+		attachment, err := openstack.AttachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.NoError(t, err)
+		require.NotNil(t, attachment)
+		requireVolumeAttachment(t, attachment.Device)
+	})
+
+	t.Run("AttachedToDifferentServerReturnsConflictEvenWhenMultiattachCapable", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		attachedVolume := cinderVolumeWithAttachment(cinderVolume, otherServerID, true)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(attachedVolume, nil)
+
+		attachment, err := openstack.AttachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.ErrorIs(t, err, coreerrors.ErrConflict)
+		require.Nil(t, attachment)
+	})
+
+	t.Run("MissingServerReturnsNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(nil, coreerrors.ErrResourceNotFound)
+
+		attachment, err := openstack.AttachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.ErrorIs(t, err, coreerrors.ErrResourceNotFound)
+		require.Nil(t, attachment)
+	})
+
+	t.Run("MissingVolumeReturnsNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(nil, coreerrors.ErrResourceNotFound)
+
+		attachment, err := openstack.AttachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.ErrorIs(t, err, coreerrors.ErrResourceNotFound)
+		require.Nil(t, attachment)
+	})
+
+	t.Run("CreateNotFoundReturnsNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
+		compute.EXPECT().CreateVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(nil, notFound)
+
+		attachment, err := openstack.AttachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.ErrorIs(t, err, coreerrors.ErrResourceNotFound)
+		require.Nil(t, attachment)
+	})
+
+	t.Run("ConcurrentAttachConflictBecomesSuccess", func(t *testing.T) {
+		t.Parallel()
+
+		conflict := gophercloud.ErrUnexpectedResponseCode{Actual: http.StatusConflict}
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
+		compute.EXPECT().CreateVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(nil, conflict)
+		compute.EXPECT().GetVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(novaAttachment, nil)
+
+		attachment, err := openstack.AttachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.NoError(t, err)
+		require.NotNil(t, attachment)
+		requireVolumeAttachment(t, attachment.Device)
+	})
+
+	t.Run("UnresolvedConflictReturnsConflict", func(t *testing.T) {
+		t.Parallel()
+
+		conflict := gophercloud.ErrUnexpectedResponseCode{Actual: http.StatusConflict}
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
+		compute.EXPECT().CreateVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(nil, conflict)
+		compute.EXPECT().GetVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(nil, notFound)
+
+		attachment, err := openstack.AttachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.ErrorIs(t, err, coreerrors.ErrConflict)
+		require.Nil(t, attachment)
+	})
+
+	t.Run("ProviderErrorIsPreserved", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
+		compute.EXPECT().CreateVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(nil, errVolumeAttachmentProvider)
+
+		attachment, err := openstack.AttachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.ErrorIs(t, err, errVolumeAttachmentProvider)
+		require.Nil(t, attachment)
+	})
+}
+
+func TestDetachVolume(t *testing.T) {
+	t.Parallel()
+
+	server := serverFixture()
+	volume := volumeAttachmentVolumeFixture()
+	openstackServer := openstackServerFixture(server)
+	cinderVolume := cinderVolumeFixture(volume)
+	notFound := gophercloud.ErrUnexpectedResponseCode{Actual: http.StatusNotFound}
+
+	t.Run("DetachesExistingVolume", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		attachedVolume := cinderVolumeWithAttachment(cinderVolume, openstackServer.ID, false)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(attachedVolume, nil)
+		compute.EXPECT().DeleteVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(nil)
+
+		require.NoError(t, openstack.DetachVolumeWithClients(t.Context(), compute, blockStorage, server, volume))
+	})
+
+	t.Run("AlreadyDetachedIsIdempotent", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
+
+		require.NoError(t, openstack.DetachVolumeWithClients(t.Context(), compute, blockStorage, server, volume))
+	})
+
+	t.Run("AttachedOnlyToDifferentServerIsIdempotent", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		attachedVolume := cinderVolumeWithAttachment(cinderVolume, otherServerID, true)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(attachedVolume, nil)
+
+		require.NoError(t, openstack.DetachVolumeWithClients(t.Context(), compute, blockStorage, server, volume))
+	})
+
+	t.Run("MissingServerIsIdempotent", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(nil, coreerrors.ErrResourceNotFound)
+
+		require.NoError(t, openstack.DetachVolumeWithClients(t.Context(), compute, blockStorage, server, volume))
+	})
+
+	t.Run("MissingVolumeIsIdempotent", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(nil, coreerrors.ErrResourceNotFound)
+
+		require.NoError(t, openstack.DetachVolumeWithClients(t.Context(), compute, blockStorage, server, volume))
+	})
+
+	t.Run("DeleteNotFoundIsIdempotent", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		attachedVolume := cinderVolumeWithAttachment(cinderVolume, openstackServer.ID, false)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(attachedVolume, nil)
+		compute.EXPECT().DeleteVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(notFound)
+
+		require.NoError(t, openstack.DetachVolumeWithClients(t.Context(), compute, blockStorage, server, volume))
+	})
+
+	t.Run("ConflictReturnsConflict", func(t *testing.T) {
+		t.Parallel()
+
+		conflict := gophercloud.ErrUnexpectedResponseCode{Actual: http.StatusConflict}
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		attachedVolume := cinderVolumeWithAttachment(cinderVolume, openstackServer.ID, false)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(attachedVolume, nil)
+		compute.EXPECT().DeleteVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(conflict)
+
+		err := openstack.DetachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.ErrorIs(t, err, coreerrors.ErrConflict)
+	})
+
+	t.Run("ProviderErrorIsPreserved", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		compute := mock.NewMockComputeInterface(c)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		attachedVolume := cinderVolumeWithAttachment(cinderVolume, openstackServer.ID, false)
+
+		compute.EXPECT().GetServer(t.Context(), server).Return(openstackServer, nil)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(attachedVolume, nil)
+		compute.EXPECT().DeleteVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(errVolumeAttachmentProvider)
+
+		err := openstack.DetachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.ErrorIs(t, err, errVolumeAttachmentProvider)
+	})
+}
+
+func TestDetachVolumeNoopsForUnrealizedIdentity(t *testing.T) {
+	t.Parallel()
+
+	identity := identityFixture()
+	server := serverFixture()
+	volume := volumeAttachmentVolumeFixture()
+
+	t.Run("BackingIdentityAbsent", func(t *testing.T) {
+		t.Parallel()
+
+		p := openstack.NewTestProvider(getClient(t, nil), regionFixture())
+		require.NoError(t, p.DetachVolume(t.Context(), identity, server, volume))
+	})
+
+	t.Run("ProjectNotAllocated", func(t *testing.T) {
+		t.Parallel()
+
+		objects := []client.Object{unrealizedOpenstackIdentityFixture(identity)}
+		p := openstack.NewTestProvider(getClient(t, objects), regionFixture())
+
+		require.NoError(t, p.DetachVolume(t.Context(), identity, server, volume))
+	})
+}

--- a/pkg/providers/internal/openstack/volume_attachment.go
+++ b/pkg/providers/internal/openstack/volume_attachment.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/volumeattach"
+
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
+)
+
+func providerResourceNotFound(err error) bool {
+	return errors.Is(err, coreerrors.ErrResourceNotFound) ||
+		gophercloud.ResponseCodeIs(err, http.StatusNotFound)
+}
+
+func serverVolumeAttachment(device string) *types.ServerVolumeAttachment {
+	result := &types.ServerVolumeAttachment{}
+
+	if device != "" {
+		result.Device = &device
+	}
+
+	return result
+}
+
+func providerVolumeAttachment(attachment *volumeattach.VolumeAttachment) (*types.ServerVolumeAttachment, error) {
+	if attachment == nil {
+		return nil, fmt.Errorf("%w: provider returned an empty volume attachment", coreerrors.ErrConsistency)
+	}
+
+	return serverVolumeAttachment(attachment.Device), nil
+}
+
+func volumeAttachmentForServer(volume *volumes.Volume, serverID string) *volumes.Attachment {
+	for i := range volume.Attachments {
+		if volume.Attachments[i].ServerID == serverID {
+			return &volume.Attachments[i]
+		}
+	}
+
+	return nil
+}
+
+func volumeAttachmentForOtherServer(volume *volumes.Volume, serverID string) *volumes.Attachment {
+	for i := range volume.Attachments {
+		if volume.Attachments[i].ServerID != serverID {
+			return &volume.Attachments[i]
+		}
+	}
+
+	return nil
+}
+
+func volumeAttachmentResources(ctx context.Context, compute ServerInterface, blockStorage VolumeInterface, server *unikornv1.Server, volume *unikornv1.Volume) (*servers.Server, *volumes.Volume, error) {
+	openstackServer, err := compute.GetServer(ctx, server)
+	if err != nil {
+		if providerResourceNotFound(err) {
+			return nil, nil, fmt.Errorf("%w: no server found for Region server %s", coreerrors.ErrResourceNotFound, server.Name)
+		}
+
+		return nil, nil, err
+	}
+
+	cinderVolume, err := blockStorage.GetVolume(ctx, volume)
+	if err != nil {
+		if providerResourceNotFound(err) {
+			return nil, nil, fmt.Errorf("%w: no volume found for Region volume %s", coreerrors.ErrResourceNotFound, volume.Name)
+		}
+
+		return nil, nil, err
+	}
+
+	return openstackServer, cinderVolume, nil
+}
+
+func attachVolume(ctx context.Context, compute ComputeInterface, blockStorage VolumeInterface, server *unikornv1.Server, volume *unikornv1.Volume) (*types.ServerVolumeAttachment, error) {
+	openstackServer, cinderVolume, err := volumeAttachmentResources(ctx, compute, blockStorage, server, volume)
+	if err != nil {
+		return nil, err
+	}
+
+	if attachment := volumeAttachmentForOtherServer(cinderVolume, openstackServer.ID); attachment != nil {
+		return nil, fmt.Errorf(
+			"%w: volume %s is already attached to server %s",
+			coreerrors.ErrConflict,
+			cinderVolume.ID,
+			attachment.ServerID,
+		)
+	}
+
+	if attachment := volumeAttachmentForServer(cinderVolume, openstackServer.ID); attachment != nil {
+		return serverVolumeAttachment(attachment.Device), nil
+	}
+
+	attachment, err := compute.CreateVolumeAttachment(ctx, openstackServer.ID, cinderVolume.ID)
+	if err == nil {
+		return providerVolumeAttachment(attachment)
+	}
+
+	if providerResourceNotFound(err) {
+		return nil, fmt.Errorf(
+			"%w: server %s or volume %s disappeared while creating the attachment",
+			coreerrors.ErrResourceNotFound,
+			openstackServer.ID,
+			cinderVolume.ID,
+		)
+	}
+
+	if !gophercloud.ResponseCodeIs(err, http.StatusConflict) {
+		return nil, err
+	}
+
+	// A concurrent request may have created the same attachment between the
+	// read and create. Confirm that desired state before surfacing the conflict.
+	attachment, getErr := compute.GetVolumeAttachment(ctx, openstackServer.ID, cinderVolume.ID)
+	if getErr == nil {
+		return providerVolumeAttachment(attachment)
+	}
+
+	if !providerResourceNotFound(getErr) {
+		return nil, getErr
+	}
+
+	return nil, fmt.Errorf(
+		"%w: volume %s cannot be attached to server %s in its current state",
+		coreerrors.ErrConflict,
+		cinderVolume.ID,
+		openstackServer.ID,
+	)
+}
+
+func detachVolume(ctx context.Context, compute ComputeInterface, blockStorage VolumeInterface, server *unikornv1.Server, volume *unikornv1.Volume) error {
+	openstackServer, cinderVolume, err := volumeAttachmentResources(ctx, compute, blockStorage, server, volume)
+	if err != nil {
+		if providerResourceNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if volumeAttachmentForServer(cinderVolume, openstackServer.ID) == nil {
+		return nil
+	}
+
+	if err := compute.DeleteVolumeAttachment(ctx, openstackServer.ID, cinderVolume.ID); err != nil {
+		if providerResourceNotFound(err) {
+			return nil
+		}
+
+		if gophercloud.ResponseCodeIs(err, http.StatusConflict) {
+			return fmt.Errorf(
+				"%w: volume %s cannot be detached from server %s in its current state",
+				coreerrors.ErrConflict,
+				cinderVolume.ID,
+				openstackServer.ID,
+			)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provider) AttachVolume(ctx context.Context, identity *unikornv1.Identity, server *unikornv1.Server, volume *unikornv1.Volume) (*types.ServerVolumeAttachment, error) {
+	compute, err := p.computeFromServicePrincipal(ctx, identity)
+	if err != nil {
+		return nil, err
+	}
+
+	blockStorage, err := p.blockStorageFromServicePrincipal(ctx, identity)
+	if err != nil {
+		return nil, err
+	}
+
+	return attachVolume(ctx, compute, blockStorage, server, volume)
+}
+
+func (p *Provider) DetachVolume(ctx context.Context, identity *unikornv1.Identity, server *unikornv1.Server, volume *unikornv1.Volume) error {
+	provisioned, err := p.openstackIdentityProvisioned(ctx, identity)
+	if err != nil {
+		return err
+	}
+
+	if !provisioned {
+		return nil
+	}
+
+	compute, err := p.computeFromServicePrincipal(ctx, identity)
+	if err != nil {
+		return err
+	}
+
+	blockStorage, err := p.blockStorageFromServicePrincipal(ctx, identity)
+	if err != nil {
+		return err
+	}
+
+	return detachVolume(ctx, compute, blockStorage, server, volume)
+}

--- a/pkg/providers/internal/simulated/README.md
+++ b/pkg/providers/internal/simulated/README.md
@@ -34,6 +34,9 @@ development, while keeping behaviour deterministic and cheap to run.
   images through the same query/filter contract used by real providers.
 - Unsupported operations fail explicitly with `ErrUnsupportedOperation` rather
   than pretending to succeed.
+- Server volume attach/detach participates in the full interface contract but
+  is currently unsupported; attachment fidelity belongs to the OpenStack
+  provider until a higher-level simulated workflow requires it.
 - Some mutable operations intentionally act by mutating service-side resource
   status deterministically, for example network status and load balancer VIP or
   public IP assignment.

--- a/pkg/providers/internal/simulated/provider.go
+++ b/pkg/providers/internal/simulated/provider.go
@@ -473,6 +473,14 @@ func (p *Provider) CreateServer(_ context.Context, _ *unikornv1.Identity, _ *uni
 	return unsupported("CreateServer")
 }
 
+func (p *Provider) AttachVolume(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.Server, _ *unikornv1.Volume) (*types.ServerVolumeAttachment, error) {
+	return nil, unsupported("AttachVolume")
+}
+
+func (p *Provider) DetachVolume(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.Server, _ *unikornv1.Volume) error {
+	return unsupported("DetachVolume")
+}
+
 func (p *Provider) RebootServer(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.Server, _ bool) error {
 	return unsupported("RebootServer")
 }

--- a/pkg/providers/types/README.md
+++ b/pkg/providers/types/README.md
@@ -15,8 +15,8 @@ That makes this package a mixed abstraction layer on purpose:
 - when the thing is provider-derived, query-driven, transient, or otherwise not
   represented as a concrete CRD, this package provides the neutral shape and
   capability contract instead, for example `Flavor`, `Image`,
-  `VolumeClass`, `ExternalNetwork`, `ServerCreateOptions`, and the image query
-  interfaces
+  `VolumeClass`, `ExternalNetwork`, `ServerCreateOptions`,
+  `ServerVolumeAttachment`, and the image query interfaces
 
 So this package is not "all provider models". It is the intermediate
 portability layer for provider-facing concepts that higher layers still need to
@@ -34,6 +34,9 @@ continue to be passed directly through many provider interface methods.
 - `Provider` is a capability composition interface, not one monolithic "SDK"
   wrapper. It embeds smaller contracts such as `ImageRead`, `ImageWrite`,
   `Network`, `Server`, `ServerConsole`, and `ServerSnapshot`.
+- The `Server` capability owns both ends of the existing-volume attachment
+  boundary. `AttachVolume` and `DetachVolume` receive the repo-native
+  `Server` and `Volume` resources; `Volume` does not own attachment intent.
 - CRD-backed lifecycle operations continue to use repo-native
   `unikornv1.*` resource types where those are the stable service contract.
 - Provider-derived or non-CRD concepts use the intermediate types defined in
@@ -58,6 +61,9 @@ continue to be passed directly through many provider interface methods.
   operations.
 - `ServerCreateOptions` carries launch-time derived inputs without forcing them
   into the persisted `Server` CRD shape.
+- `ServerVolumeAttachment` contains only provider-neutral observation needed by
+  higher layers: the optional guest device name. Provider IDs and SDK-native
+  attachment objects remain inside the concrete provider.
 - Exported errors such as `ErrImageNotReadyForUpload` and
   `ErrImageStillInUse` are semantic contract values used to communicate provider
   behaviour upward.

--- a/pkg/providers/types/interfaces.go
+++ b/pkg/providers/types/interfaces.go
@@ -102,6 +102,10 @@ type Volume interface {
 type Server interface {
 	// CreateServer creates a new server.
 	CreateServer(ctx context.Context, identity *unikornv1.Identity, server *unikornv1.Server, options *ServerCreateOptions) error
+	// AttachVolume attaches an existing Region volume to a server.
+	AttachVolume(ctx context.Context, identity *unikornv1.Identity, server *unikornv1.Server, volume *unikornv1.Volume) (*ServerVolumeAttachment, error)
+	// DetachVolume detaches an existing Region volume from a server.
+	DetachVolume(ctx context.Context, identity *unikornv1.Identity, server *unikornv1.Server, volume *unikornv1.Volume) error
 	// RebootServer soft reboots a server.
 	RebootServer(ctx context.Context, identity *unikornv1.Identity, server *unikornv1.Server, hard bool) error
 	// StartServer starts a server.

--- a/pkg/providers/types/mock/interfaces.go
+++ b/pkg/providers/types/mock/interfaces.go
@@ -509,6 +509,21 @@ func (m *MockServer) EXPECT() *MockServerMockRecorder {
 	return m.recorder
 }
 
+// AttachVolume mocks base method.
+func (m *MockServer) AttachVolume(ctx context.Context, identity *v1alpha1.Identity, server *v1alpha1.Server, volume *v1alpha1.Volume) (*types.ServerVolumeAttachment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AttachVolume", ctx, identity, server, volume)
+	ret0, _ := ret[0].(*types.ServerVolumeAttachment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AttachVolume indicates an expected call of AttachVolume.
+func (mr *MockServerMockRecorder) AttachVolume(ctx, identity, server, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachVolume", reflect.TypeOf((*MockServer)(nil).AttachVolume), ctx, identity, server, volume)
+}
+
 // CreateServer mocks base method.
 func (m *MockServer) CreateServer(ctx context.Context, identity *v1alpha1.Identity, server *v1alpha1.Server, options *types.ServerCreateOptions) error {
 	m.ctrl.T.Helper()
@@ -535,6 +550,20 @@ func (m *MockServer) DeleteServer(ctx context.Context, identity *v1alpha1.Identi
 func (mr *MockServerMockRecorder) DeleteServer(ctx, identity, server any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServer", reflect.TypeOf((*MockServer)(nil).DeleteServer), ctx, identity, server)
+}
+
+// DetachVolume mocks base method.
+func (m *MockServer) DetachVolume(ctx context.Context, identity *v1alpha1.Identity, server *v1alpha1.Server, volume *v1alpha1.Volume) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachVolume", ctx, identity, server, volume)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DetachVolume indicates an expected call of DetachVolume.
+func (mr *MockServerMockRecorder) DetachVolume(ctx, identity, server, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVolume", reflect.TypeOf((*MockServer)(nil).DetachVolume), ctx, identity, server, volume)
 }
 
 // RebootServer mocks base method.
@@ -775,6 +804,21 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
 }
 
+// AttachVolume mocks base method.
+func (m *MockProvider) AttachVolume(ctx context.Context, identity *v1alpha1.Identity, server *v1alpha1.Server, volume *v1alpha1.Volume) (*types.ServerVolumeAttachment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AttachVolume", ctx, identity, server, volume)
+	ret0, _ := ret[0].(*types.ServerVolumeAttachment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AttachVolume indicates an expected call of AttachVolume.
+func (mr *MockProviderMockRecorder) AttachVolume(ctx, identity, server, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachVolume", reflect.TypeOf((*MockProvider)(nil).AttachVolume), ctx, identity, server, volume)
+}
+
 // CreateConsoleSession mocks base method.
 func (m *MockProvider) CreateConsoleSession(ctx context.Context, identity *v1alpha1.Identity, server *v1alpha1.Server) (string, error) {
 	m.ctrl.T.Helper()
@@ -972,6 +1016,20 @@ func (m *MockProvider) DeleteServer(ctx context.Context, identity *v1alpha1.Iden
 func (mr *MockProviderMockRecorder) DeleteServer(ctx, identity, server any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServer", reflect.TypeOf((*MockProvider)(nil).DeleteServer), ctx, identity, server)
+}
+
+// DetachVolume mocks base method.
+func (m *MockProvider) DetachVolume(ctx context.Context, identity *v1alpha1.Identity, server *v1alpha1.Server, volume *v1alpha1.Volume) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachVolume", ctx, identity, server, volume)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DetachVolume indicates an expected call of DetachVolume.
+func (mr *MockProviderMockRecorder) DetachVolume(ctx, identity, server, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVolume", reflect.TypeOf((*MockProvider)(nil).DetachVolume), ctx, identity, server, volume)
 }
 
 // Flavors mocks base method.

--- a/pkg/providers/types/types.go
+++ b/pkg/providers/types/types.go
@@ -281,3 +281,10 @@ type ServerCreateOptions struct {
 	// UserData overrides the user data passed to the provider when specified.
 	UserData []byte
 }
+
+// ServerVolumeAttachment is the provider-neutral result of attaching a volume
+// to a server.
+type ServerVolumeAttachment struct {
+	// Device is the guest OS device name reported by the provider, when known.
+	Device *string
+}


### PR DESCRIPTION
## Summary

- add the server-owned provider boundary for attaching and detaching existing Region Volumes
- implement Nova volume-attachment create/get/delete operations and OpenStack provider glue
- make attach/detach idempotent where Nova semantics allow and normalize not-found/conflict responses to repository errors
- regenerate provider mocks and update the affected architecture/provider documentation

## Behavior

- attach requires both the server and volume; missing resources return `ErrResourceNotFound`
- already-attached requests succeed and return the observed optional guest device
- attach conflicts are re-read once so a concurrent successful attachment converges; unresolved conflicts return `ErrConflict`
- detach treats missing servers, volumes, attachments, and delete 404 responses as already converged
- detach conflicts return `ErrConflict`; other provider errors are preserved
- attachment intent remains owned by the existing Server model; Volume does not own attachment state

STO-140 is superseded by this implementation-backed slice. Volume lifecycle/observation, claims/locking, controller reconciliation, and public API behavior remain out of scope.

## Validation

- `make touch`
- `make license`
- `make validate`
- `make lint`
- `make generate`
- generated changes verified in Git status and committed
- `make test-unit`
- `git diff --check`
