### PR TITLE
Implement Volume API handlers

### DIFF
--- a/charts/region/templates/api/clusterrole.yaml
+++ b/charts/region/templates/api/clusterrole.yaml
@@ -33,6 +33,7 @@ rules:
   - securitygrouprules
   - servers
   - filestorages
+  - volumes
   - sshcertificateauthorities
   verbs:
   - list

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -19,15 +19,15 @@ The useful way to read it is not as a directory tree, but as one system:
 - provisioners and managers realize provider-side effects
 - monitors project observed provider truth back into status and metrics
 - providers bind the region model to real or simulated clouds
-- `Volume` is an internal Region storage model today: a network-anchored,
+- `Volume` is a Region block storage model: a network-anchored,
   quota-carrying block storage resource. Its deployable controller now drives
   idempotent OpenStack create/delete lifecycle, keeps creation provisioning
   until Cinder reports the backing volume `available`, and releases an
   annotated Identity allocation only after Cinder confirms provider deletion.
   A Cinder error is surfaced through a safe typed provisioning condition. Its
-  public v2 Volume lifecycle contract is published, while handler behavior,
-  quota admission, and general observed-state projection remain later lifecycle
-  slices
+  public v2 Volume lifecycle contract and core CRUD handlers are published,
+  while quota admission, attachment projection, and general observed-state
+  projection remain later lifecycle slices
 - `Server` now carries the internal attach-existing-only block volume intent
   and observed per-volume attachment rows. The provider boundary and OpenStack
   Nova attach/detach implementation exist; public API projection and

--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -487,6 +487,11 @@ func (c *Volume) OrganizationAndProjectID() (identityids.OrganizationID, identit
 	return organizationAndProjectIDFromLabels(c.Labels)
 }
 
