### PR TITLE
Add configurable OpenStack default architecture

### DIFF
--- a/charts/region/crds/region.unikorn-cloud.org_regions.yaml
+++ b/charts/region/crds/region.unikorn-cloud.org_regions.yaml
@@ -435,6 +435,15 @@ spec:
                           scheduling cluster nodes.  Defaults to "soft-anti-affinity".
                         type: string
                     type: object
+                  defaultArchitecture:
+                    default: x86_64
+                    description: |-
+                      DefaultArchitecture is the fallback architecture for flavors and images
+                      that do not define one explicitly.
+                    enum:
+                    - x86_64
+                    - aarch64
+                    type: string
                   endpoint:
                     description: Endpoint is the Keystone URL e.g. https://foo.bar:5000.
                     type: string

--- a/charts/region/templates/region.yaml
+++ b/charts/region/templates/region.yaml
@@ -45,6 +45,9 @@ spec:
       namespace: {{ $.Release.Namespace }}
       {{- end }}
       name: {{ $openstack.serviceAccountSecret.name }}
+    {{- with $defaultArchitecture := $openstack.defaultArchitecture }}
+    defaultArchitecture: {{ $defaultArchitecture }}
+    {{- end }}
     {{- with $identity := $openstack.identity }}
       {{ printf "identity:" | nindent 4 }}
       {{- toYaml $identity | nindent 6 }}

--- a/charts/region/values.schema.json
+++ b/charts/region/values.schema.json
@@ -289,6 +289,13 @@
               "endpoint": {
                 "type": "string"
               },
