### PR TITLE
Implement OpenStack Volume discovery and monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ test-results.json
 fuzz-results.xml
 hack/ci/ca-bundle.pem
 .claude/settings.local.json
+
+# Local agent discussion artifacts.
+CONTEXT.md
+docs/adr/

--- a/charts/region/templates/monitor/clusterrole.yaml
+++ b/charts/region/templates/monitor/clusterrole.yaml
@@ -14,6 +14,7 @@ rules:
   - openstackidentities
   - servers
   - openstackservers
+  - volumes
   verbs:
   - list
   - watch
@@ -28,6 +29,7 @@ rules:
   - region.unikorn-cloud.org
   resources:
   - servers/status
+  - volumes/status
   verbs:
   - patch
 # Patch server metadata (annotations) for Pending phase duration tracking.

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -27,10 +27,13 @@ The useful way to read it is not as a directory tree, but as one system:
   A Cinder error is surfaced through a safe typed provisioning condition. Its
   public v2 Volume lifecycle contract and core CRUD handlers are published;
   creation allocates requested capacity through Identity before persisting the
-  Volume. Its provider capability also exposes neutral backing discovery, observed
-  size, and lifecycle state, while OpenStack supports server attachment
-  behavior. Attachment projection, monitor integration, and observed-state
-  projection into the CRD remain later lifecycle slices
+  Volume. Its provider capability exposes neutral backing discovery, observed
+  size, and lifecycle state. The monitor projects that truth into observed
+  size and coarse health without taking over the controller-owned `Available`
+  condition. A provisioned Volume is a durable identity. Provider loss degrades
+  health and never triggers replacement under the same Region Volume ID.
+  OpenStack also supports server
+  attachment behavior. Attachment projection remains a later lifecycle slice
 - `Server` now carries the internal attach-existing-only block volume intent
   and observed per-volume attachment rows. The provider boundary and OpenStack
   Nova attach/detach implementation exist; public API projection and
@@ -102,6 +105,7 @@ relationships.
 
 - [monitor](./monitor/README.md)
 - [monitor/health/server](./monitor/health/server/README.md)
+- [monitor/health/volume](./monitor/health/volume/README.md)
 
 These packages cover the part of the system that is intentionally observational
 rather than declarative.

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -27,8 +27,10 @@ The useful way to read it is not as a directory tree, but as one system:
   A Cinder error is surfaced through a safe typed provisioning condition. Its
   public v2 Volume lifecycle contract and core CRUD handlers are published;
   creation allocates requested capacity through Identity before persisting the
-  Volume, while attachment projection and general observed-state projection
-  remain later lifecycle slices
+  Volume. Its provider capability also exposes neutral backing discovery, observed
+  size, and lifecycle state, while OpenStack supports server attachment
+  behavior. Attachment projection, monitor integration, and observed-state
+  projection into the CRD remain later lifecycle slices
 - `Server` now carries the internal attach-existing-only block volume intent
   and observed per-volume attachment rows. The provider boundary and OpenStack
   Nova attach/detach implementation exist; public API projection and

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -96,10 +96,13 @@ stored objects rely on for linkage, migration, and operational coordination.
   kind and Region resource ID of the resource that owns the volume's attachment
   claim; a nil claim means the volume is available for claiming. `Server` is the
   current supported claim kind. Attachment realization remains outside
-  `Volume.Status`, which is conditions-first and also reserves observed size for
-  later observation work. The Volume controller drives provider create/delete,
-  but provider-side volume identity is rediscovered by stable provider lookup
-  rather than mirrored into status.
+  `Volume.Status`, which is conditions-first. The Volume controller drives
+  provider create/delete and generic provisioning conditions.
+  `Volume.Status.Size` remains a later persisted projection: provider
+  observation returns neutral observed size and lifecycle to its caller, but
+  does not write this CRD. The later monitor projects that provider truth into
+  Volume status. Provider-side volume identity is rediscovered by stable
+  provider lookup rather than mirrored into status.
 - `Server.Spec.Volumes` is the attach-existing-only desired state for block
   storage. Each row names an existing Region `Volume` by ID; inline
   server-created volume templates are deliberately excluded from the first

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -97,12 +97,15 @@ stored objects rely on for linkage, migration, and operational coordination.
   claim; a nil claim means the volume is available for claiming. `Server` is the
   current supported claim kind. Attachment realization remains outside
   `Volume.Status`, which is conditions-first. The Volume controller drives
-  provider create/delete and generic provisioning conditions.
-  `Volume.Status.Size` remains a later persisted projection: provider
-  observation returns neutral observed size and lifecycle to its caller, but
-  does not write this CRD. The later monitor projects that provider truth into
-  Volume status. Provider-side volume identity is rediscovered by stable
-  provider lookup rather than mirrored into status.
+  provider create/delete and exclusively owns the generic `Available`
+  provisioning condition. The Volume monitor projects neutral provider
+  observation into `Volume.Status.Size` and coarse `Healthy`. A successful
+  `Available=True/Provisioned` condition records completion of the one allowed
+  provider create. Confirmed provider absence clears observed size and degrades
+  health. It does not reset provisioning or trigger replacement. Provider
+  request errors preserve observed size and make health unknown. Provider-side
+  volume identity is rediscovered by stable provider lookup rather than
+  mirrored into status.
 - `Server.Spec.Volumes` is the attach-existing-only desired state for block
   storage. Each row names an existing Region `Volume` by ID; inline
   server-created volume templates are deliberately excluded from the first

--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -159,6 +159,11 @@ func (c *Volume) SetProvisioningCondition(status corev1.ConditionStatus, reason 
 	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionAvailable, status, string(reason), message)
 }
 