+// RegionID returns the volume's owning region ID as a typed identifier.
+func (c *Volume) RegionID() (regionids.RegionID, error) {
+	return regionIDFromLabels(c.Labels)
+}
+
 // NetworkID returns the volume's anchoring network ID as a typed identifier.
 func (c *Volume) NetworkID() (regionids.NetworkID, error) {
 	id, err := regionids.ParseNetworkID(c.Spec.NetworkID)

--- a/pkg/handler/README.md
+++ b/pkg/handler/README.md
@@ -239,6 +239,8 @@ but we do not have transactions.”
   SSH CA records with explicit reference-blocked deletion
 - [`storage`](./storage/README.md): quota-heavy stateful resource with saga-backed
   create/update and attachment validation
+- [`volume`](./volume/README.md): Network-scoped block Volume CRUD with immutable
+  class/size, observed-size projection, and attached-delete blocking
 - `VolumeClass`: read-only Region-scoped provider inventory. The v2 list handler
   filters Regions through the canonical visibility policy, treats repeated
   `regionID` values as selectors, and maps only provider-neutral inventory

--- a/pkg/handler/handler_v2.go
+++ b/pkg/handler/handler_v2.go
@@ -26,27 +26,75 @@ import (
 	"github.com/unikorn-cloud/region/pkg/handler/loadbalancer"
 	"github.com/unikorn-cloud/region/pkg/handler/sshcertificateauthority"
 	"github.com/unikorn-cloud/region/pkg/handler/storage"
+	"github.com/unikorn-cloud/region/pkg/handler/volume"
 	"github.com/unikorn-cloud/region/pkg/openapi"
 )
 
+func (h *Handler) volumeClient() *volume.Client {
+	return volume.New(h.ClientArgs)
+}
+
 func (h *Handler) GetApiV2Volumes(w http.ResponseWriter, r *http.Request, params openapi.GetApiV2VolumesParams) {
-	openapi.Unimplemented{}.GetApiV2Volumes(w, r, params)
+	result, err := h.volumeClient().ListV2(r.Context(), params)
+	if err != nil {
+		errors.HandleError(w, r, err)
+		return
+	}
+
+	util.WriteJSONResponse(w, r, http.StatusOK, result)
 }
 
 func (h *Handler) PostApiV2Volumes(w http.ResponseWriter, r *http.Request) {
-	openapi.Unimplemented{}.PostApiV2Volumes(w, r)
+	request := &openapi.VolumeV2Create{}
+
+	if err := util.ReadJSONBody(r, request); err != nil {
+		errors.HandleError(w, r, err)
+		return
+	}
+
+	result, err := h.volumeClient().CreateV2(r.Context(), request)
+	if err != nil {
+		errors.HandleError(w, r, err)
+		return
+	}
+
+	util.WriteJSONResponse(w, r, http.StatusAccepted, result)
 }
 
 func (h *Handler) GetApiV2VolumesVolumeID(w http.ResponseWriter, r *http.Request, volumeID openapi.VolumeIDParameter) {
-	openapi.Unimplemented{}.GetApiV2VolumesVolumeID(w, r, volumeID)
+	result, err := h.volumeClient().GetV2(r.Context(), volumeID)
+	if err != nil {
+		errors.HandleError(w, r, err)
+		return
+	}
+
+	util.WriteJSONResponse(w, r, http.StatusOK, result)
 }
 
 func (h *Handler) PutApiV2VolumesVolumeID(w http.ResponseWriter, r *http.Request, volumeID openapi.VolumeIDParameter) {
-	openapi.Unimplemented{}.PutApiV2VolumesVolumeID(w, r, volumeID)
+	request := &openapi.VolumeV2Update{}
+
+	if err := util.ReadJSONBody(r, request); err != nil {
+		errors.HandleError(w, r, err)
+		return
+	}
+
+	result, err := h.volumeClient().UpdateV2(r.Context(), volumeID, request)
+	if err != nil {
+		errors.HandleError(w, r, err)
+		return
+	}
+
+	util.WriteJSONResponse(w, r, http.StatusOK, result)
 }
 
 func (h *Handler) DeleteApiV2VolumesVolumeID(w http.ResponseWriter, r *http.Request, volumeID openapi.VolumeIDParameter) {
-	openapi.Unimplemented{}.DeleteApiV2VolumesVolumeID(w, r, volumeID)
+	if err := h.volumeClient().DeleteV2(r.Context(), volumeID); err != nil {
+		errors.HandleError(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
 }
 
 func (h *Handler) GetApiV2Networks(w http.ResponseWriter, r *http.Request, params openapi.GetApiV2NetworksParams) {

--- a/pkg/handler/handler_v2_volume_test.go
+++ b/pkg/handler/handler_v2_volume_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:testpackage
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	regionconstants "github.com/unikorn-cloud/region/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/handler/common"
+	"github.com/unikorn-cloud/region/pkg/ids/idstest"
+	"github.com/unikorn-cloud/region/pkg/openapi"
+	mockproviders "github.com/unikorn-cloud/region/pkg/providers/mock"
+	providertypes "github.com/unikorn-cloud/region/pkg/providers/types"
+	mockprovider "github.com/unikorn-cloud/region/pkg/providers/types/mock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	volumeHandlerNamespace      = "volume-handler-test"
+	volumeHandlerOrganizationID = "81111111-1111-4111-a111-111111111111"
+	volumeHandlerProjectID      = "82222222-2222-4222-a222-222222222222"
+	volumeHandlerRegionID       = "83333333-3333-4333-a333-333333333333"
+	volumeHandlerIdentityID     = "84444444-4444-4444-a444-444444444444"
+	volumeHandlerNetworkID      = "85555555-5555-4555-a555-555555555555"
+	volumeHandlerClassID        = "fast"
+)
+
+func volumeHandlerContext(ctx context.Context) context.Context {
+	ctx = rbac.NewContext(ctx, &identityapi.Acl{
+		Organizations: &identityapi.AclOrganizationList{{
+			Id: volumeHandlerOrganizationID,
+			Projects: &identityapi.AclProjectList{{
+				Id: volumeHandlerProjectID,
+				Endpoints: identityapi.AclEndpoints{
+					{Name: "region:networks:v2", Operations: identityapi.AclOperations{identityapi.Read}},
+					{Name: "region:volumes:v2", Operations: identityapi.AclOperations{identityapi.Read, identityapi.Create, identityapi.Update, identityapi.Delete}},
+				},
+			}},
+		}},
+	})
+
+	return withPrincipal(ctx)
+}
+
+func volumeHandlerRequest(ctx context.Context, t *testing.T, method, target string, body any) *http.Request {
+	t.Helper()
+
+	var data []byte
+
+	if body != nil {
+		var err error
+		data, err = json.Marshal(body)
+		require.NoError(t, err)
+	}
+
+	return httptest.NewRequestWithContext(ctx, method, target, bytes.NewReader(data))
+}
+
+func TestVolumeV2Handlers(t *testing.T) {
+	t.Parallel()
+
+	network := &regionv1.Network{ObjectMeta: metav1.ObjectMeta{
+		Name:      volumeHandlerNetworkID,
+		Namespace: volumeHandlerNamespace,
+		Labels: map[string]string{
+			coreconstants.OrganizationLabel:         volumeHandlerOrganizationID,
+			coreconstants.ProjectLabel:              volumeHandlerProjectID,
+			regionconstants.RegionLabel:             volumeHandlerRegionID,
+			regionconstants.IdentityLabel:           volumeHandlerIdentityID,
+			regionconstants.ResourceAPIVersionLabel: regionconstants.MarshalAPIVersion(2),
+		},
+	}}
+
+	ctrl := gomock.NewController(t)
+	providers := mockproviders.NewMockProviders(ctrl)
+	provider := mockprovider.NewMockCommonProvider(ctrl)
+	providers.EXPECT().LookupCommon(volumeHandlerRegionID).Return(provider, nil)
+	provider.EXPECT().VolumeClasses(gomock.Any()).Return(providertypes.VolumeClassList{{ID: volumeHandlerClassID}}, nil)
+
+	handler := &Handler{ClientArgs: common.ClientArgs{
+		Client:    fakeClientWithSchema(t, network),
+		Namespace: volumeHandlerNamespace,
+		Providers: providers,
+	}}
+	ctx := volumeHandlerContext(t.Context())
+
+	create := openapi.VolumeV2Create{
+		Metadata: coreapi.ResourceWriteMetadata{Name: "data"},
+		Spec: openapi.VolumeV2Spec{
+			NetworkId:     idstest.MustParseNetworkID(volumeHandlerNetworkID),
+			VolumeClassId: volumeHandlerClassID,
+			SizeGiB:       20,
+		},
+	}
+	response := httptest.NewRecorder()
+	handler.PostApiV2Volumes(response, volumeHandlerRequest(ctx, t, http.MethodPost, "/api/v2/volumes", create))
+	require.Equal(t, http.StatusAccepted, response.Code)
+
+	var created openapi.VolumeV2Response
+
+	requireDeserialiseBody(t, response.Body, &created)
+	volumeID := idstest.MustParseVolumeID(created.Metadata.Id)
+
+	response = httptest.NewRecorder()
+	handler.GetApiV2Volumes(response, volumeHandlerRequest(ctx, t, http.MethodGet, "/api/v2/volumes", nil), openapi.GetApiV2VolumesParams{})
+	require.Equal(t, http.StatusOK, response.Code)
+
+	var listed openapi.VolumesV2Response
+
+	requireDeserialiseBody(t, response.Body, &listed)
+	require.Len(t, listed, 1)
+
+	response = httptest.NewRecorder()
+	handler.GetApiV2VolumesVolumeID(response, volumeHandlerRequest(ctx, t, http.MethodGet, "/api/v2/volumes/"+volumeID.String(), nil), volumeID)
+	require.Equal(t, http.StatusOK, response.Code)
+
+	response = httptest.NewRecorder()
+	handler.PutApiV2VolumesVolumeID(response, volumeHandlerRequest(ctx, t, http.MethodPut, "/api/v2/volumes/"+volumeID.String(), openapi.VolumeV2Update{
+		Metadata: coreapi.ResourceWriteMetadata{Name: "renamed"},
+	}), volumeID)
+	require.Equal(t, http.StatusOK, response.Code)
+
+	response = httptest.NewRecorder()
+	handler.DeleteApiV2VolumesVolumeID(response, volumeHandlerRequest(ctx, t, http.MethodDelete, "/api/v2/volumes/"+volumeID.String(), nil), volumeID)
+	require.Equal(t, http.StatusAccepted, response.Code)
+}

--- a/pkg/handler/volume/README.md
+++ b/pkg/handler/volume/README.md
@@ -1,0 +1,20 @@
+# Volume
+
+`pkg/handler/volume` implements the public v2 Volume lifecycle API.
+
+Volume creation validates the selected Network and VolumeClass, derives Region,
+Identity, organization, and project scope from that Network, and persists a
+controller-finalized `Volume` CRD owned by the Network with deletion blocking.
+Requested size is stored as a binary quantity while the API remains whole-GiB.
+Quota admission is not part of this package. A later slice adds create-time
+quota admission.
+
+List and get expose project-scoped metadata, immutable Network/class/size, the
+standard lifecycle and health projection, and observed size when it is present
+in CRD status. Attachment-derived fields are not projected by this package.
+
+Updates replace mutable metadata and tags with optimistic locking while
+preserving Network, VolumeClass, size, claims, controller state, and any
+future allocation annotation. Delete is idempotent once started and rejects a
+Volume with an active attachment claim or resource reference until it is
+manually detached.

--- a/pkg/handler/volume/client.go
+++ b/pkg/handler/volume/client.go
@@ -1,0 +1,406 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"math"
+	"slices"
+
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	"github.com/unikorn-cloud/core/pkg/manager"
+	"github.com/unikorn-cloud/core/pkg/server/conversion"
+	"github.com/unikorn-cloud/core/pkg/server/errors"
+	coreutil "github.com/unikorn-cloud/core/pkg/server/util"
+	identitycommon "github.com/unikorn-cloud/identity/pkg/handler/common"
+	identityids "github.com/unikorn-cloud/identity/pkg/ids"
+	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/principal"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/handler/common"
+	"github.com/unikorn-cloud/region/pkg/handler/network"
+	"github.com/unikorn-cloud/region/pkg/handler/util"
+	regionids "github.com/unikorn-cloud/region/pkg/ids"
+	"github.com/unikorn-cloud/region/pkg/openapi"
+	"github.com/unikorn-cloud/region/pkg/providers"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const endpoint = "region:volumes:v2"
+
+// Client implements the v2 Volume lifecycle API.
+type Client struct {
+	common.ClientArgs
+}
+
+// New creates a Volume client.
+func New(args common.ClientArgs) *Client {
+	return &Client{ClientArgs: args}
+}
+
+func sizeGiB(quantity resource.Quantity) int64 {
+	return quantity.Value() / (1 << 30)
+}
+
+func convertV2(in *regionv1.Volume) (*openapi.VolumeV2Read, error) {
+	regionID, err := in.RegionID()
+	if err != nil {
+		return nil, err
+	}
+
+	networkID, err := in.NetworkID()
+	if err != nil {
+		return nil, err
+	}
+
+	out := &openapi.VolumeV2Read{
+		Metadata: conversion.ProjectScopedResourceReadMetadata(in, in.Spec.Tags),
+		Spec: openapi.VolumeV2Spec{
+			SizeGiB:       sizeGiB(in.Spec.Size),
+			NetworkId:     networkID,
+			VolumeClassId: in.Spec.VolumeClassID,
+		},
+		Status: openapi.VolumeV2Status{
+			RegionId: regionID,
+		},
+	}
+
+	if in.Status.Size != nil {
+		out.Status.SizeGiB = ptr.To(sizeGiB(*in.Status.Size))
+	}
+
+	return out, nil
+}
+
+func convertV2List(in *regionv1.VolumeList) (openapi.VolumesV2Read, error) {
+	out := make(openapi.VolumesV2Read, len(in.Items))
+
+	for i := range in.Items {
+		volume, err := convertV2(&in.Items[i])
+		if err != nil {
+			return nil, err
+		}
+
+		out[i] = *volume
+	}
+
+	return out, nil
+}
+
+// ListV2 lists visible v2 Volumes.
+func (c *Client) ListV2(ctx context.Context, params openapi.GetApiV2VolumesParams) (openapi.VolumesV2Read, error) {
+	selector := labels.SelectorFromSet(map[string]string{
+		constants.ResourceAPIVersionLabel: constants.MarshalAPIVersion(2),
+	})
+
+	var err error
+
+	selector, err = rbac.AddOrganizationAndProjectIDQuery(ctx, selector, util.OrganizationIDQuery(params.OrganizationID), util.ProjectIDQuery(params.ProjectID))
+	if err != nil {
+		if rbac.HasNoMatches(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("%w: failed to add identity label selector", err)
+	}
+
+	selector, err = util.AddRegionIDQuery(selector, params.RegionID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to add region label selector", err)
+	}
+
+	selector, err = util.AddNetworkIDQuery(selector, params.NetworkID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to add network label selector", err)
+	}
+
+	result := &regionv1.VolumeList{}
+	if err := c.Client.List(ctx, result, &client.ListOptions{Namespace: c.Namespace, LabelSelector: selector}); err != nil {
+		return nil, fmt.Errorf("%w: unable to list volumes", err)
+	}
+
+	tagSelector, err := coreutil.DecodeTagSelectorParam(params.Tag)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Items = slices.DeleteFunc(result.Items, func(resource regionv1.Volume) bool {
+		return !resource.Spec.Tags.ContainsAll(tagSelector) || rbac.AllowProjectScopeReader(ctx, endpoint, identityapi.Read, &resource) != nil
+	})
+
+	slices.SortStableFunc(result.Items, func(a, b regionv1.Volume) int {
+		return cmp.Or(
+			cmp.Compare(a.Labels[coreconstants.NameLabel], b.Labels[coreconstants.NameLabel]),
+			cmp.Compare(a.Name, b.Name),
+		)
+	})
+
+	return convertV2List(result)
+}
+
+// GetV2Raw retrieves and authorizes a v2 Volume.
+func (c *Client) GetV2Raw(ctx context.Context, volumeID string) (*regionv1.Volume, error) {
+	result := &regionv1.Volume{}
+
+	if err := c.Client.Get(ctx, client.ObjectKey{Namespace: c.Namespace, Name: volumeID}, result); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil, errors.HTTPNotFound().WithError(err)
+		}
+
+		return nil, fmt.Errorf("%w: unable to lookup volume", err)
+	}
+
+	if err := rbac.AllowProjectScopeReader(ctx, endpoint, identityapi.Read, result); err != nil {
+		return nil, err
+	}
+
+	version, err := constants.UnmarshalAPIVersion(result.Labels[constants.ResourceAPIVersionLabel])
+	if err != nil || version != 2 {
+		return nil, errors.HTTPNotFound()
+	}
+
+	return result, nil
+}
+
+// GetV2 gets a v2 Volume.
+func (c *Client) GetV2(ctx context.Context, volumeID regionids.VolumeID) (*openapi.VolumeV2Read, error) {
+	result, err := c.GetV2Raw(ctx, volumeID.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return convertV2(result)
+}
+
+func requestedSize(sizeGiB int64) (resource.Quantity, error) {
+	if sizeGiB > math.MaxInt64/(1<<30) {
+		return resource.Quantity{}, errors.HTTPUnprocessableContent("sizeGiB exceeds the supported maximum")
+	}
+
+	return *resource.NewQuantity(sizeGiB*(1<<30), resource.BinarySI), nil
+}
+
+func (c *Client) validateVolumeClass(ctx context.Context, regionID, volumeClassID string, sizeGiB int64) error {
+	provider, err := c.Providers.LookupCommon(regionID)
+	if err != nil {
+		return providers.ProviderToServerError(err)
+	}
+
+	classes, err := provider.VolumeClasses(ctx)
+	if err != nil {
+		return fmt.Errorf("%w: failed to list volume classes", err)
+	}
+
+	for i := range classes {
+		class := &classes[i]
+		if class.ID != volumeClassID {
+			continue
+		}
+
+		if class.MinimumSizeGiB != nil && sizeGiB < *class.MinimumSizeGiB {
+			return errors.HTTPUnprocessableContent("sizeGiB is below the VolumeClass minimum")
+		}
+
+		if class.MaximumSizeGiB != nil && sizeGiB > *class.MaximumSizeGiB {
+			return errors.HTTPUnprocessableContent("sizeGiB exceeds the VolumeClass maximum")
+		}
+
+		return nil
+	}
+
+	return errors.HTTPUnprocessableContent("volumeClassId is not available in the Network's Region")
+}
+
+func (c *Client) generate(ctx context.Context, organizationID identityids.OrganizationID, projectID identityids.ProjectID, metadata *openapi.VolumeV2Update, network *regionv1.Network, volumeClassID string, size resource.Quantity) (*regionv1.Volume, error) {
+	out := &regionv1.Volume{
+		ObjectMeta: conversion.NewObjectMetadata(&metadata.Metadata, c.Namespace).
+			WithLabel(constants.RegionLabel, network.Labels[constants.RegionLabel]).
+			WithLabel(constants.IdentityLabel, network.Labels[constants.IdentityLabel]).
+			WithLabel(constants.NetworkLabel, network.Name).
+			WithLabel(constants.ResourceAPIVersionLabel, constants.MarshalAPIVersion(2)).
+			Get(),
+		Spec: regionv1.VolumeSpec{
+			Tags:          conversion.GenerateTagList(metadata.Metadata.Tags),
+			NetworkID:     network.Name,
+			VolumeClassID: volumeClassID,
+			Size:          size,
+		},
+	}
+
+	if err := identitycommon.SetIdentityMetadataProjectScope(ctx, &out.ObjectMeta, organizationID, projectID); err != nil {
+		return nil, fmt.Errorf("%w: failed to set identity metadata", err)
+	}
+
+	if err := controllerutil.SetOwnerReference(network, out, c.Client.Scheme(), controllerutil.WithBlockOwnerDeletion(true)); err != nil {
+		return nil, fmt.Errorf("%w: unable to set resource owner", err)
+	}
+
+	return out, nil
+}
+
+// CreateV2 creates a v2 Volume from Network-derived scope.
+func (c *Client) CreateV2(ctx context.Context, request *openapi.VolumeV2Create) (*openapi.VolumeV2Read, error) {
+	network, err := network.New(c.ClientArgs).GetV2Raw(ctx, request.Spec.NetworkId.String())
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, projectID, err := network.OrganizationAndProjectID()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := principal.EnrichUserPrincipalProjectScopeReader(ctx, network); err != nil {
+		return nil, fmt.Errorf("%w: unable to set principal information", err)
+	}
+
+	if err := rbac.AllowProjectScopeCreateID(ctx, c.Identity, endpoint, identityapi.Create, organizationID, projectID); err != nil {
+		return nil, err
+	}
+
+	regionID := network.Labels[constants.RegionLabel]
+	if err := c.validateVolumeClass(ctx, regionID, request.Spec.VolumeClassId, request.Spec.SizeGiB); err != nil {
+		return nil, err
+	}
+
+	size, err := requestedSize(request.Spec.SizeGiB)
+	if err != nil {
+		return nil, err
+	}
+
+	resource, err := c.generate(ctx, organizationID, projectID, &openapi.VolumeV2Update{Metadata: request.Metadata}, network, request.Spec.VolumeClassId, size)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add the finalizer before the controller can observe the resource, as required by specification §7.2.
+	resource.Finalizers = []string{coreconstants.Finalizer}
+
+	if err := c.Client.Create(ctx, resource); err != nil {
+		return nil, fmt.Errorf("%w: unable to create volume", err)
+	}
+
+	return convertV2(resource)
+}
+
+func (c *Client) generateUpdate(ctx context.Context, current *regionv1.Volume, request *openapi.VolumeV2Update) (*regionv1.Volume, error) {
+	organizationID, projectID, err := current.OrganizationAndProjectID()
+	if err != nil {
+		return nil, err
+	}
+
+	network, err := network.New(c.ClientArgs).GetV2Raw(ctx, current.Spec.NetworkID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := principal.EnrichUserPrincipalProjectScopeReader(ctx, network); err != nil {
+		return nil, fmt.Errorf("%w: unable to set principal information", err)
+	}
+
+	required, err := c.generate(ctx, organizationID, projectID, request, network, current.Spec.VolumeClassID, current.Spec.Size)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := conversion.UpdateObjectMetadata(required, current, identitycommon.IdentityMetadataMutator); err != nil {
+		return nil, fmt.Errorf("%w: failed to merge metadata", err)
+	}
+
+	if allocationID := current.Annotations[coreconstants.AllocationAnnotation]; allocationID != "" {
+		required.Annotations[coreconstants.AllocationAnnotation] = allocationID
+	}
+
+	updated := current.DeepCopy()
+	updated.Labels = required.Labels
+	updated.Annotations = required.Annotations
+	updated.Spec.Tags = required.Spec.Tags
+
+	return updated, nil
+}
+
+// UpdateV2 updates only Volume metadata and tags.
+func (c *Client) UpdateV2(ctx context.Context, volumeID regionids.VolumeID, request *openapi.VolumeV2Update) (*openapi.VolumeV2Read, error) {
+	current, err := c.GetV2Raw(ctx, volumeID.String())
+	if err != nil {
+		return nil, err
+	}
+
+	if err := rbac.AllowProjectScopeReader(ctx, endpoint, identityapi.Update, current); err != nil {
+		return nil, err
+	}
+
+	if current.DeletionTimestamp != nil {
+		return nil, errors.OAuth2InvalidRequest("volume is being deleted")
+	}
+
+	updated, err := c.generateUpdate(ctx, current, request)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.Client.Patch(ctx, updated, client.MergeFromWithOptions(current, &client.MergeFromWithOptimisticLock{})); err != nil {
+		if kerrors.IsConflict(err) {
+			return nil, errors.HTTPConflict().WithError(err)
+		}
+
+		return nil, fmt.Errorf("%w: unable to update volume", err)
+	}
+
+	return convertV2(updated)
+}
+
+// DeleteV2 deletes an unattached v2 Volume.
+func (c *Client) DeleteV2(ctx context.Context, volumeID regionids.VolumeID) error {
+	resource, err := c.GetV2Raw(ctx, volumeID.String())
+	if err != nil {
+		return err
+	}
+
+	if err := rbac.AllowProjectScopeReader(ctx, endpoint, identityapi.Delete, resource); err != nil {
+		return err
+	}
+
+	if resource.DeletionTimestamp != nil {
+		return nil
+	}
+
+	if resource.Spec.ClaimRef != nil || len(manager.GetResourceReferences(resource)) != 0 {
+		return errors.HTTPForbidden("volume is attached and must be detached before deletion")
+	}
+
+	if err := c.Client.Delete(ctx, resource); err != nil {
+		if kerrors.IsNotFound(err) {
+			return errors.HTTPNotFound().WithError(err)
+		}
+
+		return fmt.Errorf("%w: unable to delete volume", err)
+	}
+
+	return nil
+}

--- a/pkg/handler/volume/client_test.go
+++ b/pkg/handler/volume/client_test.go
@@ -1,0 +1,434 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume_test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	corev1 "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	coreerrors "github.com/unikorn-cloud/core/pkg/server/errors"
+	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
+	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	"github.com/unikorn-cloud/identity/pkg/principal"
+	"github.com/unikorn-cloud/identity/pkg/rbac"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/handler/common"
+	"github.com/unikorn-cloud/region/pkg/handler/volume"
+	idstest "github.com/unikorn-cloud/region/pkg/ids/idstest"
+	"github.com/unikorn-cloud/region/pkg/openapi"
+	mockproviders "github.com/unikorn-cloud/region/pkg/providers/mock"
+	providertypes "github.com/unikorn-cloud/region/pkg/providers/types"
+	mockprovider "github.com/unikorn-cloud/region/pkg/providers/types/mock"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testNamespace      = "test-namespace"
+	testOrganizationID = "11111111-1111-4111-a111-111111111111"
+	testProjectID      = "22222222-2222-4222-a222-222222222222"
+	testRegionID       = "33333333-3333-4333-a333-333333333333"
+	testIdentityID     = "44444444-4444-4444-a444-444444444444"
+	testNetworkID      = "55555555-5555-4555-a555-555555555555"
+	testVolumeID       = "66666666-6666-4666-a666-666666666666"
+	testServerID       = "77777777-7777-4777-a777-777777777777"
+	testVolumeClassID  = "fast"
+	volumeEndpoint     = "region:volumes:v2"
+)
+
+func testClient(t *testing.T, providers *mockproviders.MockProviders, objects ...client.Object) (*volume.Client, client.Client) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, regionv1.AddToScheme(scheme))
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+	return volume.New(common.ClientArgs{
+		Client:    cli,
+		Namespace: testNamespace,
+		Providers: providers,
+	}), cli
+}
+
+func testNetwork() *regionv1.Network {
+	return &regionv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNetworkID,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				coreconstants.OrganizationLabel:   testOrganizationID,
+				coreconstants.ProjectLabel:        testProjectID,
+				constants.RegionLabel:             testRegionID,
+				constants.IdentityLabel:           testIdentityID,
+				constants.ResourceAPIVersionLabel: constants.MarshalAPIVersion(2),
+			},
+		},
+	}
+}
+
+func testVolume(name string) *regionv1.Volume {
+	return &regionv1.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVolumeID,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				coreconstants.NameLabel:           name,
+				coreconstants.OrganizationLabel:   testOrganizationID,
+				coreconstants.ProjectLabel:        testProjectID,
+				constants.RegionLabel:             testRegionID,
+				constants.IdentityLabel:           testIdentityID,
+				constants.NetworkLabel:            testNetworkID,
+				constants.ResourceAPIVersionLabel: constants.MarshalAPIVersion(2),
+			},
+		},
+		Spec: regionv1.VolumeSpec{
+			NetworkID:     testNetworkID,
+			VolumeClassID: testVolumeClassID,
+			Size:          resource.MustParse("20Gi"),
+		},
+	}
+}
+
+func testContext(t *testing.T, operations ...identityapi.AclOperation) context.Context {
+	t.Helper()
+
+	ctx := rbac.NewContext(t.Context(), &identityapi.Acl{
+		Organizations: &identityapi.AclOrganizationList{{
+			Id: testOrganizationID,
+			Projects: &identityapi.AclProjectList{{
+				Id: testProjectID,
+				Endpoints: identityapi.AclEndpoints{
+					{Name: "region:networks:v2", Operations: identityapi.AclOperations{identityapi.Read}},
+					{Name: volumeEndpoint, Operations: operations},
+				},
+			}},
+		}},
+	})
+
+	ctx = authorization.NewContext(ctx, &authorization.Info{Userinfo: &identityapi.Userinfo{Sub: "token-actor"}})
+
+	return principal.NewContext(ctx, &principal.Principal{Actor: "test@example.com"})
+}
+
+func expectVolumeClasses(ctrl *gomock.Controller, providers *mockproviders.MockProviders, classes providertypes.VolumeClassList) {
+	provider := mockprovider.NewMockCommonProvider(ctrl)
+	providers.EXPECT().LookupCommon(testRegionID).Return(provider, nil)
+	provider.EXPECT().VolumeClasses(gomock.Any()).Return(classes, nil)
+}
+
+func TestCreateV2DerivesScopeAndPersistsCapacity(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	providers := mockproviders.NewMockProviders(ctrl)
+	expectVolumeClasses(ctrl, providers, providertypes.VolumeClassList{{ID: testVolumeClassID}})
+
+	volumeClient, cli := testClient(t, providers, testNetwork())
+	tags := coreapi.TagList{{Name: "environment", Value: "test"}}
+
+	result, err := volumeClient.CreateV2(testContext(t, identityapi.Read, identityapi.Create), &openapi.VolumeV2Create{
+		Metadata: coreapi.ResourceWriteMetadata{Name: "data", Tags: &tags},
+		Spec: openapi.VolumeV2Spec{
+			NetworkId:     idstest.MustParseNetworkID(testNetworkID),
+			VolumeClassId: testVolumeClassID,
+			SizeGiB:       20,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(20), result.Spec.SizeGiB)
+	require.Nil(t, result.Status.SizeGiB)
+	require.Equal(t, coreapi.ResourceProvisioningStatusPending, result.Metadata.ProvisioningStatus)
+
+	volumes := &regionv1.VolumeList{}
+	require.NoError(t, cli.List(t.Context(), volumes, client.InNamespace(testNamespace)))
+	require.Len(t, volumes.Items, 1)
+
+	stored := &volumes.Items[0]
+	require.Equal(t, testRegionID, stored.Labels[constants.RegionLabel])
+	require.Equal(t, testIdentityID, stored.Labels[constants.IdentityLabel])
+	require.Equal(t, testNetworkID, stored.Labels[constants.NetworkLabel])
+	require.Equal(t, testOrganizationID, stored.Labels[coreconstants.OrganizationLabel])
+	require.Equal(t, testProjectID, stored.Labels[coreconstants.ProjectLabel])
+	require.Equal(t, testNetworkID, stored.Spec.NetworkID)
+	require.Equal(t, testVolumeClassID, stored.Spec.VolumeClassID)
+	require.Equal(t, int64(20), stored.Spec.Size.Value()/(1<<30))
+	require.Equal(t, corev1.TagList{{Name: "environment", Value: "test"}}, stored.Spec.Tags)
+	require.Contains(t, stored.Finalizers, coreconstants.Finalizer)
+	require.Equal(t, []metav1.OwnerReference{{
+		APIVersion:         regionv1.SchemeGroupVersion.String(),
+		Kind:               "Network",
+		Name:               testNetworkID,
+		BlockOwnerDeletion: ptr.To(true),
+	}}, stored.OwnerReferences)
+	require.NotContains(t, stored.Annotations, coreconstants.AllocationAnnotation)
+}
+
+func TestCreateV2ValidatesVolumeClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		classID   string
+		size      int64
+		classes   providertypes.VolumeClassList
+		wantError bool
+	}{
+		{
+			name:    "valid",
+			classID: testVolumeClassID,
+			size:    20,
+			classes: providertypes.VolumeClassList{{
+				ID:             testVolumeClassID,
+				MinimumSizeGiB: ptr.To(int64(10)),
+				MaximumSizeGiB: ptr.To(int64(30)),
+			}},
+		},
+		{
+			name:    "below minimum",
+			classID: testVolumeClassID,
+			size:    9,
+			classes: providertypes.VolumeClassList{{
+				ID:             testVolumeClassID,
+				MinimumSizeGiB: ptr.To(int64(10)),
+			}},
+			wantError: true,
+		},
+		{
+			name:    "above maximum",
+			classID: testVolumeClassID,
+			size:    31,
+			classes: providertypes.VolumeClassList{{
+				ID:             testVolumeClassID,
+				MaximumSizeGiB: ptr.To(int64(30)),
+			}},
+			wantError: true,
+		},
+		{
+			name:      "unknown class",
+			classID:   "missing",
+			size:      20,
+			classes:   providertypes.VolumeClassList{{ID: testVolumeClassID}},
+			wantError: true,
+		},
+		{
+			name:      "quantity overflow",
+			classID:   testVolumeClassID,
+			size:      math.MaxInt64/(1<<30) + 1,
+			classes:   providertypes.VolumeClassList{{ID: testVolumeClassID}},
+			wantError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			providers := mockproviders.NewMockProviders(ctrl)
+			expectVolumeClasses(ctrl, providers, test.classes)
+
+			volumeClient, _ := testClient(t, providers, testNetwork())
+			_, err := volumeClient.CreateV2(testContext(t, identityapi.Read, identityapi.Create), &openapi.VolumeV2Create{
+				Metadata: coreapi.ResourceWriteMetadata{Name: "data"},
+				Spec: openapi.VolumeV2Spec{
+					NetworkId:     idstest.MustParseNetworkID(testNetworkID),
+					VolumeClassId: test.classID,
+					SizeGiB:       test.size,
+				},
+			})
+
+			if test.wantError {
+				require.True(t, coreerrors.IsUnprocessableContent(err))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestListAndGetV2ProjectBaseStatusWithoutAttachments(t *testing.T) {
+	t.Parallel()
+
+	observedSize := resource.MustParse("25Gi")
+	resource := testVolume("beta")
+	resource.Spec.Tags = corev1.TagList{{Name: "environment", Value: "test"}}
+	resource.Spec.ClaimRef = &regionv1.VolumeClaimRef{Kind: regionv1.VolumeClaimKindServer, ID: testServerID}
+	resource.Status.Size = &observedSize
+	resource.Status.Conditions = []metav1.Condition{{
+		Type:   string(corev1.ConditionAvailable),
+		Status: metav1.ConditionTrue,
+		Reason: string(corev1.ConditionReasonProvisioned),
+	}}
+
+	volumeClient, _ := testClient(t, nil, resource)
+	ctx := testContext(t, identityapi.Read)
+	tag := coreapi.TagSelectorParameter{"environment=test"}
+
+	result, err := volumeClient.ListV2(ctx, openapi.GetApiV2VolumesParams{
+		Tag:       &tag,
+		RegionID:  &openapi.RegionIDQueryParameter{testRegionID},
+		NetworkID: &openapi.NetworkIDQueryParameter{testNetworkID},
+	})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, coreapi.ResourceProvisioningStatusProvisioned, result[0].Metadata.ProvisioningStatus)
+	require.Equal(t, ptr.To(int64(25)), result[0].Status.SizeGiB)
+
+	got, err := volumeClient.GetV2(ctx, idstest.MustParseVolumeID(testVolumeID))
+	require.NoError(t, err)
+	require.Equal(t, testOrganizationID, got.Metadata.OrganizationId)
+	require.Equal(t, testProjectID, got.Metadata.ProjectId)
+	require.Equal(t, testRegionID, got.Status.RegionId.String())
+	require.Equal(t, testNetworkID, got.Spec.NetworkId.String())
+}
+
+func TestUpdateV2ChangesOnlyMetadataAndTags(t *testing.T) {
+	t.Parallel()
+
+	resource := testVolume("before")
+	resource.Annotations = map[string]string{coreconstants.AllocationAnnotation: "allocation-id"}
+	resource.Spec.ClaimRef = &regionv1.VolumeClaimRef{Kind: regionv1.VolumeClaimKindServer, ID: testServerID}
+
+	volumeClient, cli := testClient(t, nil, testNetwork(), resource)
+	tags := coreapi.TagList{{Name: "environment", Value: "updated"}}
+	description := "updated description"
+
+	result, err := volumeClient.UpdateV2(testContext(t, identityapi.Read, identityapi.Update), idstest.MustParseVolumeID(testVolumeID), &openapi.VolumeV2Update{
+		Metadata: coreapi.ResourceWriteMetadata{Name: "after", Description: &description, Tags: &tags},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "after", result.Metadata.Name)
+	require.Equal(t, int64(20), result.Spec.SizeGiB)
+	require.Equal(t, testVolumeClassID, result.Spec.VolumeClassId)
+
+	stored := &regionv1.Volume{}
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{Namespace: testNamespace, Name: testVolumeID}, stored))
+	require.Equal(t, testNetworkID, stored.Spec.NetworkID)
+	require.Equal(t, testVolumeClassID, stored.Spec.VolumeClassID)
+	require.Equal(t, int64(20), stored.Spec.Size.Value()/(1<<30))
+	require.Equal(t, resource.Spec.ClaimRef, stored.Spec.ClaimRef)
+	require.Equal(t, "allocation-id", stored.Annotations[coreconstants.AllocationAnnotation])
+	require.Equal(t, corev1.TagList{{Name: "environment", Value: "updated"}}, stored.Spec.Tags)
+}
+
+func TestDeleteV2RejectsAttachedVolumes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*regionv1.Volume)
+	}{
+		{
+			name: "claim",
+			mutate: func(resource *regionv1.Volume) {
+				resource.Spec.ClaimRef = &regionv1.VolumeClaimRef{Kind: regionv1.VolumeClaimKindServer, ID: testServerID}
+			},
+		},
+		{
+			name: "resource reference",
+			mutate: func(resource *regionv1.Volume) {
+				resource.Finalizers = []string{"servers.region.unikorn-cloud.org/" + testServerID}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			resource := testVolume("attached")
+			test.mutate(resource)
+			volumeClient, cli := testClient(t, nil, resource)
+
+			err := volumeClient.DeleteV2(testContext(t, identityapi.Read, identityapi.Delete), idstest.MustParseVolumeID(testVolumeID))
+			require.True(t, coreerrors.IsForbidden(err))
+			require.EqualError(t, err, "volume is attached and must be detached before deletion")
+			require.NoError(t, cli.Get(t.Context(), client.ObjectKey{Namespace: testNamespace, Name: testVolumeID}, &regionv1.Volume{}))
+		})
+	}
+}
+
+func TestCreateV2RequiresCreatePermission(t *testing.T) {
+	t.Parallel()
+
+	volumeClient, cli := testClient(t, nil, testNetwork())
+	_, err := volumeClient.CreateV2(testContext(t, identityapi.Read), &openapi.VolumeV2Create{
+		Metadata: coreapi.ResourceWriteMetadata{Name: "data"},
+		Spec: openapi.VolumeV2Spec{
+			NetworkId:     idstest.MustParseNetworkID(testNetworkID),
+			VolumeClassId: testVolumeClassID,
+			SizeGiB:       20,
+		},
+	})
+	require.True(t, coreerrors.IsForbidden(err))
+
+	volumes := &regionv1.VolumeList{}
+	require.NoError(t, cli.List(t.Context(), volumes, client.InNamespace(testNamespace)))
+	require.Empty(t, volumes.Items)
+}
+
+func TestGetV2RejectsCrossProjectAccess(t *testing.T) {
+	t.Parallel()
+
+	resource := testVolume("hidden")
+	resource.Labels[coreconstants.ProjectLabel] = "88888888-8888-4888-a888-888888888888"
+	volumeClient, _ := testClient(t, nil, resource)
+
+	_, err := volumeClient.GetV2(testContext(t, identityapi.Read), idstest.MustParseVolumeID(testVolumeID))
+	require.True(t, coreerrors.IsForbidden(err))
+}
+
+func TestListV2ExcludesCrossProjectVolumes(t *testing.T) {
+	t.Parallel()
+
+	visible := testVolume("visible")
+	hidden := testVolume("hidden")
+	hidden.Name = "99999999-9999-4999-a999-999999999999"
+	hidden.Labels[coreconstants.ProjectLabel] = "88888888-8888-4888-a888-888888888888"
+	volumeClient, _ := testClient(t, nil, visible, hidden)
+
+	result, err := volumeClient.ListV2(testContext(t, identityapi.Read), openapi.GetApiV2VolumesParams{})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, testVolumeID, result[0].Metadata.Id)
+}
+
+func TestDeleteV2DeletesUnattachedVolume(t *testing.T) {
+	t.Parallel()
+
+	volumeClient, cli := testClient(t, nil, testVolume("available"))
+	require.NoError(t, volumeClient.DeleteV2(testContext(t, identityapi.Read, identityapi.Delete), idstest.MustParseVolumeID(testVolumeID)))
+
+	err := cli.Get(t.Context(), client.ObjectKey{Namespace: testNamespace, Name: testVolumeID}, &regionv1.Volume{})
+	require.True(t, kerrors.IsNotFound(err))
+}

--- a/pkg/openapi/README.md
+++ b/pkg/openapi/README.md
@@ -76,9 +76,8 @@ immutable through this API; updates contain resource metadata and tags only.
 Reads expose the requested inputs alongside the Region the volume was
 provisioned in, provider-observed size, and the standard provisioning and
 health metadata.
-Attachment-derived state is not part of this base contract. The generated
-unimplemented server methods remain in use until the Volume handlers are added
-separately.
+Attachment-derived state is not part of this base contract. The Region handler
+implements this lifecycle surface.
 
 Keeping the schema unified matters because it allows:
 


### PR DESCRIPTION
## Summary

- Add Volume create, list, get, update, and delete handlers.
- Derive Region, Identity, organization, and project scope from the validated Network.
- Store requested capacity, preserve immutable size and class, and reject deletion while attached.
- Add focused handler, lifecycle, and RBAC unit coverage.

## Deferred scope

- STO-131 adds attachment API projection and Server attachment behavior.
- STO-159 adds create-time quota admission. Until then, Volume creation does not enforce organization quota.
- STO-133 adds full KinD Volume lifecycle integration coverage.

## Validation

- `make touch`
- `make license`
- `make validate`
- `make lint`
- `make generate`
- `make test-unit`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>