+              "defaultArchitecture": {
+                "type": "string",
+                "enum": [
+                  "x86_64",
+                  "aarch64"
+                ]
+              },
               "serviceAccountSecret": {
                 "type": "object",
                 "required": [

--- a/charts/region/values.yaml
+++ b/charts/region/values.yaml
@@ -34,6 +34,10 @@ organization: nscaledev
 #       # Defaults to the release namespace if not specified.
 #       namespace: default
 #       name: openstack-admin-secret
+#     # Fallback for flavors without per-ID cpu.architecture metadata and images
+#     # without an explicit Glance architecture property. Explicit metadata wins.
+#     # Defaults to x86_64.
+#     defaultArchitecture: x86_64
 #     # Identity service configuration.
 #     identity:
 #       # Roles to be assigned to application credentials that are used for

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -39,6 +39,11 @@ stored objects rely on for linkage, migration, and operational coordination.
   region. It carries provider type, provider-specific configuration, stored
   visibility inputs, flavor/image/network/volume-class selection rules, and
   helper methods that downstream code actively depends on.
+- `Region.Spec.Openstack.DefaultArchitecture` controls the Region-scoped
+  fallback used when OpenStack flavor or image inventory lacks explicit
+  architecture metadata. CRD admission defaults omission to `x86_64` and
+  accepts only `x86_64` or `aarch64`; per-flavor `cpu.architecture` and the
+  Glance `architecture` property remain authoritative when present.
 - OpenStack `VolumeClass` configuration is Region-scoped inventory metadata. It
   records which provider volume classes are eligible for export and how that
   inventory should be enriched; it does not create a project-owned

--- a/pkg/apis/unikorn/v1alpha1/openstack_default_architecture_test.go
+++ b/pkg/apis/unikorn/v1alpha1/openstack_default_architecture_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	structuraldefaulting "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestOpenstackDefaultArchitectureValidation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		architecture *string
+		valid        bool
+	}{
+		{name: "omitted", valid: true},
+		{name: "x86_64", architecture: architectureValue("x86_64"), valid: true},
+		{name: "aarch64", architecture: architectureValue("aarch64"), valid: true},
+		{name: "amd64", architecture: architectureValue("amd64")},
+		{name: "arm64", architecture: architectureValue("arm64")},
+		{name: "empty", architecture: architectureValue("")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resource := regionWithOpenstackDefaultArchitecture(tc.architecture)
+			valid := newCRDValidator(t, regionCRDFile).validatesUnstructured(t, resource)
+
+			require.Equal(t, tc.valid, valid)
+		})
+	}
+}
+
+func TestOpenstackDefaultArchitectureDefaulting(t *testing.T) {
+	t.Parallel()
+
+	resource := regionWithOpenstackDefaultArchitecture(nil)
+	validator := newCRDValidator(t, regionCRDFile)
+
+	structuraldefaulting.Default(resource, validator.structural)
+
+	architecture, found, err := unstructured.NestedString(resource, "spec", "openstack", "defaultArchitecture")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "x86_64", architecture)
+}
+
+func architectureValue(value string) *string {
+	return &value
+}
+
+func regionWithOpenstackDefaultArchitecture(architecture *string) map[string]any {
+	openstack := map[string]any{
+		"endpoint": "https://openstack.example.com:5000",
+		"serviceAccountSecret": map[string]any{
+			"name":      "credentials",
+			"namespace": "default",
+		},
+	}
+
+	if architecture != nil {
+		openstack["defaultArchitecture"] = *architecture
+	}
+
+	return map[string]any{
+		"apiVersion": "region.unikorn-cloud.org/v1alpha1",
+		"kind":       "Region",
+		"metadata": map[string]any{
+			"name":      "region",
+			"namespace": "default",
+		},
+		"spec": map[string]any{
+			"provider":  "openstack",
+			"openstack": openstack,
+		},
+	}
+}

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -133,6 +133,10 @@ type RegionOpenstackSpec struct {
 	// ServiceAccountSecretName points to the secret containing credentials
 	// required to perform the tasks the provider needs to perform.
 	ServiceAccountSecret *NamespacedObject `json:"serviceAccountSecret"`
+	// DefaultArchitecture is the fallback architecture for flavors and images
+	// that do not define one explicitly.
+	// +kubebuilder:default=x86_64
+	DefaultArchitecture *Architecture `json:"defaultArchitecture,omitempty"`
 	// Identity is configuration for the identity service.
 	Identity *RegionOpenstackIdentitySpec `json:"identity,omitempty"`
 	// Compute is configuration for the compute service.

--- a/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
@@ -2083,6 +2083,11 @@ func (in *RegionOpenstackSpec) DeepCopyInto(out *RegionOpenstackSpec) {
 		*out = new(NamespacedObject)
 		**out = **in
 	}
+	if in.DefaultArchitecture != nil {
+		in, out := &in.DefaultArchitecture, &out.DefaultArchitecture
+		*out = new(Architecture)
+		**out = **in
+	}
 	if in.Identity != nil {
 		in, out := &in.Identity, &out.Identity
 		*out = new(RegionOpenstackIdentitySpec)

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -279,7 +279,10 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
     attach/detach are intentionally outside this lifecycle slice
 - Flavor export is a hybrid model: OpenStack discovers the flavor inventory, but
   region configuration can enrich or override user-facing flavor metadata such
-  as architecture, baremetal status, and GPU semantics. The baremetal flag is
+  as architecture, baremetal status, and GPU semantics. Architecture resolves
+  from per-flavor `cpu.architecture`, then `openstack.defaultArchitecture`,
+  then the legacy `x86_64` fallback for objects that bypass CRD defaulting. The
+  baremetal flag is
   also operationally meaningful for live lifecycle (`Active` condition) reporting:
   a Nova `BUILD` server with a baremetal flavor is disambiguated through Ironic so the API
   can distinguish `Queued` (waiting on hardware) from `Building` (provider
@@ -309,6 +312,9 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   - public images can additionally be signature-verified
   - image properties are translated into provider-neutral OS, package, GPU,
     ownership, virtualization, and tag metadata
+  - an explicit Glance `architecture` property wins; otherwise image conversion
+    uses `openstack.defaultArchitecture`, with the same defensive legacy
+    `x86_64` fallback as flavor conversion
   - an optional refresh-ahead cache exists because raw image API latency is too
     expensive to expose directly to every caller
 - Quota and role behaviour are not purely discovered from OpenStack defaults.

--- a/pkg/providers/internal/openstack/architecture_test.go
+++ b/pkg/providers/internal/openstack/architecture_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack_test
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
+	"github.com/gophercloud/gophercloud/v2/openstack/image/v2/images"
+	"github.com/stretchr/testify/require"
+
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
+
+	"k8s.io/utils/ptr"
+)
+
+func TestOpenstackArchitectureFallbacks(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                string
+		defaultArchitecture *unikornv1.Architecture
+		flavorArchitecture  *unikornv1.Architecture
+		imageArchitecture   any
+		expectedFlavor      types.Architecture
+		expectedImage       types.Architecture
+	}{
+		{
+			name:           "omitted configuration preserves the legacy fallback",
+			expectedFlavor: types.X86_64,
+			expectedImage:  types.X86_64,
+		},
+		{
+			name:                "regional aarch64 applies to missing metadata",
+			defaultArchitecture: ptr.To(unikornv1.Aarch64),
+			expectedFlavor:      types.Aarch64,
+			expectedImage:       types.Aarch64,
+		},
+		{
+			name:                "per-flavor metadata overrides the regional default",
+			defaultArchitecture: ptr.To(unikornv1.Aarch64),
+			flavorArchitecture:  ptr.To(unikornv1.X86_64),
+			expectedFlavor:      types.X86_64,
+			expectedImage:       types.Aarch64,
+		},
+		{
+			name:                "explicit Glance metadata overrides the regional default",
+			defaultArchitecture: ptr.To(unikornv1.Aarch64),
+			imageArchitecture:   "x86_64",
+			expectedFlavor:      types.Aarch64,
+			expectedImage:       types.X86_64,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			region := architectureRegion(tc.defaultArchitecture, tc.flavorArchitecture)
+			convertedFlavors := openstack.ConvertFlavors([]flavors.Flavor{{
+				ID:    "flavor-id",
+				Name:  "flavor-name",
+				VCPUs: 1,
+				RAM:   1024,
+				Disk:  10,
+			}}, region)
+
+			require.Len(t, convertedFlavors, 1)
+			require.Equal(t, tc.expectedFlavor, convertedFlavors[0].Architecture)
+
+			properties := map[string]any{}
+			if tc.imageArchitecture != nil {
+				properties["architecture"] = tc.imageArchitecture
+			}
+
+			convertedImage, err := openstack.ConvertImageForRegion(&images.Image{Properties: properties}, region)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedImage, convertedImage.Architecture)
+		})
+	}
+}
+
+func architectureRegion(defaultArchitecture, flavorArchitecture *unikornv1.Architecture) *unikornv1.Region {
+	region := &unikornv1.Region{
+		Spec: unikornv1.RegionSpec{
+			Openstack: &unikornv1.RegionOpenstackSpec{
+				DefaultArchitecture: defaultArchitecture,
+			},
+		},
+	}
+
+	if flavorArchitecture != nil {
+		region.Spec.Openstack.Compute = &unikornv1.RegionOpenstackComputeSpec{
+			Flavors: &unikornv1.OpenstackFlavorsSpec{
+				Metadata: []unikornv1.FlavorMetadata{
+					{
+						ID: "flavor-id",
+						CPU: &unikornv1.CPUSpec{
+							Architecture: flavorArchitecture,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return region
+}

--- a/pkg/providers/internal/openstack/export_test.go
+++ b/pkg/providers/internal/openstack/export_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/v2/openstack/image/v2/images"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/monitors"
@@ -49,8 +50,17 @@ func NewImageQuery(listFunc func() (*cache.ListSnapshot[types.Image], error)) ty
 	return &imageQuery{listFunc: listFunc}
 }
 
-//nolint:gochecknoglobals
-var ConvertImage = convertImage
+func ConvertImage(image *images.Image) (*types.Image, error) {
+	return convertImage(image, types.X86_64)
+}
+
+func ConvertImageForRegion(image *images.Image, region *unikornv1.Region) (*types.Image, error) {
+	return convertImage(image, openstackDefaultArchitecture(region))
+}
+
+func ConvertFlavors(resources []flavors.Flavor, region *unikornv1.Region) types.FlavorList {
+	return convertFlavors(resources, region)
+}
 
 //nolint:gochecknoglobals
 var ConvertVolumeClasses = convertVolumeClasses

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/roles"
 	"github.com/gophercloud/gophercloud/v2/openstack/image/v2/images"
@@ -451,20 +452,33 @@ func (p *Provider) Flavors(ctx context.Context) (types.FlavorList, error) {
 	}
 
 	region, _ := p.openstack.regionSnapshot()
+
+	return convertFlavors(resources, region), nil
+}
+
+// openstackDefaultArchitecture resolves the Region-configured fallback while
+// retaining the legacy x86_64 behavior for objects that bypass CRD defaulting.
+func openstackDefaultArchitecture(region *unikornv1.Region) types.Architecture {
+	if region == nil || region.Spec.Openstack == nil || region.Spec.Openstack.DefaultArchitecture == nil {
+		return types.X86_64
+	}
+
+	return types.Architecture(*region.Spec.Openstack.DefaultArchitecture)
+}
+
+func convertFlavors(resources []flavors.Flavor, region *unikornv1.Region) types.FlavorList {
 	result := make(types.FlavorList, len(resources))
+	defaultArchitecture := openstackDefaultArchitecture(region)
 
 	for i := range resources {
 		flavor := &resources[i]
 
-		// API memory is in MiB, disk is in GB. Architecture defaults to
-		// x86_64 when region metadata does not override it below: the API
-		// schema requires an enum value and existing consumers compare
-		// architectures strictly, so an honest "unknown" cannot reach the
-		// wire without coordinated schema and consumer changes.
+		// API memory is in MiB and disk is in GB. Per-flavor metadata below
+		// takes precedence over the Region-level architecture fallback.
 		f := types.Flavor{
 			ID:           flavor.ID,
 			Name:         flavor.Name,
-			Architecture: types.X86_64,
+			Architecture: defaultArchitecture,
 			CPUs:         flavor.VCPUs,
 			Memory:       resource.NewQuantity(int64(flavor.RAM)<<20, resource.BinarySI),
 			Disk:         resource.NewScaledQuantity(int64(flavor.Disk), resource.Giga),
@@ -473,7 +487,7 @@ func (p *Provider) Flavors(ctx context.Context) (types.FlavorList, error) {
 		// Apply any extra metadata to the flavor.
 		//
 		//nolint:nestif
-		if region.Spec.Openstack.Compute != nil && region.Spec.Openstack.Compute.Flavors != nil {
+		if region != nil && region.Spec.Openstack != nil && region.Spec.Openstack.Compute != nil && region.Spec.Openstack.Compute.Flavors != nil {
 			i := slices.IndexFunc(region.Spec.Openstack.Compute.Flavors.Metadata, func(metadata unikornv1.FlavorMetadata) bool {
 				return flavor.ID == metadata.ID
 			})
@@ -509,7 +523,7 @@ func (p *Provider) Flavors(ctx context.Context) (types.FlavorList, error) {
 		result[i] = f
 	}
 
-	return result, nil
+	return result
 }
 
 func (p *Provider) VolumeClasses(ctx context.Context) (types.VolumeClassList, error) {
@@ -678,15 +692,12 @@ func imageStatus(image *images.Image) types.ImageStatus {
 	return status
 }
 
-func imageArchitecture(image *images.Image) types.Architecture {
+func imageArchitecture(image *images.Image, defaultArchitecture types.Architecture) types.Architecture {
 	if v, ok := image.Properties[imageArchitectureProperty].(string); ok && v != "" {
 		return types.Architecture(v)
 	}
 
-	// Default images without the Glance architecture property to x86_64,
-	// matching the flavor default above, so the strict-equality consumers
-	// of the API keep their pre-existing behaviour.
-	return types.X86_64
+	return defaultArchitecture
 }
 
 func imageTags(image *images.Image) map[string]string {
@@ -708,7 +719,7 @@ func imageTags(image *images.Image) map[string]string {
 	return tags
 }
 
-func convertImage(image *images.Image) (*types.Image, error) {
+func convertImage(image *images.Image, defaultArchitecture types.Architecture) (*types.Image, error) {
 	var organizationID *string
 	if temp, _ := image.Properties[organizationIDLabel].(string); temp != "" {
 		organizationID = &temp
@@ -734,7 +745,7 @@ func convertImage(image *images.Image) (*types.Image, error) {
 		OrganizationID: organizationID,
 		Created:        image.CreatedAt,
 		Modified:       image.UpdatedAt,
-		Architecture:   imageArchitecture(image),
+		Architecture:   imageArchitecture(image, defaultArchitecture),
 		SizeGiB:        size,
 		Virtualization: types.ImageVirtualization(virtualization),
 		OS:             imageOS(image),
@@ -840,9 +851,11 @@ func (p *Provider) imageRefresh(ctx context.Context) ([]*types.Image, error) {
 	}
 
 	items := make([]*types.Image, len(resources))
+	region, _ := p.openstack.regionSnapshot()
+	defaultArchitecture := openstackDefaultArchitecture(region)
 
 	for i := range resources {
-		item, err := convertImage(&resources[i])
+		item, err := convertImage(&resources[i], defaultArchitecture)
 		if err != nil {
 			return nil, err
 		}
@@ -993,7 +1006,9 @@ func (p *Provider) CreateImage(ctx context.Context, image *types.Image, uri stri
 	// This seeds the cache from the pre-import Glance response, so callers may observe
 	// an intermediate queued/importing status until the next background refresh
 	// converges on the fully updated image state.
-	syntheticImage, err := convertImage(resource)
+	region, _ := p.openstack.regionSnapshot()
+
+	syntheticImage, err := convertImage(resource, openstackDefaultArchitecture(region))
 	if err != nil {
 		return nil, err
 	}
@@ -3635,7 +3650,9 @@ func (p *Provider) CreateSnapshot(ctx context.Context, identity *unikornv1.Ident
 		return nil, err
 	}
 
-	imageSnapshot, err := convertImage(updatedImage)
+	region, _ := p.openstack.regionSnapshot()
+
+	imageSnapshot, err := convertImage(updatedImage, openstackDefaultArchitecture(region))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What changed

- Add optional Region configuration at `spec.openstack.defaultArchitecture`, defaulted to `x86_64` and constrained to `x86_64` or `aarch64`.
- Apply the regional fallback to OpenStack flavor and image inventory while preserving explicit per-flavor and Glance metadata precedence.
- Pass the fallback through background image refresh, direct image creation, and server snapshot cache seeding.
- Expose the setting through Helm values, schema validation, and Region rendering.
- Regenerate the Region CRD and deepcopy implementation, and document the precedence rules.

## Why

Some OpenStack regions primarily expose `aarch64` inventory but do not consistently attach architecture metadata to every Nova flavor or Glance image. A Region-scoped fallback keeps inventory resolution inside the provider boundary without introducing a process-wide flag, while preserving existing `x86_64` behavior for omitted configuration.

## Impact

Existing Region objects require no migration and retain their current `x86_64` fallback. Operators can opt an OpenStack region into `aarch64`; explicit flavor or image metadata still wins.

## Validation

- `make license`
- `make validate`
- `make lint`
- `make generate`
- `make test-unit`
- Helm rendering verified for `x86_64` and `aarch64`
- Helm values schema verified to reject `amd64`
- Forced second CRD/deepcopy generation produced an identical content hash