+// SetHealthCondition sets the provider-observed health of a Volume.
+func (c *Volume) SetHealthCondition(status corev1.ConditionStatus, reason unikornv1core.HealthConditionReason, message string) {
+	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionHealthy, status, string(reason), message)
+}
+
 // ResourceLabels generates a set of labels to uniquely identify the resource
 // if it were to be placed in a single global namespace.
 func (c *Volume) ResourceLabels() (labels.Set, error) {

--- a/pkg/managers/volume/README.md
+++ b/pkg/managers/volume/README.md
@@ -12,3 +12,8 @@ while a typed terminal provider error records its safe `Available=False`
 reason/message without continued polling. Kubernetes increments generation when
 marking a resource for deletion, so the generation predicate also enqueues
 deprovisioning.
+
+After provisioning succeeds, the provisioner treats
+`Available=True/Provisioned` as a create-completed latch. Later generation
+events do not recreate provider storage. The health monitor reports provider
+loss separately through `Healthy`.

--- a/pkg/monitor/README.md
+++ b/pkg/monitor/README.md
@@ -22,9 +22,12 @@ controller watches.
 - runs one or more `Checker`s on a poll interval
 - logs and continues on non-fatal per-check failures
 
-Right now the only checker is
-[health/server](./health/server/README.md), but the abstraction is clearly
-intended to allow additional monitor classes later.
+The current checkers are:
+
+- [health/server](./health/server/README.md), which projects server runtime
+  state and telemetry
+- [health/volume](./health/volume/README.md), which projects provider-neutral
+  Volume size and health while preserving controller-owned provisioning state
 
 ## Caveats
 

--- a/pkg/monitor/health/volume/README.md
+++ b/pkg/monitor/health/volume/README.md
@@ -1,0 +1,23 @@
+# Volume Health
+
+`pkg/monitor/health/volume` asks the provider to update a deep copy of the
+Region `Volume` with its current backing-resource state, then persists one
+optimistic status patch.
+
+The provider owns provider-state mapping, observed size, missing-volume
+semantics, and health messages. The checker owns orchestration, patching, and
+transition logging.
+
+The Volume controller remains the sole owner of the `Available` provisioning
+condition and all create/delete intent. Provider request or observation errors
+are logged and skipped, preserving the last observed status. Provider absence
+semantics are defined by the provider implementation.
+
+Every health transition is logged with its previous and new status, reason, and
+message. Logs also include Volume, organization, and region identifiers.
+The checker never imports provider SDK types. It removes the obsolete Volume
+`Active` condition when it updates status.
+
+Provider resolution results, including failures, are cached by region for one
+poll cycle. A provider initialization failure is attempted once per region, not
+once per Volume.

--- a/pkg/monitor/health/volume/check.go
+++ b/pkg/monitor/health/volume/check.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-logr/logr"
+
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/providers"
+	providertypes "github.com/unikorn-cloud/region/pkg/providers/types"
+
+	corev1 "k8s.io/api/core/v1"
+	apiMeta "k8s.io/apimachinery/pkg/api/meta"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Checker projects provider-observed Volume state into Region status.
+type Checker struct {
+	client    client.Client
+	namespace string
+	providers providers.Providers
+}
+
+// New creates a Volume health checker.
+func New(client client.Client, namespace string, providers providers.Providers) *Checker {
+	return &Checker{client: client, namespace: namespace, providers: providers}
+}
+
+func volumeLogger(ctx context.Context, volume *unikornv1.Volume) logr.Logger {
+	return log.FromContext(ctx).WithValues(
+		"volume_id", volume.Name,
+		"org_id", volume.Labels[coreconstants.OrganizationLabel],
+		"region_id", volume.Labels[constants.RegionLabel],
+	)
+}
+
+func logTransitions(ctx context.Context, before, after *unikornv1.Volume) {
+	logger := volumeLogger(ctx, after)
+
+	oldHealth, oldErr := unikornv1core.GetHealthyCondition(before)
+	newHealth, newErr := unikornv1core.GetHealthyCondition(after)
+
+	if newErr == nil && (oldErr != nil || oldHealth.Status != newHealth.Status || oldHealth.Reason != newHealth.Reason || oldHealth.Message != newHealth.Message) {
+		fromStatus := corev1.ConditionUnknown
+		fromReason := unikornv1core.HealthConditionReason("")
+		fromMessage := ""
+
+		if oldErr == nil {
+			fromStatus = oldHealth.Status
+			fromReason = oldHealth.Reason
+			fromMessage = oldHealth.Message
+		}
+
+		logger.Info("volume health transition",
+			"from_status", fromStatus,
+			"from_health", fromReason,
+			"from_message", fromMessage,
+			"to_status", newHealth.Status,
+			"to_health", newHealth.Reason,
+			"to_message", newHealth.Message,
+		)
+	}
+}
+
+func isFatal(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+type providerEntry struct {
+	provider providertypes.Provider
+	err      error
+}
+
+func (c *Checker) resolveProvider(ctx context.Context, cache map[string]providerEntry, regionID string) (providertypes.Provider, error) {
+	if entry, ok := cache[regionID]; ok {
+		return entry.provider, entry.err
+	}
+
+	provider, err := c.providers.LookupCloud(regionID)
+	if err != nil {
+		if !isFatal(err) {
+			log.FromContext(ctx).Error(err, "failed to resolve volume provider", "region_id", regionID)
+			cache[regionID] = providerEntry{err: err}
+		}
+
+		return nil, err
+	}
+
+	cache[regionID] = providerEntry{provider: provider}
+
+	return provider, nil
+}
+
+func (c *Checker) patchStatus(ctx context.Context, volume, updated *unikornv1.Volume) error {
+	if err := c.client.Status().Patch(ctx, updated, client.MergeFromWithOptions(volume, &client.MergeFromWithOptimisticLock{})); err != nil {
+		if isFatal(err) {
+			return err
+		}
+
+		volumeLogger(ctx, volume).Error(err, "failed to update volume status, skipping")
+
+		return nil
+	}
+
+	logTransitions(ctx, volume, updated)
+
+	return nil
+}
+
+func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume, providers map[string]providerEntry) error {
+	if volume.DeletionTimestamp != nil {
+		return nil
+	}
+
+	regionID, ok := volume.Labels[constants.RegionLabel]
+	if !ok {
+		volumeLogger(ctx, volume).Info("volume missing region label, skipping")
+		return nil
+	}
+
+	identityID, ok := volume.Labels[constants.IdentityLabel]
+	if !ok {
+		volumeLogger(ctx, volume).Info("volume missing identity label, skipping")
+		return nil
+	}
+
+	updated := volume.DeepCopy()
+	apiMeta.RemoveStatusCondition(&updated.Status.Conditions, string(unikornv1core.ConditionActive))
+
+	provider, err := c.resolveProvider(ctx, providers, regionID)
+	if err != nil {
+		if isFatal(err) {
+			return err
+		}
+
+		return nil
+	}
+
+	identity := &unikornv1.Identity{}
+	if err := c.client.Get(ctx, client.ObjectKey{Namespace: c.namespace, Name: identityID}, identity); err != nil {
+		if isFatal(err) {
+			return err
+		}
+
+		volumeLogger(ctx, volume).Error(err, "failed to resolve volume identity, skipping")
+
+		return nil
+	}
+
+	if err := provider.UpdateVolumeState(ctx, identity, updated); err != nil {
+		if isFatal(err) {
+			return err
+		}
+
+		volumeLogger(ctx, volume).Error(err, "failed to update provider volume state, skipping")
+
+		return nil
+	}
+
+	return c.patchStatus(ctx, volume, updated)
+}
+
+// Check observes every non-deleting Volume in the configured namespace.
+func (c *Checker) Check(ctx context.Context) error {
+	volumes := &unikornv1.VolumeList{}
+	if err := c.client.List(ctx, volumes, &client.ListOptions{Namespace: c.namespace}); err != nil {
+		return err
+	}
+
+	providers := make(map[string]providerEntry)
+
+	for i := range volumes.Items {
+		if err := c.processVolume(ctx, &volumes.Items[i], providers); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/monitor/health/volume/check_test.go
+++ b/pkg/monitor/health/volume/check_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	volumehealth "github.com/unikorn-cloud/region/pkg/monitor/health/volume"
+	mockproviders "github.com/unikorn-cloud/region/pkg/providers/mock"
+	mocktypes "github.com/unikorn-cloud/region/pkg/providers/types/mock"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testNamespace      = "test-ns"
+	testRegionID       = "region-1"
+	testIdentityID     = "identity-1"
+	testVolumeID       = "11111111-1111-4111-8111-111111111111"
+	testOrganizationID = "00000000-0000-4000-8000-000000000001"
+)
+
+var (
+	errProviderLookup = errors.New("provider lookup failed")
+	errProviderState  = errors.New("provider state failed")
+)
+
+func volumeFixture() *unikornv1.Volume {
+	volume := &unikornv1.Volume{ObjectMeta: metav1.ObjectMeta{
+		Name: testVolumeID, Namespace: testNamespace,
+		Labels: map[string]string{
+			coreconstants.OrganizationLabel: testOrganizationID,
+			constants.RegionLabel:           testRegionID,
+			constants.IdentityLabel:         testIdentityID,
+		},
+	}}
+	volume.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "")
+	unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionActive, corev1.ConditionTrue, "legacy", "legacy condition")
+
+	return volume
+}
+
+func fakeClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme() //nolint:wsl
+
+	require.NoError(t, unikornv1.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&unikornv1.Volume{}).WithObjects(objects...).Build()
+}
+
+func runCheck(t *testing.T, volume *unikornv1.Volume, lookupErr, updateErr error, mutate func(*unikornv1.Volume)) *unikornv1.Volume {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	provider := mocktypes.NewMockProvider(ctrl)
+	providers := mockproviders.NewMockProviders(ctrl)
+	if lookupErr != nil { //nolint:wsl
+		providers.EXPECT().LookupCloud(testRegionID).Return(nil, lookupErr)
+	} else {
+		providers.EXPECT().LookupCloud(testRegionID).Return(provider, nil)
+		provider.EXPECT().UpdateVolumeState(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ any, _ any, got *unikornv1.Volume) error {
+			if mutate != nil {
+				mutate(got)
+			}
+
+			return updateErr
+		})
+	}
+
+	identity := &unikornv1.Identity{ObjectMeta: metav1.ObjectMeta{Name: testIdentityID, Namespace: testNamespace}}
+	k8sClient := fakeClient(t, identity, volume)
+
+	require.NoError(t, volumehealth.New(k8sClient, testNamespace, providers).Check(t.Context()))
+	updated := &unikornv1.Volume{} //nolint:wsl
+
+	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(volume), updated))
+
+	return updated
+}
+
+func TestCheckPersistsProviderProjection(t *testing.T) {
+	t.Parallel()
+
+	updated := runCheck(t, volumeFixture(), nil, nil, func(volume *unikornv1.Volume) {
+		size := resource.MustParse("20Gi")
+		volume.Status.Size = &size
+		unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionTrue, string(unikornv1core.ConditionReasonHealthy), "provider healthy")
+	})
+	require.NotNil(t, updated.Status.Size)
+	require.True(t, updated.Status.Size.Equal(resource.MustParse("20Gi")))
+	health, err := unikornv1core.GetHealthyCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, "provider healthy", health.Message)
+
+	_, err = unikornv1core.GetCondition(updated.Status.Conditions, unikornv1core.ConditionActive)
+	require.Error(t, err)
+}
+
+func TestCheckPreservesStateWhenProviderUnavailable(t *testing.T) {
+	t.Parallel()
+
+	volume := volumeFixture()
+	size := resource.MustParse("10Gi")
+	volume.Status.Size = &size
+	unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionTrue, string(unikornv1core.ConditionReasonHealthy), "last state")
+	updated := runCheck(t, volume, errProviderLookup, nil, nil)
+	require.True(t, updated.Status.Size.Equal(resource.MustParse("10Gi")))
+	health, err := unikornv1core.GetHealthyCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, "last state", health.Message)
+}
+
+func TestCheckPreservesStateWhenProviderObservationFails(t *testing.T) {
+	t.Parallel()
+
+	volume := volumeFixture()
+	unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionTrue, string(unikornv1core.ConditionReasonHealthy), "last state")
+	updated := runCheck(t, volume, nil, errProviderState, nil)
+	health, err := unikornv1core.GetHealthyCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, "last state", health.Message)
+}
+
+func TestCheckPersistsProviderMissingProjection(t *testing.T) {
+	t.Parallel()
+
+	updated := runCheck(t, volumeFixture(), nil, nil, func(volume *unikornv1.Volume) {
+		volume.Status.Size = nil
+		unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionFalse, string(unikornv1core.ConditionReasonDegraded), "the provider volume is missing")
+	})
+	health, err := unikornv1core.GetHealthyCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, unikornv1core.ConditionReasonDegraded, health.Reason)
+	require.Nil(t, updated.Status.Size)
+}

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/unikorn-cloud/core/pkg/options"
 	"github.com/unikorn-cloud/region/pkg/constants"
 	serverhealth "github.com/unikorn-cloud/region/pkg/monitor/health/server"
