### PR TITLE
Honor global VolumeClass read permission

### DIFF
--- a/pkg/handler/handler_v2_volumeclass_test.go
+++ b/pkg/handler/handler_v2_volumeclass_test.go
@@ -382,6 +382,43 @@ func TestVolumeClassV2ReturnsEmptyListForFilteredRegions(t *testing.T) {
 	}
 }
 
+func TestVolumeClassV2DiscoversVisibleRegionWithGlobalPermissionAndNoOrganizations(t *testing.T) {
+	t.Parallel()
+
+	const (
+		regionID      = "30303030-3030-4030-a030-303030303030"
+		volumeClassID = "31313131-3131-4131-a131-313131313131"
+	)
+
+	fixture := newVolumeClassV2TestFixture(
+		t,
+		newVolumeClassTestRegion(
+			regionID,
+			newVolumeClassTestSecurity(volumeClassOtherOrganizationID),
+		),
+	)
+	fixture.expectVolumeClasses(regionID, types.VolumeClassList{
+		{ID: volumeClassID, Name: "globally-visible-class"},
+	}, nil)
+
+	ctx := rbac.NewContext(t.Context(), &identityapi.Acl{
+		Global: &identityapi.AclEndpoints{
+			{Name: "region:regions", Operations: identityapi.AclOperations{identityapi.Read}},
+			{Name: volumeClassReadEndpoint, Operations: identityapi.AclOperations{identityapi.Read}},
+		},
+	})
+	params := openapi.GetApiV2VolumeclassesParams{
+		RegionID: ptr.To(openapi.RegionIDQueryParameter{regionID}),
+	}
+
+	response := fixture.get(ctx, params)
+	result := requireVolumeClassListResponse(t, response)
+
+	require.Len(t, result, 1)
+	require.Equal(t, volumeClassID, result[0].Metadata.Id)
+	require.Equal(t, regionID, result[0].Spec.RegionId.String())
+}
+
 func TestVolumeClassV2ReturnsEmptyProviderInventory(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/handler/region/README.md
+++ b/pkg/handler/region/README.md
@@ -46,9 +46,12 @@ provider capability discovery into user-visible region catalogue data.
 - VolumeClass access preserves the existing Region visibility distinction:
   a nil organization allowlist is unrestricted, while a configured but empty
   allowlist permits no organizations.
-- VolumeClass provider discovery requires `region:volumeclasses:v2/read` in at
-  least one organization visible to the caller. Requests without that grant
-  omit the selected Regions without performing provider lookups.
+- VolumeClass provider discovery requires global
+  `region:volumeclasses:v2/read` or that grant in at least one organization
+  visible to the caller. Global VolumeClass permission applies only to Regions
+  retained by the canonical Region visibility filter; it does not expand the
+  visible Region set. Requests without either grant omit the selected Regions
+  without performing provider lookups.
 - Region ACL checking is enforced in two places:
   - **List responses** (`FilterRegions`) — removes regions the caller cannot see
     before building the response or applying list selectors such as the

--- a/pkg/handler/region/region.go
+++ b/pkg/handler/region/region.go
@@ -194,6 +194,10 @@ func (c *Client) ListFlavors(ctx context.Context, organizationID identityids.Org
 const volumeClassReadEndpoint = "region:volumeclasses:v2"
 
 func hasVolumeClassReadAccess(ctx context.Context) bool {
+	if rbac.AllowGlobalScope(ctx, volumeClassReadEndpoint, identityapi.Read) == nil {
+		return true
+	}
+
 	for _, value := range rbac.OrganizationIDs(ctx) {
 		organizationID, err := identityids.ParseOrganizationID(value)
 		if err != nil {


### PR DESCRIPTION
## Summary

- honor global `region:volumeclasses:v2/read` permission when the ACL has no organization entries
- keep Region visibility and explicit selector filtering ahead of provider discovery
- add regression coverage and update the Region handler contract documentation

## Root cause

`hasVolumeClassReadAccess` only evaluated `AllowOrganizationScopeID` while iterating ACL organization IDs. A globally authorized principal with zero organization memberships therefore took zero iterations and was denied before provider discovery.

## Impact

Platform administrators can discover VolumeClasses for Regions they are already authorized to see. Global VolumeClass permission does not expand Region visibility, and callers without global or organization-scoped permission still receive an empty list without provider calls.

## Validation

- `go test ./pkg/handler -run '^TestVolumeClassV2' -count=1`
- `make license`
- `make validate`
- `make lint`
- `make generate` (no generated drift)
- `make test-unit`
- `git diff --check`

Linear: [STO-158](https://linear.app/nscale-workspace/issue/STO-158/uni-region-honor-global-volumeclass-read-permission)