### PR TITLE
Add VolumeClass API integration coverage and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,10 +291,12 @@ valid with at least 15 minutes remaining. The certificate lifetime must also
 cover the requested fixture certificate duration. Otherwise it removes the
 stale Secret so cert-manager issues a replacement before writing `test/.env`.
 
-The Region integration install also overlays the pinned Identity chart's
-organization `administrator` role with read access to the public VolumeClass
-endpoint. This test-only grant lets the bearer-token API suite exercise live
-provider discovery; it does not add global permission or change production
+The Region integration install also overlays the pinned Identity chart with
+organization `administrator` read access to the public VolumeClass endpoint.
+It mirrors that permission at global scope for the bootstrap
+`platform-administrator`, preserving Identity's role-grant hierarchy. The API
+suite itself uses the organization administrator token, so this test-only
+configuration does not exercise global authorization or change production
 Identity values.
 
 Fixture generation creates a private simulated Region with deterministic,

--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ regions:
     serviceAccountSecret:
       namespace: unikorn-region
       name: gb-north-1-credentials # See the provider setup section
+    blockStorage:
+      volumeClasses:
+        selector:
+          ids:
+          - cda67b98-331d-4d4f-911e-b1fd64611b0b
+        metadata:
+        - id: cda67b98-331d-4d4f-911e-b1fd64611b0b
+          minimumSizeGiB: 10
+          maximumSizeGiB: 2048
+          media: nvme
+          performance:
+            maxIOPS: 25000
+            maxThroughputMiBps: 500
+          encrypted: true
 ```
 
 This configures the service to be exposed on the specified host using an ingress
@@ -115,6 +129,40 @@ The `provider` field in the Helm values remains required installation
 configuration. The test fixture provider inference described below only controls
 which existing Region CR `make integration-fixtures` uses for generated test
 data.
+
+### VolumeClass Discovery
+
+`VolumeClass` is read-only, Region-scoped provider inventory. It describes the
+block-storage classes from which later Volume APIs can provision storage; it is
+not a resource that users create, update, or delete. Clients list the classes
+visible to them through the public v2 API:
+
+```http
+GET /api/v2/volumeclasses?regionID=c7e8492f-c320-4278-8201-48cd38fed38b
+```
+
+Repeat `regionID` to select multiple Regions. Omitting it lists inventory from
+all visible Regions. A selected Region that is missing or inaccessible is
+omitted rather than reported as not found, so the response can be an empty or
+partial JSON list.
+Each result includes the provider class ID and name plus its Region ID and
+encryption flag. Description, media, whole-GiB minimum and maximum capacities,
+and advertised performance caps are present only when the Region publishes
+them.
+
+OpenStack discovers Cinder volume types but exports only IDs in
+`openstack.blockStorage.volumeClasses.selector.ids`. Selection is fail-closed:
+omitting `volumeClasses`, omitting its selector, or supplying an empty ID list
+exports no OpenStack VolumeClasses. The optional `metadata` entries enrich
+selected classes with operator-authored user-facing capabilities; they do not
+change Cinder configuration. Kubernetes-backed Regions currently return no
+VolumeClasses, while the simulated provider exposes deterministic classes for
+development and integration testing.
+
+See the [OpenStack provider administration guide](pkg/providers/internal/openstack/ADMIN.md)
+for the complete Region resource shape and rollout guidance, and
+[pkg/README.md](pkg/README.md) for the configuration-to-provider-to-API package
+flow.
 
 ## Running Tests
 
@@ -242,6 +290,18 @@ certificate Common Name matches `ci-fixtures`, and the certificate is currently
 valid with at least 15 minutes remaining. The certificate lifetime must also
 cover the requested fixture certificate duration. Otherwise it removes the
 stale Secret so cert-manager issues a replacement before writing `test/.env`.
+
+The Region integration install also overlays the pinned Identity chart's
+organization `administrator` role with read access to the public VolumeClass
+endpoint. This test-only grant lets the bearer-token API suite exercise live
+provider discovery; it does not add global permission or change production
+Identity values.
+
+Fixture generation creates a private simulated Region with deterministic,
+enriched VolumeClasses and a private Kubernetes-backed Region whose provider
+advertises an empty VolumeClass list. The latter carries only the minimal Region
+configuration required by the CRD; VolumeClass discovery never resolves its
+placeholder kubeconfig Secret reference.
 
 Fixture certificates last one hour by default. For longer local sessions,
 override the duration when generating fixtures:

--- a/hack/ci/fixtures/main.go
+++ b/hack/ci/fixtures/main.go
@@ -61,8 +61,9 @@ const (
 
 	// Region IDs (the Region CRD name, exposed as the API region ID) are UUIDs
 	// like every other ID in the API.
-	publicRegion  = "e71f2dd2-0bc9-4601-8f3b-9696a1fa90a7"
-	privateRegion = "fae390a7-9af3-43e3-9a63-02baa1a16680"
+	publicRegion           = "e71f2dd2-0bc9-4601-8f3b-9696a1fa90a7"
+	privateRegion          = "fae390a7-9af3-43e3-9a63-02baa1a16680"
+	emptyVolumeClassRegion = "ec7a356d-ab90-454f-ae2b-4d167cb66541"
 
 	internalAPICertificateName = "ci-region-api-tests"
 	internalAPISystemAccountCN = "unikorn-compute"
@@ -531,7 +532,7 @@ func createSecondaryFixtures(ctx context.Context, ac *identityopenapi.ClientWith
 	return orgID, token
 }
 
-func upsertRegion(ctx context.Context, k8s client.Client, regionNamespace, name string, organizationIDs []string) {
+func upsertRegion(ctx context.Context, k8s client.Client, regionNamespace, name string, spec regionv1.RegionSpec, organizationIDs []string) {
 	region := &regionv1.Region{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -540,9 +541,7 @@ func upsertRegion(ctx context.Context, k8s client.Client, regionNamespace, name 
 				coreconstants.NameLabel: name,
 			},
 		},
-		Spec: regionv1.RegionSpec{
-			Provider: regionv1.ProviderSimulated,
-		},
+		Spec: spec,
 	}
 
 	if len(organizationIDs) > 0 {
@@ -824,6 +823,7 @@ func emitEnv(opts options, primary primaryFixture, secondaryOrgID, secondaryToke
 	fmt.Printf("ADMIN_AUTH_TOKEN=%s\n", primary.adminToken)
 	fmt.Printf("USER_AUTH_TOKEN=%s\n", primary.userToken)
 	fmt.Printf("TEST_REGION_ID=%s\n", testRegionID)
+	fmt.Printf("TEST_EMPTY_VOLUMECLASS_REGION_ID=%s\n", emptyVolumeClassRegion)
 	fmt.Printf("TEST_SERVER_FLAVOR_ID=%s\n", opts.serverFlavorID)
 	fmt.Printf("TEST_SERVER_IMAGE_ID=%s\n", opts.serverImageID)
 	fmt.Printf("TEST_SERVER_INFRASTRUCTURE_REF=%s\n", opts.serverInfrastructureRef)
@@ -868,11 +868,22 @@ func run(opts options) {
 
 	if provider == regionv1.ProviderSimulated && !existingRegion {
 		logf("Creating simulated public region fixture in namespace %s...", opts.regionNamespace)
-		upsertRegion(ctx, k8s, opts.regionNamespace, publicRegion, nil)
+		upsertRegion(ctx, k8s, opts.regionNamespace, publicRegion, regionv1.RegionSpec{Provider: regionv1.ProviderSimulated}, nil)
 	}
 
 	logf("Creating simulated private region fixture in namespace %s...", opts.regionNamespace)
-	upsertRegion(ctx, k8s, opts.regionNamespace, privateRegion, []string{primary.orgID})
+	upsertRegion(ctx, k8s, opts.regionNamespace, privateRegion, regionv1.RegionSpec{Provider: regionv1.ProviderSimulated}, []string{primary.orgID})
+
+	logf("Creating empty VolumeClass region fixture in namespace %s...", opts.regionNamespace)
+	upsertRegion(ctx, k8s, opts.regionNamespace, emptyVolumeClassRegion, regionv1.RegionSpec{
+		Provider: regionv1.ProviderKubernetes,
+		Kubernetes: &regionv1.RegionKubernetesSpec{
+			KubeconfigSecret: &regionv1.NamespacedObject{
+				Namespace: opts.regionNamespace,
+				Name:      "unused-volumeclass-kubeconfig",
+			},
+		},
+	}, []string{primary.orgID})
 
 	emitEnv(opts, primary, secondaryOrgID, secondaryToken, testRegionID, internalAPI)
 }

--- a/hack/ci/fixtures/main_test.go
+++ b/hack/ci/fixtures/main_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -27,9 +29,49 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 )
 
 const testRegionNamespace = "unikorn-region"
+
+type identityTestValues struct {
+	Roles map[string]identityTestRole `json:"roles"`
+}
+
+type identityTestRole struct {
+	Scopes identityTestRoleScopes `json:"scopes"`
+}
+
+type identityTestRoleScopes struct {
+	Global       map[string][]string `json:"global"`
+	Organization map[string][]string `json:"organization"`
+}
+
+func TestIdentityTestAdministratorRoleIsGrantableByPlatformAdministrator(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../identity-test-values.yaml")
+	if err != nil {
+		t.Fatalf("reading Identity test values: %v", err)
+	}
+
+	var values identityTestValues
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		t.Fatalf("decoding Identity test values: %v", err)
+	}
+
+	administrator := values.Roles["administrator"]
+	platformAdministrator := values.Roles["platform-administrator"]
+
+	for endpoint, operations := range administrator.Scopes.Organization {
+		platformOperations := platformAdministrator.Scopes.Global[endpoint]
+		for _, operation := range operations {
+			if !slices.Contains(platformOperations, operation) {
+				t.Errorf("platform-administrator cannot grant administrator permission %s/%s", endpoint, operation)
+			}
+		}
+	}
+}
 
 func TestFirstEnv(t *testing.T) {
 	t.Setenv("FIXTURE_TEST_FIRST_EMPTY", "")

--- a/hack/ci/identity-test-values.yaml
+++ b/hack/ci/identity-test-values.yaml
@@ -1,0 +1,7 @@
+# Helm value overrides applied to the pinned Identity dependency during Region
+# integration testing.
+roles:
+  administrator:
+    scopes:
+      organization:
+        region:volumeclasses:v2: [read]

--- a/hack/ci/identity-test-values.yaml
+++ b/hack/ci/identity-test-values.yaml
@@ -1,6 +1,10 @@
 # Helm value overrides applied to the pinned Identity dependency during Region
 # integration testing.
 roles:
+  platform-administrator:
+    scopes:
+      global:
+        region:volumeclasses:v2: [read]
   administrator:
     scopes:
       organization:

--- a/hack/ci/install
+++ b/hack/ci/install
@@ -133,6 +133,7 @@ IDENTITY_ARGS=(
 if [[ -f "${IDENTITY_TMP}/hack/ci/test-values.yaml" ]]; then
   IDENTITY_ARGS+=(--values "${IDENTITY_TMP}/hack/ci/test-values.yaml")
 fi
+IDENTITY_ARGS+=(--values "${SCRIPT_DIR}/identity-test-values.yaml")
 
 PATH="${IDENTITY_TOOL_TMP}:$PATH" bash "${IDENTITY_TMP}/hack/ci/install" "${IDENTITY_ARGS[@]}" > "${IDENTITY_ENV_FILE}"
 # shellcheck disable=SC1090

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -23,6 +23,10 @@ The useful way to read it is not as a directory tree, but as one system:
   quota-carrying block storage resource. OpenStack create/delete provider
   behavior exists, while its public API, controller, and observed-state
   projection remain later lifecycle slices
+- `VolumeClass` is a separate read-only inventory surface: Regions configure
+  and providers discover the classes they expose, then the public
+  `GET /api/v2/volumeclasses` endpoint returns provider-neutral metadata for
+  Regions visible to the caller. It has no CRD or create/update/delete lifecycle
 - `Server` now carries the internal attach-existing-only block volume intent
   and observed per-volume attachment rows; public API projection and provider
   reconciliation remain separate follow-up work
@@ -62,6 +66,22 @@ These packages define the mixed provider boundary:
 
 OpenStack is the real heavyweight implementation. Kubernetes and simulated are
 alternative substrates shaped to fit the same broad service model.
+
+For VolumeClass inventory, the path through those layers is deliberately
+one-way:
+
+- [`apis/unikorn/v1alpha1`](./apis/unikorn/v1alpha1/README.md) owns the
+  Region-authored OpenStack selector and optional enrichment metadata
+- [`providers`](./providers/README.md) discovers provider inventory through
+  `CommonProvider.VolumeClasses`; OpenStack filters Cinder volume types,
+  Kubernetes returns an empty list, and simulated returns deterministic classes
+- [`handler`](./handler/README.md) filters visible Regions and maps discovered
+  classes through its provider-to-API conversion boundary
+- [`openapi`](./openapi/README.md) defines the public v2 list contract for the
+  resulting provider-neutral, Region-bound metadata
+
+This is discovery, not storage lifecycle: no VolumeClass object is persisted,
+and listing classes does not create provider resources.
 
 ### Handler And Server Layer
 

--- a/test/.env.example
+++ b/test/.env.example
@@ -33,6 +33,7 @@ TEST_SECONDARY_REGION_ID=test-secondary-region-67890
 # TEST_SECONDARY_ORG_ID: a different organization that should NOT see the private region
 # TEST_SECONDARY_AUTH_TOKEN: auth token for TEST_SECONDARY_ORG_ID
 TEST_PRIVATE_REGION_ID=your-private-region-id-here
+TEST_EMPTY_VOLUMECLASS_REGION_ID=your-empty-volumeclass-region-id-here
 TEST_SECONDARY_ORG_ID=your-secondary-org-id-here
 TEST_SECONDARY_AUTH_TOKEN=your-secondary-org-token-here
 

--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -595,6 +595,21 @@ func (c *APIClient) ListFileStorageClasses(ctx context.Context, regionID string)
 	)
 }
 
+// ListVolumeClasses lists provider-neutral volume classes, optionally filtered
+// by one or more regions.
+func (c *APIClient) ListVolumeClasses(ctx context.Context, regionIDs ...string) (regionopenapi.VolumeClassListV2Read, error) {
+	path := c.endpoints.ListVolumeClasses(regionIDs...)
+
+	return coreclient.ListResource[regionopenapi.VolumeClassV2Read](
+		ctx,
+		c.regionClient,
+		path,
+		coreclient.ResponseHandlerConfig{
+			ResourceType: "volumeclasses",
+		},
+	)
+}
+
 // ListNetworks lists all networks for a project in a region.
 func (c *APIClient) ListNetworks(ctx context.Context, orgID, projectID, regionID string) (regionopenapi.NetworksV2Read, error) {
 	path := c.endpoints.ListNetworks(orgID, projectID, regionID)

--- a/test/api/config.go
+++ b/test/api/config.go
@@ -32,6 +32,7 @@ type TestConfig struct {
 	RegionCACertPath        string
 	RegionID                string
 	PrivateRegionID         string
+	EmptyClassRegionID      string
 	SecondaryOrgID          string
 	SecondaryProjectID      string
 	SecondaryAuthToken      string
@@ -96,6 +97,7 @@ func LoadTestConfig() (*TestConfig, error) {
 		ProjectID:               v.GetString("TEST_PROJECT_ID"),
 		RegionID:                v.GetString("TEST_REGION_ID"),
 		PrivateRegionID:         v.GetString("TEST_PRIVATE_REGION_ID"),
+		EmptyClassRegionID:      v.GetString("TEST_EMPTY_VOLUMECLASS_REGION_ID"),
 		SecondaryOrgID:          v.GetString("TEST_SECONDARY_ORG_ID"),
 		SecondaryProjectID:      v.GetString("TEST_SECONDARY_PROJECT_ID"),
 		SecondaryAuthToken:      v.GetString("TEST_SECONDARY_AUTH_TOKEN"),

--- a/test/api/endpoints.go
+++ b/test/api/endpoints.go
@@ -96,6 +96,22 @@ func (e *Endpoints) ListFileStorageClasses(regionID string) string {
 		url.QueryEscape(regionID))
 }
 
+// ListVolumeClasses returns the endpoint for listing available volume classes,
+// optionally filtered by one or more regions.
+func (e *Endpoints) ListVolumeClasses(regionIDs ...string) string {
+	values := url.Values{}
+	for _, regionID := range regionIDs {
+		values.Add("regionID", regionID)
+	}
+
+	path := "/api/v2/volumeclasses"
+	if len(values) == 0 {
+		return path
+	}
+
+	return fmt.Sprintf("%s?%s", path, values.Encode())
+}
+
 // ListNetworks returns the endpoint for listing networks in a project.
 func (e *Endpoints) ListNetworks(orgID, projectID, regionID string) string {
 	return fmt.Sprintf("/api/v2/networks?organizationID=%s&projectID=%s&regionID=%s",

--- a/test/api/suites/volumeclasses_test.go
+++ b/test/api/suites/volumeclasses_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:revive,testpackage // dot imports and package naming are standard for Ginkgo tests
+package suites
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	regionopenapi "github.com/unikorn-cloud/region/pkg/openapi"
+)
+
+const missingVolumeClassRegionID = "00000000-0000-4000-8000-000000000147"
+
+var _ = Describe("VolumeClass Discovery", func() {
+	Context("When listing VolumeClass metadata", func() {
+		Describe("Given a visible Region with default simulated provider configuration", func() {
+			It("should return only the selected Region's enriched provider inventory", func() {
+				volumeClasses, err := regionClient.ListVolumeClasses(
+					ctx,
+					missingVolumeClassRegionID,
+					config.PrivateRegionID,
+					config.PrivateRegionID,
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(volumeClasses).To(HaveLen(2))
+
+				byID := map[string]regionopenapi.VolumeClassV2Read{}
+				for _, volumeClass := range volumeClasses {
+					Expect(volumeClass.Metadata.Id).NotTo(BeEmpty())
+					Expect(volumeClass.Metadata.Name).NotTo(BeEmpty())
+					Expect(volumeClass.Spec.RegionId.String()).To(Equal(config.PrivateRegionID))
+
+					byID[volumeClass.Metadata.Id] = volumeClass
+				}
+
+				standard, found := byID["33333333-3333-3333-3333-333333333333"]
+				Expect(found).To(BeTrue())
+				Expect(standard.Metadata.Name).To(Equal("sim-standard-volume"))
+				Expect(standard.Metadata.Description).To(HaveValue(Equal("Simulated SSD block storage")))
+				Expect(standard.Spec.MinimumSizeGiB).To(HaveValue(Equal(int64(1))))
+				Expect(standard.Spec.MaximumSizeGiB).To(HaveValue(Equal(int64(16384))))
+				Expect(standard.Spec.Media).To(HaveValue(Equal(regionopenapi.VolumeClassV2MediaSsd)))
+				Expect(standard.Spec.Performance).To(BeNil())
+				Expect(standard.Spec.Encrypted).To(BeFalse())
+
+				fast, found := byID["44444444-4444-4444-4444-444444444444"]
+				Expect(found).To(BeTrue())
+				Expect(fast.Metadata.Name).To(Equal("sim-fast-volume"))
+				Expect(fast.Metadata.Description).To(HaveValue(Equal("Simulated NVMe block storage")))
+				Expect(fast.Spec.MinimumSizeGiB).To(HaveValue(Equal(int64(10))))
+				Expect(fast.Spec.MaximumSizeGiB).To(HaveValue(Equal(int64(2048))))
+				Expect(fast.Spec.Media).To(HaveValue(Equal(regionopenapi.VolumeClassV2MediaNvme)))
+				Expect(fast.Spec.Performance).NotTo(BeNil())
+				Expect(fast.Spec.Performance.MaxIOPS).To(HaveValue(Equal(25000)))
+				Expect(fast.Spec.Performance.MaxThroughputMiBps).To(HaveValue(Equal(500)))
+				Expect(fast.Spec.Encrypted).To(BeTrue())
+			})
+		})
+
+		Describe("Given a visible Region exposes no VolumeClass inventory", func() {
+			It("should return a typed non-nil empty list for the selected Region", func() {
+				Expect(config.EmptyClassRegionID).NotTo(BeEmpty())
+
+				Eventually(func(g Gomega) {
+					regions, err := regionClient.ListRegions(ctx, config.OrgID)
+					g.Expect(err).NotTo(HaveOccurred())
+
+					regionIDs := make([]string, 0, len(regions))
+					for _, region := range regions {
+						g.Expect(region.Metadata).NotTo(BeNil())
+						regionIDs = append(regionIDs, region.Metadata.Id)
+					}
+
+					g.Expect(regionIDs).To(ContainElement(config.EmptyClassRegionID))
+				}).WithTimeout(5 * time.Second).WithPolling(250 * time.Millisecond).Should(Succeed())
+
+				volumeClasses, err := regionClient.ListVolumeClasses(ctx, config.EmptyClassRegionID)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(volumeClasses).NotTo(BeNil())
+				Expect(volumeClasses).To(BeEmpty())
+			})
+		})
+	})
+})


### PR DESCRIPTION
## What changed

- add typed public API helpers and integration coverage for VolumeClass metadata listing
- cover repeated Region filters, enriched simulated metadata, and a visible Region with an empty provider inventory
- add deterministic integration fixtures and a test-only Identity role overlay
- document VolumeClass configuration, provider discovery behavior, and public API exposure

## Why

VolumeClass provider discovery and public API behavior existed without end-to-end integration coverage or a clear user-facing configuration guide. This change exercises the published typed contract while documenting provider-specific selection and enrichment semantics.

## Impact

Operators can configure and understand OpenStack VolumeClass filtering and metadata enrichment. The integration suite now detects regressions in filtering, typed response mapping, enrichment, and empty inventory behavior.

This remains read-only discovery coverage. It does not add Volume CRUD, Volume controller lifecycle, Server attach/detach behavior, or global-permission regression coverage.

## Identity fixture permissions

The bearer-token API suite exercises the endpoint through organization-scoped administrator read access. Identity only exposes roles a caller is allowed to grant, so the test overlay mirrors that read permission at global scope for the bootstrap platform administrator. A unit test guards this grant hierarchy. The global permission is used only for fixture bootstrapping; the API integration assertions remain organization-scoped.

## Validation

- `make touch`
- `make license`
- `make validate`
- `make lint` — 0 issues; Helm lint passed
- `make generate`
- `make test-unit`
- `go test -count=1 ./hack/ci/fixtures -run TestIdentityTestAdministratorRoleIsGrantableByPlatformAdministrator`
- `go test -count=1 -tags=integration ./test/api/suites -run '^$'`
- `go test -count=1 ./test/api ./hack/ci/fixtures`
- rendered the pinned Identity chart with both integration values files and verified the administrator and platform-administrator scopes
- `shellcheck hack/ci/install`
- `bash -n hack/ci/install`
- `git diff --check`

Live integration execution was not available locally because this worktree has no configured `test/.env`; integration-tagged compilation passed.