+	volumehealth "github.com/unikorn-cloud/region/pkg/monitor/health/volume"
 	"github.com/unikorn-cloud/region/pkg/providers"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,6 +84,7 @@ func Run(ctx context.Context, c client.Client, o *Options) error {
 
 	checkers := []Checker{
 		serverhealth.New(c, o.CoreOptions.Namespace, providerCache, serverMetrics),
+		volumehealth.New(c, o.CoreOptions.Namespace, providerCache),
 	}
 
 	for {

--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -80,8 +80,8 @@ packages are the concrete provider implementations.
     removal wait for provider convergence
   - its `resource.Quantity` size and one of the nine neutral lifecycle values
     (`creating`, `available`, `attaching`, `attached`, `detaching`, `updating`,
-    `deleting`, `error`, or `unknown`) let later consumers observe backing truth
-    without importing a provider SDK
+    `deleting`, `error`, or `unknown`) let the Volume monitor project backing
+    truth without importing a provider SDK
   - no backing resource maps to the shared `ErrResourceNotFound` sentinel;
     client/request failures remain Go errors, while successfully observed
     provider `error` and unrecognized/empty `unknown` lifecycle values remain

--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -61,14 +61,14 @@ packages are the concrete provider implementations.
     the real backing resources
   - mirrored provider-state records are not the preferred answer unless the
     state cannot be reconstructed safely enough by other means
-- `types.Volume` is the focused create/delete/observation capability embedded in the full
+- `types.Volume` is the focused create/delete/state-update capability embedded in the full
   `types.Provider` contract and consumed through `LookupCloud` by the Volume
   controller. Discovery-only providers remain on `types.CommonProvider` and do
   not implement workload lifecycle:
   - lifecycle intent is the native Region `Volume` CRD
   - provider implementations rediscover their backing object internally before
-    create, delete, or observation; observation returns a `types.VolumeObservation`
-    rather than writing the CRD
+    create, delete, or state update; `UpdateVolumeState` mutates the CRD status
+    without exposing provider SDK types
   - create success means the rediscovered backing volume is usable, not merely
     that an asynchronous provider request was accepted. Providers return
     `provisioners.ErrYield` while creation is still converging and a safe typed

--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -61,13 +61,14 @@ packages are the concrete provider implementations.
     the real backing resources
   - mirrored provider-state records are not the preferred answer unless the
     state cannot be reconstructed safely enough by other means
-- `types.Volume` is the focused create/delete capability embedded in the full
+- `types.Volume` is the focused create/delete/observation capability embedded in the full
   `types.Provider` contract and consumed through `LookupCloud` by the Volume
   controller. Discovery-only providers remain on `types.CommonProvider` and do
   not implement workload lifecycle:
   - lifecycle intent is the native Region `Volume` CRD
   - provider implementations rediscover their backing object internally before
-    create or delete; rediscovery is not a public existence-only contract
+    create, delete, or observation; observation returns a `types.VolumeObservation`
+    rather than writing the CRD
   - create success means the rediscovered backing volume is usable, not merely
     that an asynchronous provider request was accepted. Providers return
     `provisioners.ErrYield` while creation is still converging and a safe typed
@@ -77,9 +78,14 @@ packages are the concrete provider implementations.
     merely that an asynchronous provider request was accepted. Accepted delete
     requests return `provisioners.ErrYield` so allocation cleanup and finalizer
     removal wait for provider convergence
-  - provider-neutral observation belongs to the later read-side slice and is
-    not implied by the provider-internal state check required to converge
-    controller create/delete support
+  - its `resource.Quantity` size and one of the nine neutral lifecycle values
+    (`creating`, `available`, `attaching`, `attached`, `detaching`, `updating`,
+    `deleting`, `error`, or `unknown`) let later consumers observe backing truth
+    without importing a provider SDK
+  - no backing resource maps to the shared `ErrResourceNotFound` sentinel;
+    client/request failures remain Go errors, while successfully observed
+    provider `error` and unrecognized/empty `unknown` lifecycle values remain
+    successful observations
   - VolumeClass inventory remains on `CommonProvider`, and server
     attach/detach is a separate capability
 - Provider `Delete*` methods must be idempotent and must tolerate an unrealized

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -316,9 +316,10 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
     observations, not Go errors.
   - observation returns only the neutral size and lifecycle result. It neither
     writes `Volume.Status` nor introduces a mirrored provider-state CRD. The
-    later monitor projects observed provider size and lifecycle into Volume
-    status; the Volume controller separately owns create/delete intent and
-    generic provisioning conditions. VolumeClass inventory and Nova
+    Volume monitor projects observed provider size, lifecycle, and coarse
+    health into Volume status; the Volume controller separately owns
+    create/delete intent and the generic `Available` provisioning condition.
+    VolumeClass inventory and Nova
     attach/detach remain separate capabilities
 - Flavor export is a hybrid model: OpenStack discovers the flavor inventory, but
   region configuration can enrich or override user-facing flavor metadata such

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -255,13 +255,14 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   - identity-scoped resources use fixed generated names
   - network lookups rely on deterministic names
   - Cinder volumes use `volume-{Region Volume UUID}` inside the service
-    principal's project; create, delete, attach, and detach rediscover that
-    exact name
+    principal's project; create, delete, observation, attach, and detach
+    rediscover that exact name
   - server metadata is written deliberately as both a control-plane lookup aid
     and an in-guest linkage surface exposed through the metadata service
   - legacy camelCase server metadata keys remain frozen for backwards
     compatibility while newer namespaced keys provide the upgrade path
-- Cinder Volume create/delete is a project-scoped lifecycle slice:
+- Cinder Volume create/delete and observation are project-scoped lifecycle
+  operations:
   - the Region Volume controller resolves the full cloud provider and drives
     its Volume capability after the service-principal Identity is ready
   - the native Region `Volume` CRD supplies the requested size and
@@ -288,10 +289,37 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
     `OpenstackIdentity` as proof that no provider volume could have been
     created; this lets controller deletion delegate unconditionally before
     releasing any Identity allocation
-  - general observed size/status mapping and VolumeClass inventory are outside
-    this lifecycle slice; the narrow status classification above exists only to
-    determine create convergence, while Nova attach/detach is the separate
-    server-owned provider slice described below
+  - observation creates an ephemeral Cinder client in the identity's project,
+    exact-matches the stable name `volume-{Region Volume UUID}` after Cinder's
+    fuzzy name filter, and fails closed on duplicate exact matches
+  - after discovery it validates all six system linkage keys written at create:
+    `region:volume_id`, `identity:organization_id`, `identity:project_id`,
+    `region:region_id`, `region:network_id`, and `region:identity_id`.
+    An empty Region-side linkage anchor or missing/conflicting Cinder linkage is
+    `ErrConsistency`, not a successful observation or a not-found result;
+    mutable user tag metadata is not part of this validation
+  - Cinder's whole-GiB capacity becomes a binary `resource.Quantity` by
+    multiplying by one GiB. Negative capacity or a value that cannot be
+    represented in bytes as an `int64` is `ErrConsistency`, not a neutral
+    observation. Cinder lifecycle values map to neutral values as follows:
+    `creating` and `available` retain their names; `reserved` and
+    `attaching` become `attaching`; `in-use` becomes `attached`; `detaching`
+    and `deleting` retain their names; `managing`, `maintenance`,
+    `restoring-backup`, `awaiting-transfer`, `backing-up`, `downloading`,
+    `uploading`, `retyping`, and `extending` become `updating`; and `error`,
+    `error_deleting`, `error_managing`, `error_restoring`, `error_backing-up`,
+    and `error_extending` become `error`. Empty or unrecognized values become
+    `unknown`.
+  - no exact match returns `ErrResourceNotFound`, while Cinder request,
+    decoding, and client-construction failures remain errors. A recognized
+    Cinder error lifecycle and an unknown lifecycle are successful neutral
+    observations, not Go errors.
+  - observation returns only the neutral size and lifecycle result. It neither
+    writes `Volume.Status` nor introduces a mirrored provider-state CRD. The
+    later monitor projects observed provider size and lifecycle into Volume
+    status; the Volume controller separately owns create/delete intent and
+    generic provisioning conditions. VolumeClass inventory and Nova
+    attach/detach remain separate capabilities
 - Flavor export is a hybrid model: OpenStack discovers the flavor inventory, but
   region configuration can enrich or override user-facing flavor metadata such
   as architecture, baremetal status, and GPU semantics. Architecture resolves
@@ -331,12 +359,13 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
   compute and block-storage clients from the service principal, rediscovers the
   Nova server and detailed Cinder volume, and uses Cinder's attachment rows as
   the normal-path observation before calling Nova's volume-attachment
-  create/delete API. Cinder volume lifecycle observation is not part of this
-  slice. The Cinder name filter is treated as fuzzy and is post-filtered against
-  the exact stable name `volume-{Volume.Name}`; duplicate exact matches fail
-  closed with `ErrConsistency`. Only the optional guest device name crosses the
-  provider-neutral boundary; Nova and Cinder IDs and Gophercloud objects remain
-  internal.
+  create/delete API. Cinder volume lifecycle observation is a separate
+  capability from this attachment slice. The Cinder name filter is treated as
+  fuzzy and post-filtered against the exact stable name
+  `volume-{Volume.Name}`; duplicate
+  exact matches fail closed with `ErrConsistency`. Only the optional guest
+  device name crosses the provider-neutral boundary; Nova and Cinder IDs and
+  Gophercloud objects remain internal.
 
   Attachment behavior is deliberately asymmetric:
   - attach requires both the server and volume; either missing resource maps to

--- a/pkg/providers/internal/openstack/export_test.go
+++ b/pkg/providers/internal/openstack/export_test.go
@@ -263,6 +263,10 @@ func ReconcileVolume(ctx context.Context, client VolumeInterface, identity *unik
 	return reconcileVolume(ctx, client, identity, volume)
 }
 
+func ObserveVolumeWithClient(ctx context.Context, client VolumeInterface, identity *unikornv1.Identity, volume *unikornv1.Volume) (*types.VolumeObservation, error) {
+	return observeVolume(ctx, client, identity, volume)
+}
+
 func DeleteVolumeWithClient(ctx context.Context, client VolumeInterface, volume *unikornv1.Volume) error {
 	return deleteVolume(ctx, client, volume)
 }

--- a/pkg/providers/internal/openstack/export_test.go
+++ b/pkg/providers/internal/openstack/export_test.go
@@ -263,8 +263,8 @@ func ReconcileVolume(ctx context.Context, client VolumeInterface, identity *unik
 	return reconcileVolume(ctx, client, identity, volume)
 }
 
-func ObserveVolumeWithClient(ctx context.Context, client VolumeInterface, identity *unikornv1.Identity, volume *unikornv1.Volume) (*types.VolumeObservation, error) {
-	return observeVolume(ctx, client, identity, volume)
+func UpdateVolumeStateWithClient(ctx context.Context, client VolumeInterface, identity *unikornv1.Identity, volume *unikornv1.Volume) error {
+	return updateVolumeState(ctx, client, identity, volume)
 }
 
 func DeleteVolumeWithClient(ctx context.Context, client VolumeInterface, volume *unikornv1.Volume) error {

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -1987,14 +1987,7 @@ func (p *Provider) deleteNetwork(ctx context.Context, networking NetworkingInter
 }
 
 func volumeMetadata(identity *unikornv1.Identity, volume *unikornv1.Volume) map[string]string {
-	namespacedSystemMetadata := map[string]string{
-		"region:volume_id":         volume.Name,
-		"identity:organization_id": volume.Labels[coreconstants.OrganizationLabel],
-		"identity:project_id":      volume.Labels[coreconstants.ProjectLabel],
-		"region:region_id":         volume.Labels[constants.RegionLabel],
-		"region:network_id":        volume.Spec.NetworkID,
-		"region:identity_id":       identity.Name,
-	}
+	namespacedSystemMetadata := volumeSystemMetadata(identity, volume)
 
 	metadata := make(map[string]string, len(volume.Spec.Tags)+len(namespacedSystemMetadata))
 

--- a/pkg/providers/internal/openstack/provider_volume_observation_test.go
+++ b/pkg/providers/internal/openstack/provider_volume_observation_test.go
@@ -115,7 +115,9 @@ func TestUpdateVolumeStateMapsCinderStatuses(t *testing.T) {
 	for cinderStatus, want := range tests {
 		t.Run(cinderStatus, func(t *testing.T) {
 			t.Parallel()
+
 			identity, volume := identityFixture(), volumeFixture()
+
 			require.NoError(t, updateVolumeState(t, identity, volume, observedCinderVolume(identity, volume, cinderStatus, 20), nil))
 
 			health, err := unikornv1core.GetHealthyCondition(volume)
@@ -131,7 +133,9 @@ func TestUpdateVolumeStateHandlesMissingAfterProvisioning(t *testing.T) {
 	t.Parallel()
 
 	identity, volume := identityFixture(), volumeFixture()
+
 	volume.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "")
+
 	size := resource.MustParse("20Gi")
 	volume.Status.Size = &size
 
@@ -170,15 +174,16 @@ func TestUpdateVolumeStatePreservesStateOnProviderError(t *testing.T) {
 func TestUpdateVolumeStateRejectsInvalidProviderData(t *testing.T) {
 	t.Parallel()
 
-	identity, volume := identityFixture(), volumeFixture()
-	for _, size := range []int{-1, int(math.MaxInt64 >> 30)} {
-		if size == int(math.MaxInt64>>30) && strconv.IntSize < 64 {
-			continue
-		}
-		if size >= 0 {
-			size++
-		}
+	check := func(size int) {
+		identity, volume := identityFixture(), volumeFixture()
+
 		require.ErrorIs(t, updateVolumeState(t, identity, volume, observedCinderVolume(identity, volume, "available", size), nil), coreerrors.ErrConsistency)
+	}
+
+	check(-1)
+
+	if strconv.IntSize >= 64 {
+		check(int(math.MaxInt64>>30) + 1)
 	}
 }
 

--- a/pkg/providers/internal/openstack/provider_volume_observation_test.go
+++ b/pkg/providers/internal/openstack/provider_volume_observation_test.go
@@ -1,0 +1,339 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack_test
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack"
+	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack/mock"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var errVolumeObservationProvider = errors.New("cinder unavailable")
+
+func observedCinderVolume(identity *regionv1.Identity, volume *regionv1.Volume, status string, size int) *volumes.Volume {
+	return &volumes.Volume{
+		ID:     "provider-volume-id",
+		Name:   "volume-" + volume.Name,
+		Status: status,
+		Size:   size,
+		Metadata: map[string]string{
+			"region:volume_id":         volume.Name,
+			"identity:organization_id": organizationID,
+			"identity:project_id":      projectID,
+			"region:region_id":         regionID,
+			"region:network_id":        volume.Spec.NetworkID,
+			"region:identity_id":       identity.Name,
+		},
+	}
+}
+
+func TestObserveVolumeReturnsProviderNeutralResult(t *testing.T) {
+	t.Parallel()
+
+	identity, volume := identityFixture(), volumeFixture()
+	c := gomock.NewController(t)
+	blockStorage := mock.NewMockVolumeInterface(c)
+	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, "available", 20), nil)
+
+	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+	require.NoError(t, err)
+	require.Equal(t, types.VolumeStatusAvailable, got.Status)
+}
+
+func TestObserveVolumeMapsCinderStatuses(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]types.VolumeStatus{
+		"creating":            types.VolumeStatusCreating,
+		"available":           types.VolumeStatusAvailable,
+		"reserved":            types.VolumeStatusAttaching,
+		"attaching":           types.VolumeStatusAttaching,
+		"in-use":              types.VolumeStatusAttached,
+		"detaching":           types.VolumeStatusDetaching,
+		"deleting":            types.VolumeStatusDeleting,
+		"managing":            types.VolumeStatusUpdating,
+		"maintenance":         types.VolumeStatusUpdating,
+		"restoring-backup":    types.VolumeStatusUpdating,
+		"awaiting-transfer":   types.VolumeStatusUpdating,
+		"backing-up":          types.VolumeStatusUpdating,
+		"downloading":         types.VolumeStatusUpdating,
+		"uploading":           types.VolumeStatusUpdating,
+		"retyping":            types.VolumeStatusUpdating,
+		"extending":           types.VolumeStatusUpdating,
+		"error":               types.VolumeStatusError,
+		"error_deleting":      types.VolumeStatusError,
+		"error_managing":      types.VolumeStatusError,
+		"error_restoring":     types.VolumeStatusError,
+		"error_backing-up":    types.VolumeStatusError,
+		"error_extending":     types.VolumeStatusError,
+		"":                    types.VolumeStatusUnknown,
+		"future-cinder-state": types.VolumeStatusUnknown,
+	}
+
+	for cinderStatus, want := range cases {
+		name := cinderStatus
+		if name == "" {
+			name = "unknown-empty"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			identity, volume := identityFixture(), volumeFixture()
+			c := gomock.NewController(t)
+			blockStorage := mock.NewMockVolumeInterface(c)
+			blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, cinderStatus, 20), nil)
+
+			got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+			require.NoError(t, err)
+			require.Equal(t, want, got.Status)
+		})
+	}
+}
+
+func TestObserveVolumeReturnsResourceNotFound(t *testing.T) {
+	t.Parallel()
+
+	identity, volume := identityFixture(), volumeFixture()
+	c := gomock.NewController(t)
+	blockStorage := mock.NewMockVolumeInterface(c)
+	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(nil, coreerrors.ErrResourceNotFound)
+
+	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+	require.Nil(t, got)
+	require.ErrorIs(t, err, coreerrors.ErrResourceNotFound)
+}
+
+func TestObserveVolumePreservesProviderError(t *testing.T) {
+	t.Parallel()
+
+	identity, volume := identityFixture(), volumeFixture()
+	c := gomock.NewController(t)
+	blockStorage := mock.NewMockVolumeInterface(c)
+	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(nil, errVolumeObservationProvider)
+
+	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+	require.Nil(t, got)
+	require.ErrorIs(t, err, errVolumeObservationProvider)
+}
+
+func TestObserveVolumeConvertsObservedSize(t *testing.T) {
+	t.Parallel()
+
+	identity, volume := identityFixture(), volumeFixture()
+	c := gomock.NewController(t)
+	blockStorage := mock.NewMockVolumeInterface(c)
+	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, "available", 37), nil)
+
+	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+	require.NoError(t, err)
+	require.Zero(t, got.Size.Cmp(resource.MustParse("37Gi")))
+}
+
+func TestObserveVolumeConvertsMaxRepresentableSize(t *testing.T) {
+	t.Parallel()
+
+	if strconv.IntSize < 64 {
+		t.Skip("Cinder's int size cannot represent the largest safe GiB value on this architecture")
+	}
+
+	maxSizeGiB := int64(math.MaxInt64 >> 30)
+	identity, volume := identityFixture(), volumeFixture()
+	c := gomock.NewController(t)
+	blockStorage := mock.NewMockVolumeInterface(c)
+	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, "available", int(maxSizeGiB)), nil)
+
+	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+	require.NoError(t, err)
+	require.Zero(t, got.Size.Cmp(resource.MustParse("8589934591Gi")))
+}
+
+func TestObserveVolumeRejectsNegativeSize(t *testing.T) {
+	t.Parallel()
+
+	identity, volume := identityFixture(), volumeFixture()
+	c := gomock.NewController(t)
+	blockStorage := mock.NewMockVolumeInterface(c)
+	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, "available", -1), nil)
+
+	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+	require.Nil(t, got)
+	require.ErrorIs(t, err, coreerrors.ErrConsistency)
+}
+
+func TestObserveVolumeRejectsOverflowSize(t *testing.T) {
+	t.Parallel()
+
+	if strconv.IntSize < 64 {
+		t.Skip("Cinder's int size cannot exceed the largest safe GiB value on this architecture")
+	}
+
+	maxSizeGiB := int64(math.MaxInt64 >> 30)
+	identity, volume := identityFixture(), volumeFixture()
+	c := gomock.NewController(t)
+	blockStorage := mock.NewMockVolumeInterface(c)
+	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, "available", int(maxSizeGiB+1)), nil)
+
+	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+	require.Nil(t, got)
+	require.ErrorIs(t, err, coreerrors.ErrConsistency)
+}
+
+func TestObserveVolumeRejectsInvalidMetadata(t *testing.T) {
+	t.Parallel()
+
+	keys := map[string]string{
+		"volume ID":       "region:volume_id",
+		"organization ID": "identity:organization_id",
+		"project ID":      "identity:project_id",
+		"region ID":       "region:region_id",
+		"network ID":      "region:network_id",
+		"identity ID":     "region:identity_id",
+	}
+
+	for name, key := range keys {
+		for _, mutation := range []string{"missing", "conflicting"} {
+			t.Run(mutation+" "+name, func(t *testing.T) {
+				t.Parallel()
+
+				identity, volume := identityFixture(), volumeFixture()
+				cinderVolume := observedCinderVolume(identity, volume, "available", 20)
+
+				if mutation == "missing" {
+					delete(cinderVolume.Metadata, key)
+				} else {
+					cinderVolume.Metadata[key] = "other-resource"
+				}
+
+				c := gomock.NewController(t)
+				blockStorage := mock.NewMockVolumeInterface(c)
+				blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
+
+				got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+				require.Nil(t, got)
+				require.ErrorIs(t, err, coreerrors.ErrConsistency)
+			})
+		}
+	}
+
+	t.Run("nil metadata", func(t *testing.T) {
+		t.Parallel()
+
+		identity, volume := identityFixture(), volumeFixture()
+		cinderVolume := observedCinderVolume(identity, volume, "available", 20)
+		cinderVolume.Metadata = nil
+		c := gomock.NewController(t)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
+
+		got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+		require.Nil(t, got)
+		require.ErrorIs(t, err, coreerrors.ErrConsistency)
+	})
+}
+
+func TestObserveVolumeRejectsEmptyExpectedMetadata(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		key   string
+		clear func(*regionv1.Identity, *regionv1.Volume)
+	}{
+		"volume ID": {
+			key: "region:volume_id",
+			clear: func(_ *regionv1.Identity, volume *regionv1.Volume) {
+				volume.Name = ""
+			},
+		},
+		"organization ID": {
+			key: "identity:organization_id",
+			clear: func(_ *regionv1.Identity, volume *regionv1.Volume) {
+				volume.Labels[coreconstants.OrganizationLabel] = ""
+			},
+		},
+		"project ID": {
+			key: "identity:project_id",
+			clear: func(_ *regionv1.Identity, volume *regionv1.Volume) {
+				volume.Labels[coreconstants.ProjectLabel] = ""
+			},
+		},
+		"region ID": {
+			key: "region:region_id",
+			clear: func(_ *regionv1.Identity, volume *regionv1.Volume) {
+				volume.Labels[constants.RegionLabel] = ""
+			},
+		},
+		"network ID": {
+			key: "region:network_id",
+			clear: func(_ *regionv1.Identity, volume *regionv1.Volume) {
+				volume.Spec.NetworkID = ""
+			},
+		},
+		"identity ID": {
+			key: "region:identity_id",
+			clear: func(identity *regionv1.Identity, _ *regionv1.Volume) {
+				identity.Name = ""
+			},
+		},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			identity, volume := identityFixture(), volumeFixture()
+			testCase.clear(identity, volume)
+			cinderVolume := observedCinderVolume(identity, volume, "available", 20)
+			cinderVolume.Metadata[testCase.key] = ""
+			c := gomock.NewController(t)
+			blockStorage := mock.NewMockVolumeInterface(c)
+			blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
+
+			got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+			require.Nil(t, got)
+			require.ErrorIs(t, err, coreerrors.ErrConsistency)
+		})
+	}
+}
+
+func TestObserveVolumeRejectsNilResult(t *testing.T) {
+	t.Parallel()
+
+	identity, volume := identityFixture(), volumeFixture()
+	c := gomock.NewController(t)
+	blockStorage := mock.NewMockVolumeInterface(c)
+	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(nil, nil)
+
+	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+	require.Nil(t, got)
+	require.ErrorIs(t, err, coreerrors.ErrConsistency)
+}

--- a/pkg/providers/internal/openstack/provider_volume_observation_test.go
+++ b/pkg/providers/internal/openstack/provider_volume_observation_test.go
@@ -26,18 +26,17 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
 	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
-	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack"
 	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack/mock"
-	"github.com/unikorn-cloud/region/pkg/providers/types"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-var errVolumeObservationProvider = errors.New("cinder unavailable")
+var errVolumeStateProvider = errors.New("cinder unavailable")
 
 func observedCinderVolume(identity *regionv1.Identity, volume *regionv1.Volume, status string, size int) *volumes.Volume {
 	return &volumes.Volume{
@@ -56,284 +55,138 @@ func observedCinderVolume(identity *regionv1.Identity, volume *regionv1.Volume, 
 	}
 }
 
-func TestObserveVolumeReturnsProviderNeutralResult(t *testing.T) {
+func updateVolumeState(t *testing.T, identity *regionv1.Identity, volume *regionv1.Volume, providerVolume *volumes.Volume, providerErr error) error {
+	t.Helper()
+	c := gomock.NewController(t)
+	blockStorage := mock.NewMockVolumeInterface(c)
+	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(providerVolume, providerErr)
+
+	return openstack.UpdateVolumeStateWithClient(t.Context(), blockStorage, identity, volume)
+}
+
+func TestUpdateVolumeStateProjectsSizeAndHealth(t *testing.T) {
 	t.Parallel()
 
 	identity, volume := identityFixture(), volumeFixture()
-	c := gomock.NewController(t)
-	blockStorage := mock.NewMockVolumeInterface(c)
-	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, "available", 20), nil)
+	require.NoError(t, updateVolumeState(t, identity, volume, observedCinderVolume(identity, volume, "available", 20), nil))
 
-	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
+	require.NotNil(t, volume.Status.Size)
+	require.True(t, volume.Status.Size.Equal(resource.MustParse("20Gi")))
+	health, err := unikornv1core.GetHealthyCondition(volume)
 	require.NoError(t, err)
-	require.Equal(t, types.VolumeStatusAvailable, got.Status)
+	require.Equal(t, corev1.ConditionTrue, health.Status)
+	require.Equal(t, unikornv1core.ConditionReasonHealthy, health.Reason)
 }
 
-func TestObserveVolumeMapsCinderStatuses(t *testing.T) {
+func TestUpdateVolumeStateMapsCinderStatuses(t *testing.T) {
 	t.Parallel()
 
-	cases := map[string]types.VolumeStatus{
-		"creating":            types.VolumeStatusCreating,
-		"available":           types.VolumeStatusAvailable,
-		"reserved":            types.VolumeStatusAttaching,
-		"attaching":           types.VolumeStatusAttaching,
-		"in-use":              types.VolumeStatusAttached,
-		"detaching":           types.VolumeStatusDetaching,
-		"deleting":            types.VolumeStatusDeleting,
-		"managing":            types.VolumeStatusUpdating,
-		"maintenance":         types.VolumeStatusUpdating,
-		"restoring-backup":    types.VolumeStatusUpdating,
-		"awaiting-transfer":   types.VolumeStatusUpdating,
-		"backing-up":          types.VolumeStatusUpdating,
-		"downloading":         types.VolumeStatusUpdating,
-		"uploading":           types.VolumeStatusUpdating,
-		"retyping":            types.VolumeStatusUpdating,
-		"extending":           types.VolumeStatusUpdating,
-		"error":               types.VolumeStatusError,
-		"error_deleting":      types.VolumeStatusError,
-		"error_managing":      types.VolumeStatusError,
-		"error_restoring":     types.VolumeStatusError,
-		"error_backing-up":    types.VolumeStatusError,
-		"error_extending":     types.VolumeStatusError,
-		"":                    types.VolumeStatusUnknown,
-		"future-cinder-state": types.VolumeStatusUnknown,
-	}
-
-	for cinderStatus, want := range cases {
-		name := cinderStatus
-		if name == "" {
-			name = "unknown-empty"
-		}
-
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			identity, volume := identityFixture(), volumeFixture()
-			c := gomock.NewController(t)
-			blockStorage := mock.NewMockVolumeInterface(c)
-			blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, cinderStatus, 20), nil)
-
-			got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
-			require.NoError(t, err)
-			require.Equal(t, want, got.Status)
-		})
-	}
-}
-
-func TestObserveVolumeReturnsResourceNotFound(t *testing.T) {
-	t.Parallel()
-
-	identity, volume := identityFixture(), volumeFixture()
-	c := gomock.NewController(t)
-	blockStorage := mock.NewMockVolumeInterface(c)
-	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(nil, coreerrors.ErrResourceNotFound)
-
-	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
-	require.Nil(t, got)
-	require.ErrorIs(t, err, coreerrors.ErrResourceNotFound)
-}
-
-func TestObserveVolumePreservesProviderError(t *testing.T) {
-	t.Parallel()
-
-	identity, volume := identityFixture(), volumeFixture()
-	c := gomock.NewController(t)
-	blockStorage := mock.NewMockVolumeInterface(c)
-	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(nil, errVolumeObservationProvider)
-
-	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
-	require.Nil(t, got)
-	require.ErrorIs(t, err, errVolumeObservationProvider)
-}
-
-func TestObserveVolumeConvertsObservedSize(t *testing.T) {
-	t.Parallel()
-
-	identity, volume := identityFixture(), volumeFixture()
-	c := gomock.NewController(t)
-	blockStorage := mock.NewMockVolumeInterface(c)
-	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, "available", 37), nil)
-
-	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
-	require.NoError(t, err)
-	require.Zero(t, got.Size.Cmp(resource.MustParse("37Gi")))
-}
-
-func TestObserveVolumeConvertsMaxRepresentableSize(t *testing.T) {
-	t.Parallel()
-
-	if strconv.IntSize < 64 {
-		t.Skip("Cinder's int size cannot represent the largest safe GiB value on this architecture")
-	}
-
-	maxSizeGiB := int64(math.MaxInt64 >> 30)
-	identity, volume := identityFixture(), volumeFixture()
-	c := gomock.NewController(t)
-	blockStorage := mock.NewMockVolumeInterface(c)
-	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, "available", int(maxSizeGiB)), nil)
-
-	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
-	require.NoError(t, err)
-	require.Zero(t, got.Size.Cmp(resource.MustParse("8589934591Gi")))
-}
-
-func TestObserveVolumeRejectsNegativeSize(t *testing.T) {
-	t.Parallel()
-
-	identity, volume := identityFixture(), volumeFixture()
-	c := gomock.NewController(t)
-	blockStorage := mock.NewMockVolumeInterface(c)
-	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, "available", -1), nil)
-
-	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
-	require.Nil(t, got)
-	require.ErrorIs(t, err, coreerrors.ErrConsistency)
-}
-
-func TestObserveVolumeRejectsOverflowSize(t *testing.T) {
-	t.Parallel()
-
-	if strconv.IntSize < 64 {
-		t.Skip("Cinder's int size cannot exceed the largest safe GiB value on this architecture")
-	}
-
-	maxSizeGiB := int64(math.MaxInt64 >> 30)
-	identity, volume := identityFixture(), volumeFixture()
-	c := gomock.NewController(t)
-	blockStorage := mock.NewMockVolumeInterface(c)
-	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(observedCinderVolume(identity, volume, "available", int(maxSizeGiB+1)), nil)
-
-	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
-	require.Nil(t, got)
-	require.ErrorIs(t, err, coreerrors.ErrConsistency)
-}
-
-func TestObserveVolumeRejectsInvalidMetadata(t *testing.T) {
-	t.Parallel()
-
-	keys := map[string]string{
-		"volume ID":       "region:volume_id",
-		"organization ID": "identity:organization_id",
-		"project ID":      "identity:project_id",
-		"region ID":       "region:region_id",
-		"network ID":      "region:network_id",
-		"identity ID":     "region:identity_id",
-	}
-
-	for name, key := range keys {
-		for _, mutation := range []string{"missing", "conflicting"} {
-			t.Run(mutation+" "+name, func(t *testing.T) {
-				t.Parallel()
-
-				identity, volume := identityFixture(), volumeFixture()
-				cinderVolume := observedCinderVolume(identity, volume, "available", 20)
-
-				if mutation == "missing" {
-					delete(cinderVolume.Metadata, key)
-				} else {
-					cinderVolume.Metadata[key] = "other-resource"
-				}
-
-				c := gomock.NewController(t)
-				blockStorage := mock.NewMockVolumeInterface(c)
-				blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
-
-				got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
-				require.Nil(t, got)
-				require.ErrorIs(t, err, coreerrors.ErrConsistency)
-			})
-		}
-	}
-
-	t.Run("nil metadata", func(t *testing.T) {
-		t.Parallel()
-
-		identity, volume := identityFixture(), volumeFixture()
-		cinderVolume := observedCinderVolume(identity, volume, "available", 20)
-		cinderVolume.Metadata = nil
-		c := gomock.NewController(t)
-		blockStorage := mock.NewMockVolumeInterface(c)
-		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
-
-		got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
-		require.Nil(t, got)
-		require.ErrorIs(t, err, coreerrors.ErrConsistency)
-	})
-}
-
-func TestObserveVolumeRejectsEmptyExpectedMetadata(t *testing.T) {
-	t.Parallel()
-
-	cases := map[string]struct {
-		key   string
-		clear func(*regionv1.Identity, *regionv1.Volume)
+	tests := map[string]struct {
+		status  corev1.ConditionStatus
+		reason  unikornv1core.HealthConditionReason
+		message string
 	}{
-		"volume ID": {
-			key: "region:volume_id",
-			clear: func(_ *regionv1.Identity, volume *regionv1.Volume) {
-				volume.Name = ""
-			},
-		},
-		"organization ID": {
-			key: "identity:organization_id",
-			clear: func(_ *regionv1.Identity, volume *regionv1.Volume) {
-				volume.Labels[coreconstants.OrganizationLabel] = ""
-			},
-		},
-		"project ID": {
-			key: "identity:project_id",
-			clear: func(_ *regionv1.Identity, volume *regionv1.Volume) {
-				volume.Labels[coreconstants.ProjectLabel] = ""
-			},
-		},
-		"region ID": {
-			key: "region:region_id",
-			clear: func(_ *regionv1.Identity, volume *regionv1.Volume) {
-				volume.Labels[constants.RegionLabel] = ""
-			},
-		},
-		"network ID": {
-			key: "region:network_id",
-			clear: func(_ *regionv1.Identity, volume *regionv1.Volume) {
-				volume.Spec.NetworkID = ""
-			},
-		},
-		"identity ID": {
-			key: "region:identity_id",
-			clear: func(identity *regionv1.Identity, _ *regionv1.Volume) {
-				identity.Name = ""
-			},
-		},
+		"creating":          {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"available":         {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"reserved":          {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"attaching":         {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"in-use":            {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"detaching":         {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"managing":          {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"maintenance":       {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"restoring-backup":  {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"awaiting-transfer": {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"backing-up":        {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"downloading":       {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"uploading":         {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"retyping":          {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"extending":         {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		"deleting":          {corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider volume is being deleted"},
+		"error":             {corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider reported the volume in an error state"},
+		"error_deleting":    {corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider reported the volume in an error state"},
+		"error_managing":    {corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider reported the volume in an error state"},
+		"error_restoring":   {corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider reported the volume in an error state"},
+		"error_backing-up":  {corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider reported the volume in an error state"},
+		"error_extending":   {corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider reported the volume in an error state"},
+		"":                  {corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "the provider volume state is unknown"},
+		"future-state":      {corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "the provider volume state is unknown"},
 	}
 
-	for name, testCase := range cases {
-		t.Run(name, func(t *testing.T) {
+	for cinderStatus, want := range tests {
+		t.Run(cinderStatus, func(t *testing.T) {
 			t.Parallel()
-
 			identity, volume := identityFixture(), volumeFixture()
-			testCase.clear(identity, volume)
-			cinderVolume := observedCinderVolume(identity, volume, "available", 20)
-			cinderVolume.Metadata[testCase.key] = ""
-			c := gomock.NewController(t)
-			blockStorage := mock.NewMockVolumeInterface(c)
-			blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(cinderVolume, nil)
+			require.NoError(t, updateVolumeState(t, identity, volume, observedCinderVolume(identity, volume, cinderStatus, 20), nil))
 
-			got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
-			require.Nil(t, got)
-			require.ErrorIs(t, err, coreerrors.ErrConsistency)
+			health, err := unikornv1core.GetHealthyCondition(volume)
+			require.NoError(t, err)
+			require.Equal(t, want.status, health.Status)
+			require.Equal(t, want.reason, health.Reason)
+			require.Equal(t, want.message, health.Message)
 		})
 	}
 }
 
-func TestObserveVolumeRejectsNilResult(t *testing.T) {
+func TestUpdateVolumeStateHandlesMissingAfterProvisioning(t *testing.T) {
 	t.Parallel()
 
 	identity, volume := identityFixture(), volumeFixture()
-	c := gomock.NewController(t)
-	blockStorage := mock.NewMockVolumeInterface(c)
-	blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(nil, nil)
+	volume.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "")
+	size := resource.MustParse("20Gi")
+	volume.Status.Size = &size
 
-	got, err := openstack.ObserveVolumeWithClient(t.Context(), blockStorage, identity, volume)
-	require.Nil(t, got)
-	require.ErrorIs(t, err, coreerrors.ErrConsistency)
+	require.NoError(t, updateVolumeState(t, identity, volume, nil, coreerrors.ErrResourceNotFound))
+	require.Nil(t, volume.Status.Size)
+	health, err := unikornv1core.GetHealthyCondition(volume)
+	require.NoError(t, err)
+	require.Equal(t, corev1.ConditionFalse, health.Status)
+	require.Equal(t, unikornv1core.ConditionReasonDegraded, health.Reason)
+	require.Equal(t, "the provider volume is missing", health.Message)
+}
+
+func TestUpdateVolumeStateIgnoresMissingBeforeProvisioning(t *testing.T) {
+	t.Parallel()
+
+	identity, volume := identityFixture(), volumeFixture()
+	size := resource.MustParse("20Gi")
+	volume.Status.Size = &size
+
+	require.NoError(t, updateVolumeState(t, identity, volume, nil, coreerrors.ErrResourceNotFound))
+	require.NotNil(t, volume.Status.Size)
+	require.True(t, volume.Status.Size.Equal(size))
+	_, err := unikornv1core.GetHealthyCondition(volume)
+	require.Error(t, err)
+}
+
+func TestUpdateVolumeStatePreservesStateOnProviderError(t *testing.T) {
+	t.Parallel()
+
+	identity, volume := identityFixture(), volumeFixture()
+	require.ErrorIs(t, updateVolumeState(t, identity, volume, nil, errVolumeStateProvider), errVolumeStateProvider)
+	_, err := unikornv1core.GetHealthyCondition(volume)
+	require.Error(t, err)
+}
+
+func TestUpdateVolumeStateRejectsInvalidProviderData(t *testing.T) {
+	t.Parallel()
+
+	identity, volume := identityFixture(), volumeFixture()
+	for _, size := range []int{-1, int(math.MaxInt64 >> 30)} {
+		if size == int(math.MaxInt64>>30) && strconv.IntSize < 64 {
+			continue
+		}
+		if size >= 0 {
+			size++
+		}
+		require.ErrorIs(t, updateVolumeState(t, identity, volume, observedCinderVolume(identity, volume, "available", size), nil), coreerrors.ErrConsistency)
+	}
+}
+
+func TestUpdateVolumeStateRejectsInvalidMetadata(t *testing.T) {
+	t.Parallel()
+
+	identity, volume := identityFixture(), volumeFixture()
+	cinderVolume := observedCinderVolume(identity, volume, "available", 20)
+	delete(cinderVolume.Metadata, "region:volume_id")
+	require.ErrorIs(t, updateVolumeState(t, identity, volume, cinderVolume, nil), coreerrors.ErrConsistency)
 }

--- a/pkg/providers/internal/openstack/volume_observation.go
+++ b/pkg/providers/internal/openstack/volume_observation.go
@@ -18,15 +18,17 @@ package openstack
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
 	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/constants"
-	"github.com/unikorn-cloud/region/pkg/providers/types"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -55,29 +57,6 @@ func validateVolumeSystemMetadata(identity *unikornv1.Identity, volume *unikornv
 	return nil
 }
 
-func volumeStatus(status string) types.VolumeStatus {
-	switch status {
-	case "creating":
-		return types.VolumeStatusCreating
-	case "available":
-		return types.VolumeStatusAvailable
-	case "reserved", "attaching":
-		return types.VolumeStatusAttaching
-	case "in-use":
-		return types.VolumeStatusAttached
-	case "detaching":
-		return types.VolumeStatusDetaching
-	case "deleting":
-		return types.VolumeStatusDeleting
-	case "managing", "maintenance", "restoring-backup", "awaiting-transfer", "backing-up", "downloading", "uploading", "retyping", "extending":
-		return types.VolumeStatusUpdating
-	case "error", "error_deleting", "error_managing", "error_restoring", "error_backing-up", "error_extending":
-		return types.VolumeStatusError
-	default:
-		return types.VolumeStatusUnknown
-	}
-}
-
 func volumeSize(sizeGiB int) (resource.Quantity, error) {
 	const bytesPerGiB = int64(1 << 30)
 
@@ -88,33 +67,65 @@ func volumeSize(sizeGiB int) (resource.Quantity, error) {
 	return *resource.NewQuantity(int64(sizeGiB)*bytesPerGiB, resource.BinarySI), nil
 }
 
-func observeVolume(ctx context.Context, blockStorage VolumeInterface, identity *unikornv1.Identity, volume *unikornv1.Volume) (*types.VolumeObservation, error) {
+func setVolumeHealth(volume *unikornv1.Volume, status string) {
+	switch status {
+	case "creating", "available", "reserved", "attaching", "in-use", "detaching", "managing", "maintenance", "restoring-backup", "awaiting-transfer", "backing-up", "downloading", "uploading", "retyping", "extending":
+		unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionTrue, string(unikornv1core.ConditionReasonHealthy), "the provider volume state is healthy")
+	case "deleting":
+		unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionFalse, string(unikornv1core.ConditionReasonDegraded), "the provider volume is being deleted")
+	case "error", "error_deleting", "error_managing", "error_restoring", "error_backing-up", "error_extending":
+		unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionFalse, string(unikornv1core.ConditionReasonDegraded), "the provider reported the volume in an error state")
+	default:
+		unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionUnknown, string(unikornv1core.ConditionReasonUnknown), "the provider volume state is unknown")
+	}
+}
+
+func updateVolumeState(ctx context.Context, blockStorage VolumeInterface, identity *unikornv1.Identity, volume *unikornv1.Volume) error {
 	cinderVolume, err := blockStorage.GetVolume(ctx, volume)
 	if err != nil {
-		return nil, err
+		if !errors.Is(err, coreerrors.ErrResourceNotFound) {
+			return err
+		}
+
+		available, availableErr := unikornv1core.GetAvailableCondition(volume)
+		if availableErr != nil {
+			return nil //nolint:nilerr // absence before provisioning is expected
+		}
+
+		if available.Status != corev1.ConditionTrue || available.Reason != unikornv1core.ConditionReasonProvisioned {
+			return nil
+		}
+
+		volume.Status.Size = nil
+		unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionFalse, string(unikornv1core.ConditionReasonDegraded), "the provider volume is missing")
+
+		return nil
 	}
 
 	if cinderVolume == nil {
-		return nil, fmt.Errorf("%w: nil Cinder volume returned for Region volume %s", coreerrors.ErrConsistency, volume.Name)
+		return fmt.Errorf("%w: nil Cinder volume returned for Region volume %s", coreerrors.ErrConsistency, volume.Name)
 	}
 
 	if err := validateVolumeSystemMetadata(identity, volume, cinderVolume.Metadata); err != nil {
-		return nil, err
+		return err
 	}
 
 	size, err := volumeSize(cinderVolume.Size)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &types.VolumeObservation{Size: size, Status: volumeStatus(cinderVolume.Status)}, nil
+	volume.Status.Size = &size
+	setVolumeHealth(volume, cinderVolume.Status)
+
+	return nil
 }
 
-func (p *Provider) ObserveVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) (*types.VolumeObservation, error) {
+func (p *Provider) UpdateVolumeState(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error {
 	blockStorage, err := p.blockStorageFromServicePrincipal(ctx, identity)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return observeVolume(ctx, blockStorage, identity, volume)
+	return updateVolumeState(ctx, blockStorage, identity, volume)
 }

--- a/pkg/providers/internal/openstack/volume_observation.go
+++ b/pkg/providers/internal/openstack/volume_observation.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func volumeSystemMetadata(identity *unikornv1.Identity, volume *unikornv1.Volume) map[string]string {
+	return map[string]string{
+		"region:volume_id":         volume.Name,
+		"identity:organization_id": volume.Labels[coreconstants.OrganizationLabel],
+		"identity:project_id":      volume.Labels[coreconstants.ProjectLabel],
+		"region:region_id":         volume.Labels[constants.RegionLabel],
+		"region:network_id":        volume.Spec.NetworkID,
+		"region:identity_id":       identity.Name,
+	}
+}
+
+func validateVolumeSystemMetadata(identity *unikornv1.Identity, volume *unikornv1.Volume, metadata map[string]string) error {
+	for key, want := range volumeSystemMetadata(identity, volume) {
+		if want == "" {
+			return fmt.Errorf("%w: Region volume %s has empty linkage metadata %s", coreerrors.ErrConsistency, volume.Name, key)
+		}
+
+		if got, ok := metadata[key]; !ok || got != want {
+			return fmt.Errorf("%w: Cinder volume metadata %s does not match Region volume %s", coreerrors.ErrConsistency, key, volume.Name)
+		}
+	}
+
+	return nil
+}
+
+func volumeStatus(status string) types.VolumeStatus {
+	switch status {
+	case "creating":
+		return types.VolumeStatusCreating
+	case "available":
+		return types.VolumeStatusAvailable
+	case "reserved", "attaching":
+		return types.VolumeStatusAttaching
+	case "in-use":
+		return types.VolumeStatusAttached
+	case "detaching":
+		return types.VolumeStatusDetaching
+	case "deleting":
+		return types.VolumeStatusDeleting
+	case "managing", "maintenance", "restoring-backup", "awaiting-transfer", "backing-up", "downloading", "uploading", "retyping", "extending":
+		return types.VolumeStatusUpdating
+	case "error", "error_deleting", "error_managing", "error_restoring", "error_backing-up", "error_extending":
+		return types.VolumeStatusError
+	default:
+		return types.VolumeStatusUnknown
+	}
+}
+
+func volumeSize(sizeGiB int) (resource.Quantity, error) {
+	const bytesPerGiB = int64(1 << 30)
+
+	if sizeGiB < 0 || int64(sizeGiB) > math.MaxInt64/bytesPerGiB {
+		return resource.Quantity{}, fmt.Errorf("%w: invalid Cinder volume size %d GiB", coreerrors.ErrConsistency, sizeGiB)
+	}
+
+	return *resource.NewQuantity(int64(sizeGiB)*bytesPerGiB, resource.BinarySI), nil
+}
+
+func observeVolume(ctx context.Context, blockStorage VolumeInterface, identity *unikornv1.Identity, volume *unikornv1.Volume) (*types.VolumeObservation, error) {
+	cinderVolume, err := blockStorage.GetVolume(ctx, volume)
+	if err != nil {
+		return nil, err
+	}
+
+	if cinderVolume == nil {
+		return nil, fmt.Errorf("%w: nil Cinder volume returned for Region volume %s", coreerrors.ErrConsistency, volume.Name)
+	}
+
+	if err := validateVolumeSystemMetadata(identity, volume, cinderVolume.Metadata); err != nil {
+		return nil, err
+	}
+
+	size, err := volumeSize(cinderVolume.Size)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.VolumeObservation{Size: size, Status: volumeStatus(cinderVolume.Status)}, nil
+}
+
+func (p *Provider) ObserveVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) (*types.VolumeObservation, error) {
+	blockStorage, err := p.blockStorageFromServicePrincipal(ctx, identity)
+	if err != nil {
+		return nil, err
+	}
+
+	return observeVolume(ctx, blockStorage, identity, volume)
+}

--- a/pkg/providers/internal/simulated/README.md
+++ b/pkg/providers/internal/simulated/README.md
@@ -34,9 +34,9 @@ development, while keeping behaviour deterministic and cheap to run.
   images through the same query/filter contract used by real providers.
 - Unsupported operations fail explicitly with `ErrUnsupportedOperation` rather
   than pretending to succeed.
-- Volume creation is unsupported. Volume deletion is an idempotent no-op so
-  unconditional controller cleanup can converge when no simulated backing
-  volume could have been created.
+- Volume creation and observation are unsupported. Volume deletion is an
+  idempotent no-op so unconditional controller cleanup can converge when no
+  simulated backing volume could have been created.
 - Server volume attach/detach participates in the full interface contract but
   is currently unsupported; attachment fidelity belongs to the OpenStack
   provider until a higher-level simulated workflow requires it.

--- a/pkg/providers/internal/simulated/provider.go
+++ b/pkg/providers/internal/simulated/provider.go
@@ -477,8 +477,8 @@ func (p *Provider) DeleteVolume(_ context.Context, _ *unikornv1.Identity, _ *uni
 	return nil
 }
 
-func (p *Provider) ObserveVolume(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.Volume) (*types.VolumeObservation, error) {
-	return nil, unsupported("ObserveVolume")
+func (p *Provider) UpdateVolumeState(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.Volume) error {
+	return unsupported("UpdateVolumeState")
 }
 
 func (p *Provider) CreateServer(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.Server, _ *types.ServerCreateOptions) error {

--- a/pkg/providers/internal/simulated/provider.go
+++ b/pkg/providers/internal/simulated/provider.go
@@ -477,6 +477,10 @@ func (p *Provider) DeleteVolume(_ context.Context, _ *unikornv1.Identity, _ *uni
 	return nil
 }
 
+func (p *Provider) ObserveVolume(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.Volume) (*types.VolumeObservation, error) {
+	return nil, unsupported("ObserveVolume")
+}
+
 func (p *Provider) CreateServer(_ context.Context, _ *unikornv1.Identity, _ *unikornv1.Server, _ *types.ServerCreateOptions) error {
 	return unsupported("CreateServer")
 }

--- a/pkg/providers/internal/simulated/provider_test.go
+++ b/pkg/providers/internal/simulated/provider_test.go
@@ -128,8 +128,7 @@ func TestVolumeLifecycle(t *testing.T) {
 	require.NoError(t, provider.DeleteVolume(t.Context(), identity, volume))
 	require.NoError(t, provider.DeleteVolume(t.Context(), identity, volume))
 
-	_, err := provider.ObserveVolume(t.Context(), identity, volume)
-	require.ErrorIs(t, err, simulated.ErrUnsupportedOperation)
+	require.ErrorIs(t, provider.UpdateVolumeState(t.Context(), identity, volume), simulated.ErrUnsupportedOperation)
 }
 
 func TestImages(t *testing.T) {

--- a/pkg/providers/internal/simulated/provider_test.go
+++ b/pkg/providers/internal/simulated/provider_test.go
@@ -127,6 +127,9 @@ func TestVolumeLifecycle(t *testing.T) {
 	require.ErrorIs(t, provider.CreateVolume(t.Context(), identity, volume), simulated.ErrUnsupportedOperation)
 	require.NoError(t, provider.DeleteVolume(t.Context(), identity, volume))
 	require.NoError(t, provider.DeleteVolume(t.Context(), identity, volume))
+
+	_, err := provider.ObserveVolume(t.Context(), identity, volume)
+	require.ErrorIs(t, err, simulated.ErrUnsupportedOperation)
 }
 
 func TestImages(t *testing.T) {

--- a/pkg/providers/types/README.md
+++ b/pkg/providers/types/README.md
@@ -55,27 +55,22 @@ continue to be passed directly through many provider interface methods.
   operator-authored Region configuration propagated through this neutral
   model; they are not provider-discovered values. The same model carries an
   optional typed Region Flavor allowlist; nil or empty means unrestricted.
-- `Volume` is a focused create/delete/observation capability that accepts the
+- `Volume` is a focused create/delete/state-update capability that accepts the
   native `unikornv1.Volume` lifecycle intent and is embedded in the full
   `Provider` composition. `CreateVolume` is a reconciliation operation rather
   than a one-shot request: implementations return `provisioners.ErrYield` until
   the backing resource is usable, return `nil` only after convergence, and may
   return a typed terminal provisioning error for an unrecoverable provider
   state. `DeleteVolume` likewise yields after an accepted asynchronous delete
-  and succeeds only when provider absence is confirmed. `ObserveVolume` returns
-  a `VolumeObservation` containing the provider-neutral observed
-  `resource.Quantity` size and a `VolumeStatus`, rather than a provider SDK
-  object or a CRD write.
-  Its nine lowercase lifecycle values are `creating`, `available`, `attaching`,
-  `attached`, `detaching`, `updating`, `deleting`, `error`, and `unknown`.
+  and succeeds only when provider absence is confirmed. `UpdateVolumeState`
+  mutates the repository-native Volume status with observed size and health,
+  rather than exposing provider SDK types.
   VolumeClass inventory and server attachment remain separate operations.
   Discovery-only substrates implement `CommonProvider` instead of the full
   workload lifecycle contract.
-- `ObserveVolume` distinguishes absence, failed reads, and observed lifecycle
-  truth: no backing resource returns the shared `ErrResourceNotFound` sentinel;
-  request, decoding, and client-construction failures remain errors; a
-  successfully read provider error state returns `VolumeStatusError`, and an
-  empty or unrecognized provider state returns `VolumeStatusUnknown`.
+- `UpdateVolumeState` distinguishes absence, failed reads, and observed lifecycle
+  truth. Providers own status mapping and missing-volume semantics; read and
+  validation failures are returned so monitors preserve the last state.
 - `ServerCreateOptions` carries launch-time derived inputs without forcing them
   into the persisted `Server` CRD shape.
 - `ServerVolumeAttachment` contains only provider-neutral observation needed by

--- a/pkg/providers/types/README.md
+++ b/pkg/providers/types/README.md
@@ -55,17 +55,27 @@ continue to be passed directly through many provider interface methods.
   operator-authored Region configuration propagated through this neutral
   model; they are not provider-discovered values. The same model carries an
   optional typed Region Flavor allowlist; nil or empty means unrestricted.
-- `Volume` is the focused create/delete capability embedded in the full
-  `Provider` composition. It accepts the native `unikornv1.Volume` lifecycle
-  intent and does not expose discovery, observed state, VolumeClass inventory,
-  or server attachment operations. `CreateVolume` is a reconciliation
-  operation rather than a one-shot request: implementations return
-  `provisioners.ErrYield` until the backing resource is usable, return `nil`
-  only after convergence, and may return a typed terminal provisioning error
-  for an unrecoverable provider state. `DeleteVolume` likewise yields after an
-  accepted asynchronous delete and succeeds only when provider absence is
-  confirmed. Discovery-only substrates implement `CommonProvider` instead of
-  the full workload lifecycle contract.
+- `Volume` is a focused create/delete/observation capability that accepts the
+  native `unikornv1.Volume` lifecycle intent and is embedded in the full
+  `Provider` composition. `CreateVolume` is a reconciliation operation rather
+  than a one-shot request: implementations return `provisioners.ErrYield` until
+  the backing resource is usable, return `nil` only after convergence, and may
+  return a typed terminal provisioning error for an unrecoverable provider
+  state. `DeleteVolume` likewise yields after an accepted asynchronous delete
+  and succeeds only when provider absence is confirmed. `ObserveVolume` returns
+  a `VolumeObservation` containing the provider-neutral observed
+  `resource.Quantity` size and a `VolumeStatus`, rather than a provider SDK
+  object or a CRD write.
+  Its nine lowercase lifecycle values are `creating`, `available`, `attaching`,
+  `attached`, `detaching`, `updating`, `deleting`, `error`, and `unknown`.
+  VolumeClass inventory and server attachment remain separate operations.
+  Discovery-only substrates implement `CommonProvider` instead of the full
+  workload lifecycle contract.
+- `ObserveVolume` distinguishes absence, failed reads, and observed lifecycle
+  truth: no backing resource returns the shared `ErrResourceNotFound` sentinel;
+  request, decoding, and client-construction failures remain errors; a
+  successfully read provider error state returns `VolumeStatusError`, and an
+  empty or unrecognized provider state returns `VolumeStatusUnknown`.
 - `ServerCreateOptions` carries launch-time derived inputs without forcing them
   into the persisted `Server` CRD shape.
 - `ServerVolumeAttachment` contains only provider-neutral observation needed by

--- a/pkg/providers/types/README.md
+++ b/pkg/providers/types/README.md
@@ -121,4 +121,4 @@ continue to be passed directly through many provider interface methods.
   consume these types when converting provider-derived information into API
   reads and actions
 - [../../monitor](../../monitor/README.md) consumes provider-neutral read-side
-  information such as flavors when observing runtime state
+  information, including `VolumeObservation`, when projecting runtime state

--- a/pkg/providers/types/interfaces.go
+++ b/pkg/providers/types/interfaces.go
@@ -99,6 +99,8 @@ type Volume interface {
 	CreateVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error
 	// DeleteVolume idempotently deletes the provider volume described by the Region Volume.
 	DeleteVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error
+	// ObserveVolume rediscovers and reports current provider state for the Region Volume.
+	ObserveVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) (*VolumeObservation, error)
 }
 
 type Server interface {

--- a/pkg/providers/types/interfaces.go
+++ b/pkg/providers/types/interfaces.go
@@ -99,8 +99,9 @@ type Volume interface {
 	CreateVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error
 	// DeleteVolume idempotently deletes the provider volume described by the Region Volume.
 	DeleteVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error
-	// ObserveVolume rediscovers and reports current provider state for the Region Volume.
-	ObserveVolume(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) (*VolumeObservation, error)
+	// UpdateVolumeState rediscovers provider state and updates the Region Volume in place.
+	// Provider failures are returned so callers can preserve the last observed state.
+	UpdateVolumeState(ctx context.Context, identity *unikornv1.Identity, volume *unikornv1.Volume) error
 }
 
 type Server interface {

--- a/pkg/providers/types/mock/interfaces.go
+++ b/pkg/providers/types/mock/interfaces.go
@@ -486,19 +486,18 @@ func (mr *MockVolumeMockRecorder) DeleteVolume(ctx, identity, volume any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockVolume)(nil).DeleteVolume), ctx, identity, volume)
 }
 
-// ObserveVolume mocks base method.
-func (m *MockVolume) ObserveVolume(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) (*types.VolumeObservation, error) {
+// UpdateVolumeState mocks base method.
+func (m *MockVolume) UpdateVolumeState(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObserveVolume", ctx, identity, volume)
-	ret0, _ := ret[0].(*types.VolumeObservation)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "UpdateVolumeState", ctx, identity, volume)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// ObserveVolume indicates an expected call of ObserveVolume.
-func (mr *MockVolumeMockRecorder) ObserveVolume(ctx, identity, volume any) *gomock.Call {
+// UpdateVolumeState indicates an expected call of UpdateVolumeState.
+func (mr *MockVolumeMockRecorder) UpdateVolumeState(ctx, identity, volume any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObserveVolume", reflect.TypeOf((*MockVolume)(nil).ObserveVolume), ctx, identity, volume)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVolumeState", reflect.TypeOf((*MockVolume)(nil).UpdateVolumeState), ctx, identity, volume)
 }
 
 // MockServer is a mock of Server interface.
@@ -1135,21 +1134,6 @@ func (mr *MockProviderMockRecorder) ListExternalNetworks(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExternalNetworks", reflect.TypeOf((*MockProvider)(nil).ListExternalNetworks), ctx)
 }
 
-// ObserveVolume mocks base method.
-func (m *MockProvider) ObserveVolume(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) (*types.VolumeObservation, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObserveVolume", ctx, identity, volume)
-	ret0, _ := ret[0].(*types.VolumeObservation)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ObserveVolume indicates an expected call of ObserveVolume.
-func (mr *MockProviderMockRecorder) ObserveVolume(ctx, identity, volume any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObserveVolume", reflect.TypeOf((*MockProvider)(nil).ObserveVolume), ctx, identity, volume)
-}
-
 // QueryImages mocks base method.
 func (m *MockProvider) QueryImages() (types.ImageQuery, error) {
 	m.ctrl.T.Helper()
@@ -1234,6 +1218,20 @@ func (m *MockProvider) UpdateServerState(ctx context.Context, identity *v1alpha1
 func (mr *MockProviderMockRecorder) UpdateServerState(ctx, identity, server any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServerState", reflect.TypeOf((*MockProvider)(nil).UpdateServerState), ctx, identity, server)
+}
+
+// UpdateVolumeState mocks base method.
+func (m *MockProvider) UpdateVolumeState(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateVolumeState", ctx, identity, volume)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateVolumeState indicates an expected call of UpdateVolumeState.
+func (mr *MockProviderMockRecorder) UpdateVolumeState(ctx, identity, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVolumeState", reflect.TypeOf((*MockProvider)(nil).UpdateVolumeState), ctx, identity, volume)
 }
 
 // VolumeClasses mocks base method.

--- a/pkg/providers/types/mock/interfaces.go
+++ b/pkg/providers/types/mock/interfaces.go
@@ -486,6 +486,21 @@ func (mr *MockVolumeMockRecorder) DeleteVolume(ctx, identity, volume any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockVolume)(nil).DeleteVolume), ctx, identity, volume)
 }
 
+// ObserveVolume mocks base method.
+func (m *MockVolume) ObserveVolume(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) (*types.VolumeObservation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ObserveVolume", ctx, identity, volume)
+	ret0, _ := ret[0].(*types.VolumeObservation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ObserveVolume indicates an expected call of ObserveVolume.
+func (mr *MockVolumeMockRecorder) ObserveVolume(ctx, identity, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObserveVolume", reflect.TypeOf((*MockVolume)(nil).ObserveVolume), ctx, identity, volume)
+}
+
 // MockServer is a mock of Server interface.
 type MockServer struct {
 	ctrl     *gomock.Controller
@@ -1118,6 +1133,21 @@ func (m *MockProvider) ListExternalNetworks(ctx context.Context) (types.External
 func (mr *MockProviderMockRecorder) ListExternalNetworks(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExternalNetworks", reflect.TypeOf((*MockProvider)(nil).ListExternalNetworks), ctx)
+}
+
+// ObserveVolume mocks base method.
+func (m *MockProvider) ObserveVolume(ctx context.Context, identity *v1alpha1.Identity, volume *v1alpha1.Volume) (*types.VolumeObservation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ObserveVolume", ctx, identity, volume)
+	ret0, _ := ret[0].(*types.VolumeObservation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ObserveVolume indicates an expected call of ObserveVolume.
+func (mr *MockProviderMockRecorder) ObserveVolume(ctx, identity, volume any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObserveVolume", reflect.TypeOf((*MockProvider)(nil).ObserveVolume), ctx, identity, volume)
 }
 
 // QueryImages mocks base method.

--- a/pkg/providers/types/types.go
+++ b/pkg/providers/types/types.go
@@ -134,25 +134,6 @@ type VolumeClassPerformance struct {
 // VolumeClassList is a list of provider volume classes.
 type VolumeClassList []VolumeClass
 
-type VolumeStatus string
-
-const (
-	VolumeStatusCreating  VolumeStatus = "creating"
-	VolumeStatusAvailable VolumeStatus = "available"
-	VolumeStatusAttaching VolumeStatus = "attaching"
-	VolumeStatusAttached  VolumeStatus = "attached"
-	VolumeStatusDetaching VolumeStatus = "detaching"
-	VolumeStatusUpdating  VolumeStatus = "updating"
-	VolumeStatusDeleting  VolumeStatus = "deleting"
-	VolumeStatusError     VolumeStatus = "error"
-	VolumeStatusUnknown   VolumeStatus = "unknown"
-)
-
-type VolumeObservation struct {
-	Size   resource.Quantity
-	Status VolumeStatus
-}
-
 type ImageVirtualization string
 
 const (

--- a/pkg/providers/types/types.go
+++ b/pkg/providers/types/types.go
@@ -134,6 +134,25 @@ type VolumeClassPerformance struct {
 // VolumeClassList is a list of provider volume classes.
 type VolumeClassList []VolumeClass
 
+type VolumeStatus string
+
+const (
+	VolumeStatusCreating  VolumeStatus = "creating"
+	VolumeStatusAvailable VolumeStatus = "available"
+	VolumeStatusAttaching VolumeStatus = "attaching"
+	VolumeStatusAttached  VolumeStatus = "attached"
+	VolumeStatusDetaching VolumeStatus = "detaching"
+	VolumeStatusUpdating  VolumeStatus = "updating"
+	VolumeStatusDeleting  VolumeStatus = "deleting"
+	VolumeStatusError     VolumeStatus = "error"
+	VolumeStatusUnknown   VolumeStatus = "unknown"
+)
+
+type VolumeObservation struct {
+	Size   resource.Quantity
+	Status VolumeStatus
+}
+
 type ImageVirtualization string
 
 const (

--- a/pkg/providers/types/volume_test.go
+++ b/pkg/providers/types/volume_test.go
@@ -24,6 +24,8 @@ import (
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 	"github.com/unikorn-cloud/region/pkg/providers/types/mock"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestVolumeMockExercisesLifecycleContract(t *testing.T) {
@@ -37,6 +39,12 @@ func TestVolumeMockExercisesLifecycleContract(t *testing.T) {
 	provider.EXPECT().CreateVolume(t.Context(), identity, volume).Return(nil)
 	provider.EXPECT().DeleteVolume(t.Context(), identity, volume).Return(nil)
 
+	observation := &types.VolumeObservation{
+		Size:   resource.MustParse("20Gi"),
+		Status: types.VolumeStatusAvailable,
+	}
+	provider.EXPECT().ObserveVolume(t.Context(), identity, volume).Return(observation, nil)
+
 	var capability types.Volume = provider
 
 	if err := capability.CreateVolume(t.Context(), identity, volume); err != nil {
@@ -45,5 +53,14 @@ func TestVolumeMockExercisesLifecycleContract(t *testing.T) {
 
 	if err := capability.DeleteVolume(t.Context(), identity, volume); err != nil {
 		t.Fatalf("DeleteVolume() error = %v", err)
+	}
+
+	got, err := capability.ObserveVolume(t.Context(), identity, volume)
+	if err != nil {
+		t.Fatalf("ObserveVolume() error = %v", err)
+	}
+
+	if got != observation {
+		t.Fatalf("ObserveVolume() = %#v, want %#v", got, observation)
 	}
 }

--- a/pkg/providers/types/volume_test.go
+++ b/pkg/providers/types/volume_test.go
@@ -24,8 +24,6 @@ import (
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 	"github.com/unikorn-cloud/region/pkg/providers/types/mock"
-
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestVolumeMockExercisesLifecycleContract(t *testing.T) {
@@ -39,11 +37,7 @@ func TestVolumeMockExercisesLifecycleContract(t *testing.T) {
 	provider.EXPECT().CreateVolume(t.Context(), identity, volume).Return(nil)
 	provider.EXPECT().DeleteVolume(t.Context(), identity, volume).Return(nil)
 
-	observation := &types.VolumeObservation{
-		Size:   resource.MustParse("20Gi"),
-		Status: types.VolumeStatusAvailable,
-	}
-	provider.EXPECT().ObserveVolume(t.Context(), identity, volume).Return(observation, nil)
+	provider.EXPECT().UpdateVolumeState(t.Context(), identity, volume).DoAndReturn(func(_ any, _ any, got *unikornv1.Volume) error { return nil })
 
 	var capability types.Volume = provider
 
@@ -55,12 +49,7 @@ func TestVolumeMockExercisesLifecycleContract(t *testing.T) {
 		t.Fatalf("DeleteVolume() error = %v", err)
 	}
 
-	got, err := capability.ObserveVolume(t.Context(), identity, volume)
-	if err != nil {
-		t.Fatalf("ObserveVolume() error = %v", err)
-	}
-
-	if got != observation {
-		t.Fatalf("ObserveVolume() = %#v, want %#v", got, observation)
+	if err := capability.UpdateVolumeState(t.Context(), identity, volume); err != nil {
+		t.Fatalf("UpdateVolumeState() error = %v", err)
 	}
 }

--- a/pkg/provisioners/managers/server/provisioner.go
+++ b/pkg/provisioners/managers/server/provisioner.go
@@ -244,7 +244,7 @@ func (p *Provisioner) eventRecorder(ctx context.Context) record.EventRecorder {
 	// and an action string on every call site, so it is a deployment change rather
 	// than a library bump.  Deprecated is not removed; controller-runtime suppresses
 	// the same warning internally.
-	return manager.FromContext(ctx).GetEventRecorderFor("server-controller") //nolint:staticcheck
+	return manager.FromContext(ctx).GetEventRecorderFor("server-controller")
 }
 
 func (p *Provisioner) recordProviderCreateRetryEvent(ctx context.Context, eventType, reason, logMessage, eventMessage string, attempt, maxAttempts int32) {

--- a/pkg/provisioners/managers/volume/README.md
+++ b/pkg/provisioners/managers/volume/README.md
@@ -13,6 +13,12 @@ deletion or operator intervention. This package does not check quota; the HTTP
 create handler allocates the requested capacity and stores the Identity
 allocation ID before the controller can observe the Volume.
 
+`Available=True/Provisioned` is also the durable create-completed latch. Later
+provision passes return before provider lookup or creation. If provider storage
+disappears, the monitor degrades health and the controller does not create a
+replacement under the same Region Volume ID. Users replace the Volume by
+deleting its Region resource and creating a new one.
+
 Deprovisioning deliberately has stricter ordering:
 
 1. resolve the provider and Identity through the shared provisioner lookup, then
@@ -31,10 +37,12 @@ the referenced Region `Identity` available through this cleanup; a missing
 Identity remains an error and preserves the Volume finalizer.
 Provider lookup errors also preserve the allocation and finalizer for retry.
 
-General provider observation/status mapping, quota policy, Network
-graph-edge reconciliation, HTTP handlers, and server attachment reconciliation
-are outside this package. The provider-specific state classification needed to
-decide whether create has converged remains inside the provider implementation.
+Provider observation/status projection lives in
+[`pkg/monitor/health/volume`](../../../monitor/health/volume/README.md). Quota
+policy, Network graph-edge reconciliation, HTTP handlers, and server
+attachment reconciliation remain outside this package. The provider-specific
+state classification needed to decide whether create has converged remains
+inside the provider implementation.
 
 ## Cross-Package Context
 

--- a/pkg/provisioners/managers/volume/provisioner.go
+++ b/pkg/provisioners/managers/volume/provisioner.go
@@ -30,6 +30,8 @@ import (
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/providers"
 	"github.com/unikorn-cloud/region/pkg/provisioners/internal/base"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Options allows access to CLI options in the provisioner.
@@ -85,6 +87,11 @@ func (p *Provisioner) Object() unikornv1core.ManagableResourceInterface {
 
 // Provision reconciles the desired provider Volume.
 func (p *Provisioner) Provision(ctx context.Context) error {
+	available, err := unikornv1core.GetAvailableCondition(p.volume)
+	if err == nil && available.Status == corev1.ConditionTrue && available.Reason == unikornv1core.ConditionReasonProvisioned {
+		return nil
+	}
+
 	provider, identity, err := p.ProviderAndIdentity(ctx, p.volume)
 	if err != nil {
 		return err

--- a/pkg/provisioners/managers/volume/provisioner_test.go
+++ b/pkg/provisioners/managers/volume/provisioner_test.go
@@ -156,6 +156,18 @@ func TestProvisionCreatesVolume(t *testing.T) {
 	require.NoError(t, provisioner.Provision(controllerContext(t, resource, identity)))
 }
 
+func TestProvisionDoesNotRecreateProvisionedVolume(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	providerSet := mockproviders.NewMockProviders(ctrl)
+	resource := testVolume(false)
+	resource.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "provisioned")
+
+	provisioner := volume.NewForTest(resource, providerSet, nil)
+	require.NoError(t, provisioner.Provision(controllerContext(t, resource)))
+}
+
 func TestProvisionWaitsForIdentity(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add the provider-neutral Volume state update boundary
- rediscover OpenStack Cinder Volumes and project observed size and health into Region status
- integrate provider-backed Volume observation into the health monitor
- preserve controller-owned provisioning state and last-known status during provider failures
- regenerate mocks and update affected package documentation

## Behavior

- providers own lifecycle mapping, observed size, missing-volume semantics, and health messages
- monitors delegate state updates, apply one optimistic status patch, and log transitions
- provider lookup and observation failures are logged and skipped, preserving the last observed status
- missing backing Volumes are handled by the provider after provisioning completes
- no provider-state CRDs or Cinder/Gophercloud types cross the provider boundary

## Validation

- targeted provider, monitor, and volume-manager tests
- make touch
- make license
- make validate
- make lint
- make generate with generated-output cleanliness verified
- make test-unit

Linear: STO-123, STO-127
