### PR TITLE
Integrate provider-observed Volume monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ test-results.json
 fuzz-results.xml
 hack/ci/ca-bundle.pem
 .claude/settings.local.json
+
+# Local agent discussion artifacts.
+CONTEXT.md
+docs/adr/

--- a/charts/region/templates/monitor/clusterrole.yaml
+++ b/charts/region/templates/monitor/clusterrole.yaml
@@ -14,6 +14,7 @@ rules:
   - openstackidentities
   - servers
   - openstackservers
+  - volumes
   verbs:
   - list
   - watch
@@ -28,6 +29,7 @@ rules:
   - region.unikorn-cloud.org
   resources:
   - servers/status
+  - volumes/status
   verbs:
   - patch
 # Patch server metadata (annotations) for Pending phase duration tracking.

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -29,8 +29,10 @@ The useful way to read it is not as a directory tree, but as one system:
   creation allocates requested capacity through Identity before persisting the
   Volume. Its provider capability exposes neutral backing discovery, observed
   size, and lifecycle state. The monitor projects that truth into observed
-  size, coarse health, and a domain-typed `Active` phase without taking over
-  the controller-owned `Available` condition. OpenStack also supports server
+  size and coarse health without taking over the controller-owned `Available`
+  condition. A provisioned Volume is a durable identity. Provider loss degrades
+  health and never triggers replacement under the same Region Volume ID.
+  OpenStack also supports server
   attachment behavior. Attachment projection remains a later lifecycle slice
 - `Server` now carries the internal attach-existing-only block volume intent
   and observed per-volume attachment rows. The provider boundary and OpenStack

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -27,10 +27,11 @@ The useful way to read it is not as a directory tree, but as one system:
   A Cinder error is surfaced through a safe typed provisioning condition. Its
   public v2 Volume lifecycle contract and core CRUD handlers are published;
   creation allocates requested capacity through Identity before persisting the
-  Volume. Its provider capability also exposes neutral backing discovery, observed
-  size, and lifecycle state, while OpenStack supports server attachment
-  behavior. Attachment projection, monitor integration, and observed-state
-  projection into the CRD remain later lifecycle slices
+  Volume. Its provider capability exposes neutral backing discovery, observed
+  size, and lifecycle state. The monitor projects that truth into observed
+  size, coarse health, and a domain-typed `Active` phase without taking over
+  the controller-owned `Available` condition. OpenStack also supports server
+  attachment behavior. Attachment projection remains a later lifecycle slice
 - `Server` now carries the internal attach-existing-only block volume intent
   and observed per-volume attachment rows. The provider boundary and OpenStack
   Nova attach/detach implementation exist; public API projection and
@@ -102,6 +103,7 @@ relationships.
 
 - [monitor](./monitor/README.md)
 - [monitor/health/server](./monitor/health/server/README.md)
+- [monitor/health/volume](./monitor/health/volume/README.md)
 
 These packages cover the part of the system that is intentionally observational
 rather than declarative.

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -99,11 +99,13 @@ stored objects rely on for linkage, migration, and operational coordination.
   `Volume.Status`, which is conditions-first. The Volume controller drives
   provider create/delete and exclusively owns the generic `Available`
   provisioning condition. The Volume monitor projects neutral provider
-  observation into `Volume.Status.Size`, coarse `Healthy`, and a domain-owned
-  Volume phase on the generic `Active` condition. Confirmed provider absence
-  is an observed `Missing` phase with degraded health; provider request errors
-  preserve the last observation. Provider-side volume identity is rediscovered
-  by stable provider lookup rather than mirrored into status.
+  observation into `Volume.Status.Size` and coarse `Healthy`. A successful
+  `Available=True/Provisioned` condition records completion of the one allowed
+  provider create. Confirmed provider absence clears observed size and degrades
+  health. It does not reset provisioning or trigger replacement. Provider
+  request errors preserve observed size and make health unknown. Provider-side
+  volume identity is rediscovered by stable provider lookup rather than
+  mirrored into status.
 - `Server.Spec.Volumes` is the attach-existing-only desired state for block
   storage. Each row names an existing Region `Volume` by ID; inline
   server-created volume templates are deliberately excluded from the first

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -97,12 +97,13 @@ stored objects rely on for linkage, migration, and operational coordination.
   claim; a nil claim means the volume is available for claiming. `Server` is the
   current supported claim kind. Attachment realization remains outside
   `Volume.Status`, which is conditions-first. The Volume controller drives
-  provider create/delete and generic provisioning conditions.
-  `Volume.Status.Size` remains a later persisted projection: provider
-  observation returns neutral observed size and lifecycle to its caller, but
-  does not write this CRD. The later monitor projects that provider truth into
-  Volume status. Provider-side volume identity is rediscovered by stable
-  provider lookup rather than mirrored into status.
+  provider create/delete and exclusively owns the generic `Available`
+  provisioning condition. The Volume monitor projects neutral provider
+  observation into `Volume.Status.Size`, coarse `Healthy`, and a domain-owned
+  Volume phase on the generic `Active` condition. Confirmed provider absence
+  is an observed `Missing` phase with degraded health; provider request errors
+  preserve the last observation. Provider-side volume identity is rediscovered
+  by stable provider lookup rather than mirrored into status.
 - `Server.Spec.Volumes` is the attach-existing-only desired state for block
   storage. Each row names an existing Region `Volume` by ID; inline
   server-created volume templates are deliberately excluded from the first

--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -159,6 +159,60 @@ func (c *Volume) SetProvisioningCondition(status corev1.ConditionStatus, reason 
 	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionAvailable, status, string(reason), message)
 }
 
+// SetHealthCondition sets the provider-observed health of a Volume.
+func (c *Volume) SetHealthCondition(status corev1.ConditionStatus, reason unikornv1core.HealthConditionReason, message string) {
+	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionHealthy, status, string(reason), message)
+}
+
+// SetVolumePhase sets the provider-observed Volume lifecycle phase.
+func (c *Volume) SetVolumePhase(reason VolumePhaseReason) {
+	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionActive, reason.ConditionStatus(), string(reason), reason.Message())
+}
+
+// GetVolumePhase reads the provider-observed Volume lifecycle phase.
+func GetVolumePhase(r unikornv1core.StatusConditionReader) (*unikornv1core.TypedCondition[VolumePhaseReason], error) {
+	return unikornv1core.GetTypedCondition[VolumePhaseReason](r, unikornv1core.ConditionActive)
+}
+
+// ConditionStatus reports whether the observed phase is currently usable.
+func (r VolumePhaseReason) ConditionStatus() corev1.ConditionStatus {
+	if r == VolumePhaseReasonAvailable || r == VolumePhaseReasonAttached {
+		return corev1.ConditionTrue
+	}
+
+	return corev1.ConditionFalse
+}
+
+// Message returns a user-facing description of the observed phase.
+//
+//nolint:cyclop // The branches exhaustively define the user-facing phase vocabulary.
+func (r VolumePhaseReason) Message() string {
+	switch r {
+	case VolumePhaseReasonCreating:
+		return "the volume is being created"
+	case VolumePhaseReasonAvailable:
+		return "the volume is available"
+	case VolumePhaseReasonAttaching:
+		return "the volume is being attached"
+	case VolumePhaseReasonAttached:
+		return "the volume is attached"
+	case VolumePhaseReasonDetaching:
+		return "the volume is being detached"
+	case VolumePhaseReasonUpdating:
+		return "the volume is being updated"
+	case VolumePhaseReasonDeleting:
+		return "the volume is being deleted"
+	case VolumePhaseReasonError:
+		return "the provider reported the volume in an error state"
+	case VolumePhaseReasonMissing:
+		return "the provider volume is missing"
+	case VolumePhaseReasonUnknown:
+		return "the provider volume state is unknown"
+	}
+
+	return "the provider volume state is unknown"
+}
+
 // ResourceLabels generates a set of labels to uniquely identify the resource
 // if it were to be placed in a single global namespace.
 func (c *Volume) ResourceLabels() (labels.Set, error) {

--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -164,55 +164,6 @@ func (c *Volume) SetHealthCondition(status corev1.ConditionStatus, reason unikor
 	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionHealthy, status, string(reason), message)
 }
 
-// SetVolumePhase sets the provider-observed Volume lifecycle phase.
-func (c *Volume) SetVolumePhase(reason VolumePhaseReason) {
-	unikornv1core.UpdateCondition(&c.Status.Conditions, unikornv1core.ConditionActive, reason.ConditionStatus(), string(reason), reason.Message())
-}
-
-// GetVolumePhase reads the provider-observed Volume lifecycle phase.
-func GetVolumePhase(r unikornv1core.StatusConditionReader) (*unikornv1core.TypedCondition[VolumePhaseReason], error) {
-	return unikornv1core.GetTypedCondition[VolumePhaseReason](r, unikornv1core.ConditionActive)
-}
-
-// ConditionStatus reports whether the observed phase is currently usable.
-func (r VolumePhaseReason) ConditionStatus() corev1.ConditionStatus {
-	if r == VolumePhaseReasonAvailable || r == VolumePhaseReasonAttached {
-		return corev1.ConditionTrue
-	}
-
-	return corev1.ConditionFalse
-}
-
-// Message returns a user-facing description of the observed phase.
-//
-//nolint:cyclop // The branches exhaustively define the user-facing phase vocabulary.
-func (r VolumePhaseReason) Message() string {
-	switch r {
-	case VolumePhaseReasonCreating:
-		return "the volume is being created"
-	case VolumePhaseReasonAvailable:
-		return "the volume is available"
-	case VolumePhaseReasonAttaching:
-		return "the volume is being attached"
-	case VolumePhaseReasonAttached:
-		return "the volume is attached"
-	case VolumePhaseReasonDetaching:
-		return "the volume is being detached"
-	case VolumePhaseReasonUpdating:
-		return "the volume is being updated"
-	case VolumePhaseReasonDeleting:
-		return "the volume is being deleted"
-	case VolumePhaseReasonError:
-		return "the provider reported the volume in an error state"
-	case VolumePhaseReasonMissing:
-		return "the provider volume is missing"
-	case VolumePhaseReasonUnknown:
-		return "the provider volume state is unknown"
-	}
-
-	return "the provider volume state is unknown"
-}
-
 // ResourceLabels generates a set of labels to uniquely identify the resource
 // if it were to be placed in a single global namespace.
 func (c *Volume) ResourceLabels() (labels.Set, error) {

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -897,6 +897,23 @@ const (
 	VolumeClaimKindServer VolumeClaimKind = "Server"
 )
 
+// VolumePhaseReason is the domain-owned observed lifecycle vocabulary for the
+// generic core Active condition on a Volume.
+type VolumePhaseReason string
+
+const (
+	VolumePhaseReasonCreating  VolumePhaseReason = "Creating"
+	VolumePhaseReasonAvailable VolumePhaseReason = "Available"
+	VolumePhaseReasonAttaching VolumePhaseReason = "Attaching"
+	VolumePhaseReasonAttached  VolumePhaseReason = "Attached"
+	VolumePhaseReasonDetaching VolumePhaseReason = "Detaching"
+	VolumePhaseReasonUpdating  VolumePhaseReason = "Updating"
+	VolumePhaseReasonDeleting  VolumePhaseReason = "Deleting"
+	VolumePhaseReasonError     VolumePhaseReason = "Error"
+	VolumePhaseReasonUnknown   VolumePhaseReason = "Unknown"
+	VolumePhaseReasonMissing   VolumePhaseReason = "Missing"
+)
+
 type VolumeStatus struct {
 	// ObservedGeneration is the most recent generation observed by the controller.
 	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -897,23 +897,6 @@ const (
 	VolumeClaimKindServer VolumeClaimKind = "Server"
 )
 
-// VolumePhaseReason is the domain-owned observed lifecycle vocabulary for the
-// generic core Active condition on a Volume.
-type VolumePhaseReason string
-
-const (
-	VolumePhaseReasonCreating  VolumePhaseReason = "Creating"
-	VolumePhaseReasonAvailable VolumePhaseReason = "Available"
-	VolumePhaseReasonAttaching VolumePhaseReason = "Attaching"
-	VolumePhaseReasonAttached  VolumePhaseReason = "Attached"
-	VolumePhaseReasonDetaching VolumePhaseReason = "Detaching"
-	VolumePhaseReasonUpdating  VolumePhaseReason = "Updating"
-	VolumePhaseReasonDeleting  VolumePhaseReason = "Deleting"
-	VolumePhaseReasonError     VolumePhaseReason = "Error"
-	VolumePhaseReasonUnknown   VolumePhaseReason = "Unknown"
-	VolumePhaseReasonMissing   VolumePhaseReason = "Missing"
-)
-
 type VolumeStatus struct {
 	// ObservedGeneration is the most recent generation observed by the controller.
 	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`

--- a/pkg/managers/volume/README.md
+++ b/pkg/managers/volume/README.md
@@ -12,3 +12,8 @@ while a typed terminal provider error records its safe `Available=False`
 reason/message without continued polling. Kubernetes increments generation when
 marking a resource for deletion, so the generation predicate also enqueues
 deprovisioning.
+
+After provisioning succeeds, the provisioner treats
+`Available=True/Provisioned` as a create-completed latch. Later generation
+events do not recreate provider storage. The health monitor reports provider
+loss separately through `Healthy`.

--- a/pkg/monitor/README.md
+++ b/pkg/monitor/README.md
@@ -27,8 +27,7 @@ The current checkers are:
 - [health/server](./health/server/README.md), which projects server runtime
   state and telemetry
 - [health/volume](./health/volume/README.md), which projects provider-neutral
-  Volume size, phase, and health while preserving controller-owned provisioning
-  state
+  Volume size and health while preserving controller-owned provisioning state
 
 ## Caveats
 

--- a/pkg/monitor/README.md
+++ b/pkg/monitor/README.md
@@ -22,9 +22,13 @@ controller watches.
 - runs one or more `Checker`s on a poll interval
 - logs and continues on non-fatal per-check failures
 
-Right now the only checker is
-[health/server](./health/server/README.md), but the abstraction is clearly
-intended to allow additional monitor classes later.
+The current checkers are:
+
+- [health/server](./health/server/README.md), which projects server runtime
+  state and telemetry
+- [health/volume](./health/volume/README.md), which projects provider-neutral
+  Volume size, phase, and health while preserving controller-owned provisioning
+  state
 
 ## Caveats
 

--- a/pkg/monitor/health/volume/README.md
+++ b/pkg/monitor/health/volume/README.md
@@ -1,0 +1,20 @@
+# Volume Health
+
+`pkg/monitor/health/volume` polls the provider-neutral `ObserveVolume`
+contract and projects provider truth into Region `Volume` status.
+
+The checker owns only observed state:
+
+- `status.size`
+- the domain-typed Volume phase carried by the generic `Active` condition
+- the coarse `Healthy` condition
+
+The Volume controller remains the sole owner of the `Available` provisioning
+condition and all create/delete intent. Known non-error provider phases are
+healthy without being collapsed into health reasons; `error` and confirmed
+provider absence are degraded, while an unknown provider phase has unknown
+health. Provider request failures preserve the last successful observation.
+
+Every phase and health transition is logged with Volume, organization, and
+region identifiers. Confirmed absence clears observed size. The checker never
+imports Cinder types or performs provider mutations.

--- a/pkg/monitor/health/volume/README.md
+++ b/pkg/monitor/health/volume/README.md
@@ -1,27 +1,22 @@
 # Volume Health
 
-`pkg/monitor/health/volume` polls the provider-neutral `ObserveVolume`
-contract and projects provider truth into Region `Volume` status.
+`pkg/monitor/health/volume` asks the provider to update a deep copy of the
+Region `Volume` with its current backing-resource state, then persists one
+optimistic status patch.
 
-The checker owns only observed state:
-
-- `status.size`
-- the coarse `Healthy` condition
+The provider owns provider-state mapping, observed size, missing-volume
+semantics, and health messages. The checker owns orchestration, patching, and
+transition logging.
 
 The Volume controller remains the sole owner of the `Available` provisioning
-condition and all create/delete intent. Creating, available, attaching,
-attached, detaching, and updating provider states are healthy. Provider error,
-unexpected provider deletion, and confirmed provider absence are degraded. An
-unknown provider state has unknown health. Provider request failures preserve
-the last observed size and make current health unknown. Provider absence only
-degrades health after the controller records `Available=True/Provisioned`.
-Before provisioning completes, absence is expected and does not set health.
+condition and all create/delete intent. Provider request or observation errors
+are logged and skipped, preserving the last observed status. Provider absence
+semantics are defined by the provider implementation.
 
 Every health transition is logged with its previous and new status, reason, and
 message. Logs also include Volume, organization, and region identifiers.
-Confirmed absence clears observed size. The checker never imports Cinder types
-or performs provider mutations. It removes the obsolete Volume `Active`
-condition when it updates status.
+The checker never imports provider SDK types. It removes the obsolete Volume
+`Active` condition when it updates status.
 
 Provider resolution results, including failures, are cached by region for one
 poll cycle. A provider initialization failure is attempted once per region, not

--- a/pkg/monitor/health/volume/README.md
+++ b/pkg/monitor/health/volume/README.md
@@ -13,10 +13,16 @@ condition and all create/delete intent. Creating, available, attaching,
 attached, detaching, and updating provider states are healthy. Provider error,
 unexpected provider deletion, and confirmed provider absence are degraded. An
 unknown provider state has unknown health. Provider request failures preserve
-the last observed size and make current health unknown.
+the last observed size and make current health unknown. Provider absence only
+degrades health after the controller records `Available=True/Provisioned`.
+Before provisioning completes, absence is expected and does not set health.
 
 Every health transition is logged with its previous and new status, reason, and
 message. Logs also include Volume, organization, and region identifiers.
 Confirmed absence clears observed size. The checker never imports Cinder types
 or performs provider mutations. It removes the obsolete Volume `Active`
 condition when it updates status.
+
+Provider resolution results, including failures, are cached by region for one
+poll cycle. A provider initialization failure is attempted once per region, not
+once per Volume.

--- a/pkg/monitor/health/volume/README.md
+++ b/pkg/monitor/health/volume/README.md
@@ -6,15 +6,17 @@ contract and projects provider truth into Region `Volume` status.
 The checker owns only observed state:
 
 - `status.size`
-- the domain-typed Volume phase carried by the generic `Active` condition
 - the coarse `Healthy` condition
 
 The Volume controller remains the sole owner of the `Available` provisioning
-condition and all create/delete intent. Known non-error provider phases are
-healthy without being collapsed into health reasons; `error` and confirmed
-provider absence are degraded, while an unknown provider phase has unknown
-health. Provider request failures preserve the last successful observation.
+condition and all create/delete intent. Creating, available, attaching,
+attached, detaching, and updating provider states are healthy. Provider error,
+unexpected provider deletion, and confirmed provider absence are degraded. An
+unknown provider state has unknown health. Provider request failures preserve
+the last observed size and make current health unknown.
 
-Every phase and health transition is logged with Volume, organization, and
-region identifiers. Confirmed absence clears observed size. The checker never
-imports Cinder types or performs provider mutations.
+Every health transition is logged with its previous and new status, reason, and
+message. Logs also include Volume, organization, and region identifiers.
+Confirmed absence clears observed size. The checker never imports Cinder types
+or performs provider mutations. It removes the obsolete Volume `Active`
+condition when it updates status.

--- a/pkg/monitor/health/volume/check.go
+++ b/pkg/monitor/health/volume/check.go
@@ -32,6 +32,7 @@ import (
 	providertypes "github.com/unikorn-cloud/region/pkg/providers/types"
 
 	corev1 "k8s.io/api/core/v1"
+	apiMeta "k8s.io/apimachinery/pkg/api/meta"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -57,88 +58,63 @@ func volumeLogger(ctx context.Context, volume *unikornv1.Volume) logr.Logger {
 	)
 }
 
-func volumePhase(status providertypes.VolumeStatus) unikornv1.VolumePhaseReason {
-	switch status {
-	case providertypes.VolumeStatusCreating:
-		return unikornv1.VolumePhaseReasonCreating
-	case providertypes.VolumeStatusAvailable:
-		return unikornv1.VolumePhaseReasonAvailable
-	case providertypes.VolumeStatusAttaching:
-		return unikornv1.VolumePhaseReasonAttaching
-	case providertypes.VolumeStatusAttached:
-		return unikornv1.VolumePhaseReasonAttached
-	case providertypes.VolumeStatusDetaching:
-		return unikornv1.VolumePhaseReasonDetaching
-	case providertypes.VolumeStatusUpdating:
-		return unikornv1.VolumePhaseReasonUpdating
-	case providertypes.VolumeStatusDeleting:
-		return unikornv1.VolumePhaseReasonDeleting
-	case providertypes.VolumeStatusError:
-		return unikornv1.VolumePhaseReasonError
-	case providertypes.VolumeStatusUnknown:
-		return unikornv1.VolumePhaseReasonUnknown
-	}
-
-	return unikornv1.VolumePhaseReasonUnknown
-}
-
 func setObservedStatus(volume *unikornv1.Volume, observation *providertypes.VolumeObservation) {
 	size := observation.Size.DeepCopy()
 	volume.Status.Size = &size
-	phase := volumePhase(observation.Status)
-	volume.SetVolumePhase(phase)
 
-	switch phase {
-	case unikornv1.VolumePhaseReasonError:
+	switch observation.Status {
+	case providertypes.VolumeStatusError:
 		volume.SetHealthCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider reported the volume in an error state")
-	case unikornv1.VolumePhaseReasonUnknown:
+	case providertypes.VolumeStatusDeleting:
+		volume.SetHealthCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider volume is being deleted")
+	case providertypes.VolumeStatusUnknown:
 		volume.SetHealthCondition(corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "the provider volume state is unknown")
-	case unikornv1.VolumePhaseReasonMissing:
-		volume.SetHealthCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider volume is missing")
-	case unikornv1.VolumePhaseReasonCreating,
-		unikornv1.VolumePhaseReasonAvailable,
-		unikornv1.VolumePhaseReasonAttaching,
-		unikornv1.VolumePhaseReasonAttached,
-		unikornv1.VolumePhaseReasonDetaching,
-		unikornv1.VolumePhaseReasonUpdating,
-		unikornv1.VolumePhaseReasonDeleting:
+	case providertypes.VolumeStatusCreating,
+		providertypes.VolumeStatusAvailable,
+		providertypes.VolumeStatusAttaching,
+		providertypes.VolumeStatusAttached,
+		providertypes.VolumeStatusDetaching,
+		providertypes.VolumeStatusUpdating:
 		volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy")
+	default:
+		volume.SetHealthCondition(corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "the provider volume state is unknown")
 	}
 }
 
 func setMissingStatus(volume *unikornv1.Volume) {
 	volume.Status.Size = nil
-	volume.SetVolumePhase(unikornv1.VolumePhaseReasonMissing)
 	volume.SetHealthCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider volume is missing")
+}
+
+func setObservationFailureStatus(volume *unikornv1.Volume) {
+	volume.SetHealthCondition(corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "unable to observe provider volume state")
 }
 
 func logTransitions(ctx context.Context, before, after *unikornv1.Volume) {
 	logger := volumeLogger(ctx, after)
 
-	oldPhase, oldErr := unikornv1.GetVolumePhase(before)
-	newPhase, newErr := unikornv1.GetVolumePhase(after)
-
-	if newErr == nil && (oldErr != nil || oldPhase.Reason != newPhase.Reason) {
-		from := ""
-
-		if oldErr == nil {
-			from = string(oldPhase.Reason)
-		}
-
-		logger.Info("volume phase transition", "from_phase", from, "to_phase", newPhase.Reason)
-	}
-
 	oldHealth, oldErr := unikornv1core.GetHealthyCondition(before)
 	newHealth, newErr := unikornv1core.GetHealthyCondition(after)
 
-	if newErr == nil && (oldErr != nil || oldHealth.Status != newHealth.Status || oldHealth.Reason != newHealth.Reason) {
-		from := ""
+	if newErr == nil && (oldErr != nil || oldHealth.Status != newHealth.Status || oldHealth.Reason != newHealth.Reason || oldHealth.Message != newHealth.Message) {
+		fromStatus := corev1.ConditionUnknown
+		fromReason := unikornv1core.HealthConditionReason("")
+		fromMessage := ""
 
 		if oldErr == nil {
-			from = string(oldHealth.Reason)
+			fromStatus = oldHealth.Status
+			fromReason = oldHealth.Reason
+			fromMessage = oldHealth.Message
 		}
 
-		logger.Info("volume health transition", "from_health", from, "to_health", newHealth.Reason)
+		logger.Info("volume health transition",
+			"from_status", fromStatus,
+			"from_health", fromReason,
+			"from_message", fromMessage,
+			"to_status", newHealth.Status,
+			"to_health", newHealth.Reason,
+			"to_message", newHealth.Message,
+		)
 	}
 }
 
@@ -187,6 +163,8 @@ func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume) e
 	}
 
 	updated := volume.DeepCopy()
+	apiMeta.RemoveStatusCondition(&updated.Status.Conditions, string(unikornv1core.ConditionActive))
+
 	observation, err := provider.ObserveVolume(ctx, identity, volume)
 
 	switch {
@@ -195,13 +173,11 @@ func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume) e
 	case errors.Is(err, coreerrors.ErrResourceNotFound):
 		setMissingStatus(updated)
 	case err != nil:
-		volumeLogger(ctx, volume).Error(err, "failed to observe volume, skipping")
-
-		return nil
+		volumeLogger(ctx, volume).Error(err, "failed to observe volume")
+		setObservationFailureStatus(updated)
 	case observation == nil:
-		volumeLogger(ctx, volume).Error(fmt.Errorf("%w: nil volume observation", coreerrors.ErrConsistency), "failed to observe volume, skipping")
-
-		return nil
+		volumeLogger(ctx, volume).Error(fmt.Errorf("%w: nil volume observation", coreerrors.ErrConsistency), "failed to observe volume")
+		setObservationFailureStatus(updated)
 	default:
 		setObservedStatus(updated, observation)
 	}

--- a/pkg/monitor/health/volume/check.go
+++ b/pkg/monitor/health/volume/check.go
@@ -19,13 +19,11 @@ package volume
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/go-logr/logr"
 
 	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
-	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/constants"
 	"github.com/unikorn-cloud/region/pkg/providers"
@@ -56,38 +54,6 @@ func volumeLogger(ctx context.Context, volume *unikornv1.Volume) logr.Logger {
 		"org_id", volume.Labels[coreconstants.OrganizationLabel],
 		"region_id", volume.Labels[constants.RegionLabel],
 	)
-}
-
-func setObservedStatus(volume *unikornv1.Volume, observation *providertypes.VolumeObservation) {
-	size := observation.Size.DeepCopy()
-	volume.Status.Size = &size
-
-	switch observation.Status {
-	case providertypes.VolumeStatusError:
-		volume.SetHealthCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider reported the volume in an error state")
-	case providertypes.VolumeStatusDeleting:
-		volume.SetHealthCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider volume is being deleted")
-	case providertypes.VolumeStatusUnknown:
-		volume.SetHealthCondition(corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "the provider volume state is unknown")
-	case providertypes.VolumeStatusCreating,
-		providertypes.VolumeStatusAvailable,
-		providertypes.VolumeStatusAttaching,
-		providertypes.VolumeStatusAttached,
-		providertypes.VolumeStatusDetaching,
-		providertypes.VolumeStatusUpdating:
-		volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy")
-	default:
-		volume.SetHealthCondition(corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "the provider volume state is unknown")
-	}
-}
-
-func setMissingStatus(volume *unikornv1.Volume) {
-	volume.Status.Size = nil
-	volume.SetHealthCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider volume is missing")
-}
-
-func setObservationFailureStatus(volume *unikornv1.Volume) {
-	volume.SetHealthCondition(corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "unable to observe provider volume state")
 }
 
 func logTransitions(ctx context.Context, before, after *unikornv1.Volume) {
@@ -163,7 +129,6 @@ func (c *Checker) patchStatus(ctx context.Context, volume, updated *unikornv1.Vo
 	return nil
 }
 
-//nolint:cyclop // The branches keep independent provider failures isolated to the affected Volume.
 func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume, providers map[string]providerEntry) error {
 	if volume.DeletionTimestamp != nil {
 		return nil
@@ -190,9 +155,7 @@ func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume, p
 			return err
 		}
 
-		setObservationFailureStatus(updated)
-
-		return c.patchStatus(ctx, volume, updated)
+		return nil
 	}
 
 	identity := &unikornv1.Identity{}
@@ -206,28 +169,14 @@ func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume, p
 		return nil
 	}
 
-	observation, err := provider.ObserveVolume(ctx, identity, volume)
-
-	switch {
-	case isFatal(err):
-		return err
-	case errors.Is(err, coreerrors.ErrResourceNotFound):
-		available, availableErr := unikornv1core.GetAvailableCondition(volume)
-		if availableErr != nil || available.Status != corev1.ConditionTrue || available.Reason != unikornv1core.ConditionReasonProvisioned {
-			volumeLogger(ctx, volume).Info("provider volume not found before provisioning completed")
-
-			break
+	if err := provider.UpdateVolumeState(ctx, identity, updated); err != nil {
+		if isFatal(err) {
+			return err
 		}
 
-		setMissingStatus(updated)
-	case err != nil:
-		volumeLogger(ctx, volume).Error(err, "failed to observe volume")
-		setObservationFailureStatus(updated)
-	case observation == nil:
-		volumeLogger(ctx, volume).Error(fmt.Errorf("%w: nil volume observation", coreerrors.ErrConsistency), "failed to observe volume")
-		setObservationFailureStatus(updated)
-	default:
-		setObservedStatus(updated, observation)
+		volumeLogger(ctx, volume).Error(err, "failed to update provider volume state, skipping")
+
+		return nil
 	}
 
 	return c.patchStatus(ctx, volume, updated)

--- a/pkg/monitor/health/volume/check.go
+++ b/pkg/monitor/health/volume/check.go
@@ -122,8 +122,33 @@ func isFatal(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
+type providerEntry struct {
+	provider providertypes.Provider
+	err      error
+}
+
+func (c *Checker) resolveProvider(ctx context.Context, cache map[string]providerEntry, regionID string) (providertypes.Provider, error) {
+	if entry, ok := cache[regionID]; ok {
+		return entry.provider, entry.err
+	}
+
+	provider, err := c.providers.LookupCloud(regionID)
+	if err != nil {
+		if !isFatal(err) {
+			log.FromContext(ctx).Error(err, "failed to resolve volume provider, skipping", "region_id", regionID)
+			cache[regionID] = providerEntry{err: err}
+		}
+
+		return nil, err
+	}
+
+	cache[regionID] = providerEntry{provider: provider}
+
+	return provider, nil
+}
+
 //nolint:cyclop // The branches keep independent provider failures isolated to the affected Volume.
-func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume) error {
+func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume, providers map[string]providerEntry) error {
 	if volume.DeletionTimestamp != nil {
 		return nil
 	}
@@ -140,13 +165,11 @@ func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume) e
 		return nil
 	}
 
-	provider, err := c.providers.LookupCloud(regionID)
+	provider, err := c.resolveProvider(ctx, providers, regionID)
 	if err != nil {
 		if isFatal(err) {
 			return err
 		}
-
-		volumeLogger(ctx, volume).Error(err, "failed to resolve volume provider, skipping")
 
 		return nil
 	}
@@ -171,6 +194,13 @@ func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume) e
 	case isFatal(err):
 		return err
 	case errors.Is(err, coreerrors.ErrResourceNotFound):
+		available, availableErr := unikornv1core.GetAvailableCondition(volume)
+		if availableErr != nil || available.Status != corev1.ConditionTrue || available.Reason != unikornv1core.ConditionReasonProvisioned {
+			volumeLogger(ctx, volume).Info("provider volume not found before provisioning completed")
+
+			break
+		}
+
 		setMissingStatus(updated)
 	case err != nil:
 		volumeLogger(ctx, volume).Error(err, "failed to observe volume")
@@ -204,8 +234,10 @@ func (c *Checker) Check(ctx context.Context) error {
 		return err
 	}
 
+	providers := make(map[string]providerEntry)
+
 	for i := range volumes.Items {
-		if err := c.processVolume(ctx, &volumes.Items[i]); err != nil {
+		if err := c.processVolume(ctx, &volumes.Items[i], providers); err != nil {
 			return err
 		}
 	}

--- a/pkg/monitor/health/volume/check.go
+++ b/pkg/monitor/health/volume/check.go
@@ -135,7 +135,7 @@ func (c *Checker) resolveProvider(ctx context.Context, cache map[string]provider
 	provider, err := c.providers.LookupCloud(regionID)
 	if err != nil {
 		if !isFatal(err) {
-			log.FromContext(ctx).Error(err, "failed to resolve volume provider, skipping", "region_id", regionID)
+			log.FromContext(ctx).Error(err, "failed to resolve volume provider", "region_id", regionID)
 			cache[regionID] = providerEntry{err: err}
 		}
 
@@ -145,6 +145,22 @@ func (c *Checker) resolveProvider(ctx context.Context, cache map[string]provider
 	cache[regionID] = providerEntry{provider: provider}
 
 	return provider, nil
+}
+
+func (c *Checker) patchStatus(ctx context.Context, volume, updated *unikornv1.Volume) error {
+	if err := c.client.Status().Patch(ctx, updated, client.MergeFromWithOptions(volume, &client.MergeFromWithOptimisticLock{})); err != nil {
+		if isFatal(err) {
+			return err
+		}
+
+		volumeLogger(ctx, volume).Error(err, "failed to update volume status, skipping")
+
+		return nil
+	}
+
+	logTransitions(ctx, volume, updated)
+
+	return nil
 }
 
 //nolint:cyclop // The branches keep independent provider failures isolated to the affected Volume.
@@ -165,13 +181,18 @@ func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume, p
 		return nil
 	}
 
+	updated := volume.DeepCopy()
+	apiMeta.RemoveStatusCondition(&updated.Status.Conditions, string(unikornv1core.ConditionActive))
+
 	provider, err := c.resolveProvider(ctx, providers, regionID)
 	if err != nil {
 		if isFatal(err) {
 			return err
 		}
 
-		return nil
+		setObservationFailureStatus(updated)
+
+		return c.patchStatus(ctx, volume, updated)
 	}
 
 	identity := &unikornv1.Identity{}
@@ -184,9 +205,6 @@ func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume, p
 
 		return nil
 	}
-
-	updated := volume.DeepCopy()
-	apiMeta.RemoveStatusCondition(&updated.Status.Conditions, string(unikornv1core.ConditionActive))
 
 	observation, err := provider.ObserveVolume(ctx, identity, volume)
 
@@ -212,19 +230,7 @@ func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume, p
 		setObservedStatus(updated, observation)
 	}
 
-	if err := c.client.Status().Patch(ctx, updated, client.MergeFromWithOptions(volume, &client.MergeFromWithOptimisticLock{})); err != nil {
-		if isFatal(err) {
-			return err
-		}
-
-		volumeLogger(ctx, volume).Error(err, "failed to update volume status, skipping")
-
-		return nil
-	}
-
-	logTransitions(ctx, volume, updated)
-
-	return nil
+	return c.patchStatus(ctx, volume, updated)
 }
 
 // Check observes every non-deleting Volume in the configured namespace.

--- a/pkg/monitor/health/volume/check.go
+++ b/pkg/monitor/health/volume/check.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	"github.com/unikorn-cloud/region/pkg/providers"
+	providertypes "github.com/unikorn-cloud/region/pkg/providers/types"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Checker projects provider-observed Volume state into Region status.
+type Checker struct {
+	client    client.Client
+	namespace string
+	providers providers.Providers
+}
+
+// New creates a Volume health checker.
+func New(client client.Client, namespace string, providers providers.Providers) *Checker {
+	return &Checker{client: client, namespace: namespace, providers: providers}
+}
+
+func volumeLogger(ctx context.Context, volume *unikornv1.Volume) logr.Logger {
+	return log.FromContext(ctx).WithValues(
+		"volume_id", volume.Name,
+		"org_id", volume.Labels[coreconstants.OrganizationLabel],
+		"region_id", volume.Labels[constants.RegionLabel],
+	)
+}
+
+func volumePhase(status providertypes.VolumeStatus) unikornv1.VolumePhaseReason {
+	switch status {
+	case providertypes.VolumeStatusCreating:
+		return unikornv1.VolumePhaseReasonCreating
+	case providertypes.VolumeStatusAvailable:
+		return unikornv1.VolumePhaseReasonAvailable
+	case providertypes.VolumeStatusAttaching:
+		return unikornv1.VolumePhaseReasonAttaching
+	case providertypes.VolumeStatusAttached:
+		return unikornv1.VolumePhaseReasonAttached
+	case providertypes.VolumeStatusDetaching:
+		return unikornv1.VolumePhaseReasonDetaching
+	case providertypes.VolumeStatusUpdating:
+		return unikornv1.VolumePhaseReasonUpdating
+	case providertypes.VolumeStatusDeleting:
+		return unikornv1.VolumePhaseReasonDeleting
+	case providertypes.VolumeStatusError:
+		return unikornv1.VolumePhaseReasonError
+	case providertypes.VolumeStatusUnknown:
+		return unikornv1.VolumePhaseReasonUnknown
+	}
+
+	return unikornv1.VolumePhaseReasonUnknown
+}
+
+func setObservedStatus(volume *unikornv1.Volume, observation *providertypes.VolumeObservation) {
+	size := observation.Size.DeepCopy()
+	volume.Status.Size = &size
+	phase := volumePhase(observation.Status)
+	volume.SetVolumePhase(phase)
+
+	switch phase {
+	case unikornv1.VolumePhaseReasonError:
+		volume.SetHealthCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider reported the volume in an error state")
+	case unikornv1.VolumePhaseReasonUnknown:
+		volume.SetHealthCondition(corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "the provider volume state is unknown")
+	case unikornv1.VolumePhaseReasonMissing:
+		volume.SetHealthCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider volume is missing")
+	case unikornv1.VolumePhaseReasonCreating,
+		unikornv1.VolumePhaseReasonAvailable,
+		unikornv1.VolumePhaseReasonAttaching,
+		unikornv1.VolumePhaseReasonAttached,
+		unikornv1.VolumePhaseReasonDetaching,
+		unikornv1.VolumePhaseReasonUpdating,
+		unikornv1.VolumePhaseReasonDeleting:
+		volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy")
+	}
+}
+
+func setMissingStatus(volume *unikornv1.Volume) {
+	volume.Status.Size = nil
+	volume.SetVolumePhase(unikornv1.VolumePhaseReasonMissing)
+	volume.SetHealthCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider volume is missing")
+}
+
+func logTransitions(ctx context.Context, before, after *unikornv1.Volume) {
+	logger := volumeLogger(ctx, after)
+
+	oldPhase, oldErr := unikornv1.GetVolumePhase(before)
+	newPhase, newErr := unikornv1.GetVolumePhase(after)
+
+	if newErr == nil && (oldErr != nil || oldPhase.Reason != newPhase.Reason) {
+		from := ""
+
+		if oldErr == nil {
+			from = string(oldPhase.Reason)
+		}
+
+		logger.Info("volume phase transition", "from_phase", from, "to_phase", newPhase.Reason)
+	}
+
+	oldHealth, oldErr := unikornv1core.GetHealthyCondition(before)
+	newHealth, newErr := unikornv1core.GetHealthyCondition(after)
+
+	if newErr == nil && (oldErr != nil || oldHealth.Status != newHealth.Status || oldHealth.Reason != newHealth.Reason) {
+		from := ""
+
+		if oldErr == nil {
+			from = string(oldHealth.Reason)
+		}
+
+		logger.Info("volume health transition", "from_health", from, "to_health", newHealth.Reason)
+	}
+}
+
+func isFatal(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+//nolint:cyclop // The branches keep independent provider failures isolated to the affected Volume.
+func (c *Checker) processVolume(ctx context.Context, volume *unikornv1.Volume) error {
+	if volume.DeletionTimestamp != nil {
+		return nil
+	}
+
+	regionID, ok := volume.Labels[constants.RegionLabel]
+	if !ok {
+		volumeLogger(ctx, volume).Info("volume missing region label, skipping")
+		return nil
+	}
+
+	identityID, ok := volume.Labels[constants.IdentityLabel]
+	if !ok {
+		volumeLogger(ctx, volume).Info("volume missing identity label, skipping")
+		return nil
+	}
+
+	provider, err := c.providers.LookupCloud(regionID)
+	if err != nil {
+		if isFatal(err) {
+			return err
+		}
+
+		volumeLogger(ctx, volume).Error(err, "failed to resolve volume provider, skipping")
+
+		return nil
+	}
+
+	identity := &unikornv1.Identity{}
+	if err := c.client.Get(ctx, client.ObjectKey{Namespace: c.namespace, Name: identityID}, identity); err != nil {
+		if isFatal(err) {
+			return err
+		}
+
+		volumeLogger(ctx, volume).Error(err, "failed to resolve volume identity, skipping")
+
+		return nil
+	}
+
+	updated := volume.DeepCopy()
+	observation, err := provider.ObserveVolume(ctx, identity, volume)
+
+	switch {
+	case isFatal(err):
+		return err
+	case errors.Is(err, coreerrors.ErrResourceNotFound):
+		setMissingStatus(updated)
+	case err != nil:
+		volumeLogger(ctx, volume).Error(err, "failed to observe volume, skipping")
+
+		return nil
+	case observation == nil:
+		volumeLogger(ctx, volume).Error(fmt.Errorf("%w: nil volume observation", coreerrors.ErrConsistency), "failed to observe volume, skipping")
+
+		return nil
+	default:
+		setObservedStatus(updated, observation)
+	}
+
+	if err := c.client.Status().Patch(ctx, updated, client.MergeFromWithOptions(volume, &client.MergeFromWithOptimisticLock{})); err != nil {
+		if isFatal(err) {
+			return err
+		}
+
+		volumeLogger(ctx, volume).Error(err, "failed to update volume status, skipping")
+
+		return nil
+	}
+
+	logTransitions(ctx, volume, updated)
+
+	return nil
+}
+
+// Check observes every non-deleting Volume in the configured namespace.
+func (c *Checker) Check(ctx context.Context) error {
+	volumes := &unikornv1.VolumeList{}
+	if err := c.client.List(ctx, volumes, &client.ListOptions{Namespace: c.namespace}); err != nil {
+		return err
+	}
+
+	for i := range volumes.Items {
+		if err := c.processVolume(ctx, &volumes.Items[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/monitor/health/volume/check_test.go
+++ b/pkg/monitor/health/volume/check_test.go
@@ -330,16 +330,35 @@ func TestCheckCachesFailedProviderLookupByRegion(t *testing.T) {
 	first := volumeFixture()
 	second := volumeFixture()
 	second.Name = testVolumeID2
+	size := resource.MustParse("10Gi")
+	for _, volume := range []*unikornv1.Volume{first, second} {
+		volume.Status.Size = &size
+		volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy")
+	}
+
 	k8sClient := fakeClient(t, first, second)
 	sink := newCaptureSink()
 	ctx := logr.NewContext(t.Context(), logr.New(sink))
 
 	require.NoError(t, volumehealth.New(k8sClient, testNamespace, providerSet).Check(ctx))
 
-	entry := sink.entry("failed to resolve volume provider, skipping")
+	entry := sink.entry("failed to resolve volume provider")
 	require.Equal(t, testRegionID, entry["region_id"])
 
 	loggedErr, ok := entry["error"].(error)
 	require.True(t, ok)
 	require.ErrorIs(t, loggedErr, errProviderLookup)
+
+	for _, volume := range []*unikornv1.Volume{first, second} {
+		updated := &unikornv1.Volume{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(volume), updated))
+		require.NotNil(t, updated.Status.Size)
+		require.True(t, updated.Status.Size.Equal(size))
+
+		health, err := unikornv1core.GetHealthyCondition(updated)
+		require.NoError(t, err)
+		require.Equal(t, corev1.ConditionUnknown, health.Status)
+		require.Equal(t, unikornv1core.ConditionReasonUnknown, health.Reason)
+		require.Equal(t, "unable to observe provider volume state", health.Message)
+	}
 }

--- a/pkg/monitor/health/volume/check_test.go
+++ b/pkg/monitor/health/volume/check_test.go
@@ -121,6 +121,7 @@ func volumeFixture() *unikornv1.Volume {
 		},
 	}
 	volume.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "")
+	unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionActive, corev1.ConditionTrue, "Available", "legacy condition")
 
 	return volume
 }
@@ -163,20 +164,20 @@ func TestCheckProjectsEveryNeutralVolumeStatus(t *testing.T) {
 	t.Parallel()
 
 	tests := map[providertypes.VolumeStatus]struct {
-		phase        unikornv1.VolumePhaseReason
-		activeStatus corev1.ConditionStatus
-		healthStatus corev1.ConditionStatus
-		healthReason unikornv1core.HealthConditionReason
+		healthStatus  corev1.ConditionStatus
+		healthReason  unikornv1core.HealthConditionReason
+		healthMessage string
 	}{
-		providertypes.VolumeStatusCreating:  {unikornv1.VolumePhaseReasonCreating, corev1.ConditionFalse, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
-		providertypes.VolumeStatusAvailable: {unikornv1.VolumePhaseReasonAvailable, corev1.ConditionTrue, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
-		providertypes.VolumeStatusAttaching: {unikornv1.VolumePhaseReasonAttaching, corev1.ConditionFalse, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
-		providertypes.VolumeStatusAttached:  {unikornv1.VolumePhaseReasonAttached, corev1.ConditionTrue, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
-		providertypes.VolumeStatusDetaching: {unikornv1.VolumePhaseReasonDetaching, corev1.ConditionFalse, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
-		providertypes.VolumeStatusUpdating:  {unikornv1.VolumePhaseReasonUpdating, corev1.ConditionFalse, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
-		providertypes.VolumeStatusDeleting:  {unikornv1.VolumePhaseReasonDeleting, corev1.ConditionFalse, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
-		providertypes.VolumeStatusError:     {unikornv1.VolumePhaseReasonError, corev1.ConditionFalse, corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded},
-		providertypes.VolumeStatusUnknown:   {unikornv1.VolumePhaseReasonUnknown, corev1.ConditionFalse, corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown},
+		providertypes.VolumeStatusCreating:  {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		providertypes.VolumeStatusAvailable: {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		providertypes.VolumeStatusAttaching: {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		providertypes.VolumeStatusAttached:  {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		providertypes.VolumeStatusDetaching: {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		providertypes.VolumeStatusUpdating:  {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
+		providertypes.VolumeStatusDeleting:  {corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider volume is being deleted"},
+		providertypes.VolumeStatusError:     {corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider reported the volume in an error state"},
+		providertypes.VolumeStatusUnknown:   {corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "the provider volume state is unknown"},
+		providertypes.VolumeStatus("new"):   {corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "the provider volume state is unknown"},
 	}
 
 	for status, want := range tests {
@@ -187,19 +188,17 @@ func TestCheckProjectsEveryNeutralVolumeStatus(t *testing.T) {
 			require.NotNil(t, updated.Status.Size)
 			require.True(t, updated.Status.Size.Equal(resource.MustParse("20Gi")))
 
-			phase, err := unikornv1.GetVolumePhase(updated)
-			require.NoError(t, err)
-			require.Equal(t, want.phase, phase.Reason)
-			require.Equal(t, want.activeStatus, phase.Status)
-
 			health, err := unikornv1core.GetHealthyCondition(updated)
 			require.NoError(t, err)
 			require.Equal(t, want.healthStatus, health.Status)
 			require.Equal(t, want.healthReason, health.Reason)
+			require.Equal(t, want.healthMessage, health.Message)
 
 			available, err := unikornv1core.GetAvailableCondition(updated)
 			require.NoError(t, err)
+			require.Equal(t, corev1.ConditionTrue, available.Status)
 			require.Equal(t, unikornv1core.ConditionReasonProvisioned, available.Reason)
+			require.Len(t, updated.Status.Conditions, 2)
 		})
 	}
 }
@@ -210,59 +209,57 @@ func TestCheckProjectsMissingProviderVolumeAndLogsTransition(t *testing.T) {
 	volume := volumeFixture()
 	size := resource.MustParse("10Gi")
 	volume.Status.Size = &size
-	volume.SetVolumePhase(unikornv1.VolumePhaseReasonAvailable)
-	volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "")
+	volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy")
 
 	updated, sink := runCheck(t, volume, nil, coreerrors.ErrResourceNotFound)
 	require.Nil(t, updated.Status.Size)
-
-	phase, err := unikornv1.GetVolumePhase(updated)
-	require.NoError(t, err)
-	require.Equal(t, unikornv1.VolumePhaseReasonMissing, phase.Reason)
 
 	health, err := unikornv1core.GetHealthyCondition(updated)
 	require.NoError(t, err)
 	require.Equal(t, corev1.ConditionFalse, health.Status)
 	require.Equal(t, unikornv1core.ConditionReasonDegraded, health.Reason)
+	require.Equal(t, "the provider volume is missing", health.Message)
 
 	available, err := unikornv1core.GetAvailableCondition(updated)
 	require.NoError(t, err)
+	require.Equal(t, corev1.ConditionTrue, available.Status)
 	require.Equal(t, unikornv1core.ConditionReasonProvisioned, available.Reason)
+	require.Len(t, updated.Status.Conditions, 2)
 
-	entry := sink.entry("volume phase transition")
+	entry := sink.entry("volume health transition")
 	require.Equal(t, testVolumeID, entry["volume_id"])
 	require.Equal(t, testOrganizationID, entry["org_id"])
 	require.Equal(t, testRegionID, entry["region_id"])
-	require.Equal(t, string(unikornv1.VolumePhaseReasonAvailable), entry["from_phase"])
-	require.Equal(t, unikornv1.VolumePhaseReasonMissing, entry["to_phase"])
+	require.Equal(t, unikornv1core.ConditionReasonHealthy, entry["from_health"])
+	require.Equal(t, "the provider volume state is healthy", entry["from_message"])
+	require.Equal(t, unikornv1core.ConditionReasonDegraded, entry["to_health"])
+	require.Equal(t, "the provider volume is missing", entry["to_message"])
 }
 
-func TestCheckPreservesLastObservationOnProviderErrorAndLogs(t *testing.T) {
+func TestCheckMakesHealthUnknownOnProviderErrorAndLogs(t *testing.T) {
 	t.Parallel()
 
 	volume := volumeFixture()
 	size := resource.MustParse("10Gi")
 	volume.Status.Size = &size
-	volume.SetVolumePhase(unikornv1.VolumePhaseReasonAttached)
-	volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "")
+	volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy")
 	updated, sink := runCheck(t, volume, nil, errProviderObservation)
 	require.NotNil(t, updated.Status.Size)
 	require.True(t, updated.Status.Size.Equal(size))
 
-	phase, err := unikornv1.GetVolumePhase(updated)
-	require.NoError(t, err)
-	require.Equal(t, unikornv1.VolumePhaseReasonAttached, phase.Reason)
-
 	health, err := unikornv1core.GetHealthyCondition(updated)
 	require.NoError(t, err)
-	require.Equal(t, corev1.ConditionTrue, health.Status)
-	require.Equal(t, unikornv1core.ConditionReasonHealthy, health.Reason)
+	require.Equal(t, corev1.ConditionUnknown, health.Status)
+	require.Equal(t, unikornv1core.ConditionReasonUnknown, health.Reason)
+	require.Equal(t, "unable to observe provider volume state", health.Message)
 
 	available, err := unikornv1core.GetAvailableCondition(updated)
 	require.NoError(t, err)
+	require.Equal(t, corev1.ConditionTrue, available.Status)
 	require.Equal(t, unikornv1core.ConditionReasonProvisioned, available.Reason)
+	require.Len(t, updated.Status.Conditions, 2)
 
-	entry := sink.entry("failed to observe volume, skipping")
+	entry := sink.entry("failed to observe volume")
 	require.Equal(t, testVolumeID, entry["volume_id"])
 	require.Equal(t, testOrganizationID, entry["org_id"])
 	require.Equal(t, testRegionID, entry["region_id"])
@@ -270,4 +267,9 @@ func TestCheckPreservesLastObservationOnProviderErrorAndLogs(t *testing.T) {
 	loggedErr, ok := entry["error"].(error)
 	require.True(t, ok)
 	require.ErrorIs(t, loggedErr, errProviderObservation)
+
+	transition := sink.entry("volume health transition")
+	require.Equal(t, unikornv1core.ConditionReasonHealthy, transition["from_health"])
+	require.Equal(t, unikornv1core.ConditionReasonUnknown, transition["to_health"])
+	require.Equal(t, "unable to observe provider volume state", transition["to_message"])
 }

--- a/pkg/monitor/health/volume/check_test.go
+++ b/pkg/monitor/health/volume/check_test.go
@@ -331,6 +331,7 @@ func TestCheckCachesFailedProviderLookupByRegion(t *testing.T) {
 	second := volumeFixture()
 	second.Name = testVolumeID2
 	size := resource.MustParse("10Gi")
+
 	for _, volume := range []*unikornv1.Volume{first, second} {
 		volume.Status.Size = &size
 		volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy")

--- a/pkg/monitor/health/volume/check_test.go
+++ b/pkg/monitor/health/volume/check_test.go
@@ -49,10 +49,14 @@ const (
 	testRegionID       = "region-1"
 	testIdentityID     = "identity-1"
 	testVolumeID       = "11111111-1111-4111-8111-111111111111"
+	testVolumeID2      = "22222222-2222-4222-8222-222222222222"
 	testOrganizationID = "00000000-0000-4000-8000-000000000001"
 )
 
-var errProviderObservation = errors.New("provider observation failed")
+var (
+	errProviderLookup      = errors.New("provider lookup failed")
+	errProviderObservation = errors.New("provider observation failed")
+)
 
 type captureSink struct {
 	entries   *[]map[string]any
@@ -236,6 +240,27 @@ func TestCheckProjectsMissingProviderVolumeAndLogsTransition(t *testing.T) {
 	require.Equal(t, "the provider volume is missing", entry["to_message"])
 }
 
+func TestCheckDoesNotDegradeMissingVolumeBeforeProvisioningCompletes(t *testing.T) {
+	t.Parallel()
+
+	volume := volumeFixture()
+	volume.SetProvisioningCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonProvisioning, "provisioning")
+
+	updated, sink := runCheck(t, volume, nil, coreerrors.ErrResourceNotFound)
+	require.Nil(t, updated.Status.Size)
+
+	_, err := unikornv1core.GetHealthyCondition(updated)
+	require.Error(t, err)
+
+	available, err := unikornv1core.GetAvailableCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, corev1.ConditionFalse, available.Status)
+	require.Equal(t, unikornv1core.ConditionReasonProvisioning, available.Reason)
+	require.Len(t, updated.Status.Conditions, 1)
+	require.NotNil(t, sink.entry("provider volume not found before provisioning completed"))
+	require.Nil(t, sink.entry("volume health transition"))
+}
+
 func TestCheckMakesHealthUnknownOnProviderErrorAndLogs(t *testing.T) {
 	t.Parallel()
 
@@ -272,4 +297,49 @@ func TestCheckMakesHealthUnknownOnProviderErrorAndLogs(t *testing.T) {
 	require.Equal(t, unikornv1core.ConditionReasonHealthy, transition["from_health"])
 	require.Equal(t, unikornv1core.ConditionReasonUnknown, transition["to_health"])
 	require.Equal(t, "unable to observe provider volume state", transition["to_message"])
+}
+
+func TestCheckCachesSuccessfulProviderLookupByRegion(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	provider := mocktypes.NewMockProvider(ctrl)
+	provider.EXPECT().ObserveVolume(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&providertypes.VolumeObservation{Size: resource.MustParse("20Gi"), Status: providertypes.VolumeStatusAvailable}, nil).
+		Times(2)
+
+	providerSet := mockproviders.NewMockProviders(ctrl)
+	providerSet.EXPECT().LookupCloud(testRegionID).Return(provider, nil)
+
+	identity := &unikornv1.Identity{ObjectMeta: metav1.ObjectMeta{Name: testIdentityID, Namespace: testNamespace}}
+	first := volumeFixture()
+	second := volumeFixture()
+	second.Name = testVolumeID2
+	k8sClient := fakeClient(t, identity, first, second)
+
+	require.NoError(t, volumehealth.New(k8sClient, testNamespace, providerSet).Check(t.Context()))
+}
+
+func TestCheckCachesFailedProviderLookupByRegion(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	providerSet := mockproviders.NewMockProviders(ctrl)
+	providerSet.EXPECT().LookupCloud(testRegionID).Return(nil, errProviderLookup)
+
+	first := volumeFixture()
+	second := volumeFixture()
+	second.Name = testVolumeID2
+	k8sClient := fakeClient(t, first, second)
+	sink := newCaptureSink()
+	ctx := logr.NewContext(t.Context(), logr.New(sink))
+
+	require.NoError(t, volumehealth.New(k8sClient, testNamespace, providerSet).Check(ctx))
+
+	entry := sink.entry("failed to resolve volume provider, skipping")
+	require.Equal(t, testRegionID, entry["region_id"])
+
+	loggedErr, ok := entry["error"].(error)
+	require.True(t, ok)
+	require.ErrorIs(t, loggedErr, errProviderLookup)
 }

--- a/pkg/monitor/health/volume/check_test.go
+++ b/pkg/monitor/health/volume/check_test.go
@@ -18,21 +18,17 @@ package volume_test
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
-	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/constants"
 	volumehealth "github.com/unikorn-cloud/region/pkg/monitor/health/volume"
 	mockproviders "github.com/unikorn-cloud/region/pkg/providers/mock"
-	providertypes "github.com/unikorn-cloud/region/pkg/providers/types"
 	mocktypes "github.com/unikorn-cloud/region/pkg/providers/types/mock"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,317 +45,101 @@ const (
 	testRegionID       = "region-1"
 	testIdentityID     = "identity-1"
 	testVolumeID       = "11111111-1111-4111-8111-111111111111"
-	testVolumeID2      = "22222222-2222-4222-8222-222222222222"
 	testOrganizationID = "00000000-0000-4000-8000-000000000001"
 )
 
 var (
-	errProviderLookup      = errors.New("provider lookup failed")
-	errProviderObservation = errors.New("provider observation failed")
+	errProviderLookup = errors.New("provider lookup failed")
+	errProviderState  = errors.New("provider state failed")
 )
 
-type captureSink struct {
-	entries   *[]map[string]any
-	presetKVs []any
-}
-
-func newCaptureSink() *captureSink {
-	entries := make([]map[string]any, 0)
-
-	return &captureSink{entries: &entries}
-}
-
-func (s *captureSink) Init(logr.RuntimeInfo)        {}
-func (s *captureSink) Enabled(int) bool             { return true }
-func (s *captureSink) WithName(string) logr.LogSink { return s }
-
-func (s *captureSink) WithValues(kvs ...any) logr.LogSink {
-	result := *s
-	result.presetKVs = append(append([]any{}, s.presetKVs...), kvs...)
-
-	return &result
-}
-
-func (s *captureSink) record(msg string, kvs ...any) {
-	entry := map[string]any{"_msg": msg}
-
-	for i := 0; i+1 < len(s.presetKVs); i += 2 {
-		entry[fmt.Sprint(s.presetKVs[i])] = s.presetKVs[i+1]
-	}
-
-	for i := 0; i+1 < len(kvs); i += 2 {
-		entry[fmt.Sprint(kvs[i])] = kvs[i+1]
-	}
-
-	*s.entries = append(*s.entries, entry)
-}
-
-func (s *captureSink) Info(_ int, msg string, kvs ...any) {
-	s.record(msg, kvs...)
-}
-
-func (s *captureSink) Error(err error, msg string, kvs ...any) {
-	s.record(msg, append(kvs, "error", err)...)
-}
-
-func (s *captureSink) entry(msg string) map[string]any {
-	for _, entry := range *s.entries {
-		if entry["_msg"] == msg {
-			return entry
-		}
-	}
-
-	return nil
-}
-
 func volumeFixture() *unikornv1.Volume {
-	volume := &unikornv1.Volume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testVolumeID,
-			Namespace: testNamespace,
-			Labels: map[string]string{
-				coreconstants.OrganizationLabel: testOrganizationID,
-				constants.RegionLabel:           testRegionID,
-				constants.IdentityLabel:         testIdentityID,
-			},
+	volume := &unikornv1.Volume{ObjectMeta: metav1.ObjectMeta{
+		Name: testVolumeID, Namespace: testNamespace,
+		Labels: map[string]string{
+			coreconstants.OrganizationLabel: testOrganizationID,
+			constants.RegionLabel:           testRegionID,
+			constants.IdentityLabel:         testIdentityID,
 		},
-	}
+	}}
 	volume.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "")
-	unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionActive, corev1.ConditionTrue, "Available", "legacy condition")
-
+	unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionActive, corev1.ConditionTrue, "legacy", "legacy condition")
 	return volume
 }
 
 func fakeClient(t *testing.T, objects ...client.Object) client.Client {
 	t.Helper()
-
 	scheme := runtime.NewScheme()
 	require.NoError(t, unikornv1.AddToScheme(scheme))
-
-	return fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithStatusSubresource(&unikornv1.Volume{}).
-		WithObjects(objects...).
-		Build()
+	return fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&unikornv1.Volume{}).WithObjects(objects...).Build()
 }
 
-func runCheck(t *testing.T, volume *unikornv1.Volume, observation *providertypes.VolumeObservation, observationErr error) (*unikornv1.Volume, *captureSink) {
+func runCheck(t *testing.T, volume *unikornv1.Volume, lookupErr, updateErr error, mutate func(*unikornv1.Volume)) *unikornv1.Volume {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	provider := mocktypes.NewMockProvider(ctrl)
-	provider.EXPECT().ObserveVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(observation, observationErr)
-
-	providerSet := mockproviders.NewMockProviders(ctrl)
-	providerSet.EXPECT().LookupCloud(testRegionID).Return(provider, nil)
-
-	identity := &unikornv1.Identity{ObjectMeta: metav1.ObjectMeta{Name: testIdentityID, Namespace: testNamespace}}
-	k8sClient := fakeClient(t, identity, volume)
-	sink := newCaptureSink()
-	ctx := logr.NewContext(t.Context(), logr.New(sink))
-	require.NoError(t, volumehealth.New(k8sClient, testNamespace, providerSet).Check(ctx))
-
-	updated := &unikornv1.Volume{}
-	require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(volume), updated))
-
-	return updated, sink
-}
-
-func TestCheckProjectsEveryNeutralVolumeStatus(t *testing.T) {
-	t.Parallel()
-
-	tests := map[providertypes.VolumeStatus]struct {
-		healthStatus  corev1.ConditionStatus
-		healthReason  unikornv1core.HealthConditionReason
-		healthMessage string
-	}{
-		providertypes.VolumeStatusCreating:  {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
-		providertypes.VolumeStatusAvailable: {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
-		providertypes.VolumeStatusAttaching: {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
-		providertypes.VolumeStatusAttached:  {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
-		providertypes.VolumeStatusDetaching: {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
-		providertypes.VolumeStatusUpdating:  {corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy"},
-		providertypes.VolumeStatusDeleting:  {corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider volume is being deleted"},
-		providertypes.VolumeStatusError:     {corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded, "the provider reported the volume in an error state"},
-		providertypes.VolumeStatusUnknown:   {corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "the provider volume state is unknown"},
-		providertypes.VolumeStatus("new"):   {corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown, "the provider volume state is unknown"},
-	}
-
-	for status, want := range tests {
-		t.Run(string(status), func(t *testing.T) {
-			t.Parallel()
-			updated, _ := runCheck(t, volumeFixture(), &providertypes.VolumeObservation{Size: resource.MustParse("20Gi"), Status: status}, nil)
-
-			require.NotNil(t, updated.Status.Size)
-			require.True(t, updated.Status.Size.Equal(resource.MustParse("20Gi")))
-
-			health, err := unikornv1core.GetHealthyCondition(updated)
-			require.NoError(t, err)
-			require.Equal(t, want.healthStatus, health.Status)
-			require.Equal(t, want.healthReason, health.Reason)
-			require.Equal(t, want.healthMessage, health.Message)
-
-			available, err := unikornv1core.GetAvailableCondition(updated)
-			require.NoError(t, err)
-			require.Equal(t, corev1.ConditionTrue, available.Status)
-			require.Equal(t, unikornv1core.ConditionReasonProvisioned, available.Reason)
-			require.Len(t, updated.Status.Conditions, 2)
+	providers := mockproviders.NewMockProviders(ctrl)
+	if lookupErr != nil {
+		providers.EXPECT().LookupCloud(testRegionID).Return(nil, lookupErr)
+	} else {
+		providers.EXPECT().LookupCloud(testRegionID).Return(provider, nil)
+		provider.EXPECT().UpdateVolumeState(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ any, _ any, got *unikornv1.Volume) error {
+			if mutate != nil {
+				mutate(got)
+			}
+			return updateErr
 		})
 	}
-}
-
-func TestCheckProjectsMissingProviderVolumeAndLogsTransition(t *testing.T) {
-	t.Parallel()
-
-	volume := volumeFixture()
-	size := resource.MustParse("10Gi")
-	volume.Status.Size = &size
-	volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy")
-
-	updated, sink := runCheck(t, volume, nil, coreerrors.ErrResourceNotFound)
-	require.Nil(t, updated.Status.Size)
-
-	health, err := unikornv1core.GetHealthyCondition(updated)
-	require.NoError(t, err)
-	require.Equal(t, corev1.ConditionFalse, health.Status)
-	require.Equal(t, unikornv1core.ConditionReasonDegraded, health.Reason)
-	require.Equal(t, "the provider volume is missing", health.Message)
-
-	available, err := unikornv1core.GetAvailableCondition(updated)
-	require.NoError(t, err)
-	require.Equal(t, corev1.ConditionTrue, available.Status)
-	require.Equal(t, unikornv1core.ConditionReasonProvisioned, available.Reason)
-	require.Len(t, updated.Status.Conditions, 2)
-
-	entry := sink.entry("volume health transition")
-	require.Equal(t, testVolumeID, entry["volume_id"])
-	require.Equal(t, testOrganizationID, entry["org_id"])
-	require.Equal(t, testRegionID, entry["region_id"])
-	require.Equal(t, unikornv1core.ConditionReasonHealthy, entry["from_health"])
-	require.Equal(t, "the provider volume state is healthy", entry["from_message"])
-	require.Equal(t, unikornv1core.ConditionReasonDegraded, entry["to_health"])
-	require.Equal(t, "the provider volume is missing", entry["to_message"])
-}
-
-func TestCheckDoesNotDegradeMissingVolumeBeforeProvisioningCompletes(t *testing.T) {
-	t.Parallel()
-
-	volume := volumeFixture()
-	volume.SetProvisioningCondition(corev1.ConditionFalse, unikornv1core.ConditionReasonProvisioning, "provisioning")
-
-	updated, sink := runCheck(t, volume, nil, coreerrors.ErrResourceNotFound)
-	require.Nil(t, updated.Status.Size)
-
-	_, err := unikornv1core.GetHealthyCondition(updated)
-	require.Error(t, err)
-
-	available, err := unikornv1core.GetAvailableCondition(updated)
-	require.NoError(t, err)
-	require.Equal(t, corev1.ConditionFalse, available.Status)
-	require.Equal(t, unikornv1core.ConditionReasonProvisioning, available.Reason)
-	require.Len(t, updated.Status.Conditions, 1)
-	require.NotNil(t, sink.entry("provider volume not found before provisioning completed"))
-	require.Nil(t, sink.entry("volume health transition"))
-}
-
-func TestCheckMakesHealthUnknownOnProviderErrorAndLogs(t *testing.T) {
-	t.Parallel()
-
-	volume := volumeFixture()
-	size := resource.MustParse("10Gi")
-	volume.Status.Size = &size
-	volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy")
-	updated, sink := runCheck(t, volume, nil, errProviderObservation)
-	require.NotNil(t, updated.Status.Size)
-	require.True(t, updated.Status.Size.Equal(size))
-
-	health, err := unikornv1core.GetHealthyCondition(updated)
-	require.NoError(t, err)
-	require.Equal(t, corev1.ConditionUnknown, health.Status)
-	require.Equal(t, unikornv1core.ConditionReasonUnknown, health.Reason)
-	require.Equal(t, "unable to observe provider volume state", health.Message)
-
-	available, err := unikornv1core.GetAvailableCondition(updated)
-	require.NoError(t, err)
-	require.Equal(t, corev1.ConditionTrue, available.Status)
-	require.Equal(t, unikornv1core.ConditionReasonProvisioned, available.Reason)
-	require.Len(t, updated.Status.Conditions, 2)
-
-	entry := sink.entry("failed to observe volume")
-	require.Equal(t, testVolumeID, entry["volume_id"])
-	require.Equal(t, testOrganizationID, entry["org_id"])
-	require.Equal(t, testRegionID, entry["region_id"])
-
-	loggedErr, ok := entry["error"].(error)
-	require.True(t, ok)
-	require.ErrorIs(t, loggedErr, errProviderObservation)
-
-	transition := sink.entry("volume health transition")
-	require.Equal(t, unikornv1core.ConditionReasonHealthy, transition["from_health"])
-	require.Equal(t, unikornv1core.ConditionReasonUnknown, transition["to_health"])
-	require.Equal(t, "unable to observe provider volume state", transition["to_message"])
-}
-
-func TestCheckCachesSuccessfulProviderLookupByRegion(t *testing.T) {
-	t.Parallel()
-
-	ctrl := gomock.NewController(t)
-	provider := mocktypes.NewMockProvider(ctrl)
-	provider.EXPECT().ObserveVolume(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&providertypes.VolumeObservation{Size: resource.MustParse("20Gi"), Status: providertypes.VolumeStatusAvailable}, nil).
-		Times(2)
-
-	providerSet := mockproviders.NewMockProviders(ctrl)
-	providerSet.EXPECT().LookupCloud(testRegionID).Return(provider, nil)
-
 	identity := &unikornv1.Identity{ObjectMeta: metav1.ObjectMeta{Name: testIdentityID, Namespace: testNamespace}}
-	first := volumeFixture()
-	second := volumeFixture()
-	second.Name = testVolumeID2
-	k8sClient := fakeClient(t, identity, first, second)
-
-	require.NoError(t, volumehealth.New(k8sClient, testNamespace, providerSet).Check(t.Context()))
+	k8sClient := fakeClient(t, identity, volume)
+	require.NoError(t, volumehealth.New(k8sClient, testNamespace, providers).Check(t.Context()))
+	updated := &unikornv1.Volume{}
+	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(volume), updated))
+	return updated
 }
 
-func TestCheckCachesFailedProviderLookupByRegion(t *testing.T) {
-	t.Parallel()
+func TestCheckPersistsProviderProjection(t *testing.T) {
+	updated := runCheck(t, volumeFixture(), nil, nil, func(volume *unikornv1.Volume) {
+		volume.Status.Size = resource.MustParsePtr("20Gi")
+		unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionTrue, string(unikornv1core.ConditionReasonHealthy), "provider healthy")
+	})
+	require.NotNil(t, updated.Status.Size)
+	require.True(t, updated.Status.Size.Equal(resource.MustParse("20Gi")))
+	health, err := unikornv1core.GetHealthyCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, "provider healthy", health.Message)
+	_, err = unikornv1core.GetCondition(updated.Status.Conditions, unikornv1core.ConditionActive)
+	require.Error(t, err)
+}
 
-	ctrl := gomock.NewController(t)
-	providerSet := mockproviders.NewMockProviders(ctrl)
-	providerSet.EXPECT().LookupCloud(testRegionID).Return(nil, errProviderLookup)
-
-	first := volumeFixture()
-	second := volumeFixture()
-	second.Name = testVolumeID2
+func TestCheckPreservesStateWhenProviderUnavailable(t *testing.T) {
+	volume := volumeFixture()
 	size := resource.MustParse("10Gi")
+	volume.Status.Size = &size
+	unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionTrue, string(unikornv1core.ConditionReasonHealthy), "last state")
+	updated := runCheck(t, volume, errProviderLookup, nil, nil)
+	require.True(t, updated.Status.Size.Equal(resource.MustParse("10Gi")))
+	health, err := unikornv1core.GetHealthyCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, "last state", health.Message)
+}
 
-	for _, volume := range []*unikornv1.Volume{first, second} {
-		volume.Status.Size = &size
-		volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "the provider volume state is healthy")
-	}
+func TestCheckPreservesStateWhenProviderObservationFails(t *testing.T) {
+	volume := volumeFixture()
+	unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionTrue, string(unikornv1core.ConditionReasonHealthy), "last state")
+	updated := runCheck(t, volume, nil, errProviderState, nil)
+	health, err := unikornv1core.GetHealthyCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, "last state", health.Message)
+}
 
-	k8sClient := fakeClient(t, first, second)
-	sink := newCaptureSink()
-	ctx := logr.NewContext(t.Context(), logr.New(sink))
-
-	require.NoError(t, volumehealth.New(k8sClient, testNamespace, providerSet).Check(ctx))
-
-	entry := sink.entry("failed to resolve volume provider")
-	require.Equal(t, testRegionID, entry["region_id"])
-
-	loggedErr, ok := entry["error"].(error)
-	require.True(t, ok)
-	require.ErrorIs(t, loggedErr, errProviderLookup)
-
-	for _, volume := range []*unikornv1.Volume{first, second} {
-		updated := &unikornv1.Volume{}
-		require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(volume), updated))
-		require.NotNil(t, updated.Status.Size)
-		require.True(t, updated.Status.Size.Equal(size))
-
-		health, err := unikornv1core.GetHealthyCondition(updated)
-		require.NoError(t, err)
-		require.Equal(t, corev1.ConditionUnknown, health.Status)
-		require.Equal(t, unikornv1core.ConditionReasonUnknown, health.Reason)
-		require.Equal(t, "unable to observe provider volume state", health.Message)
-	}
+func TestCheckPersistsProviderMissingProjection(t *testing.T) {
+	updated := runCheck(t, volumeFixture(), nil, nil, func(volume *unikornv1.Volume) {
+		volume.Status.Size = nil
+		unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionFalse, string(unikornv1core.ConditionReasonDegraded), "the provider volume is missing")
+	})
+	health, err := unikornv1core.GetHealthyCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, unikornv1core.ConditionReasonDegraded, health.Reason)
+	require.Nil(t, updated.Status.Size)
 }

--- a/pkg/monitor/health/volume/check_test.go
+++ b/pkg/monitor/health/volume/check_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	volumehealth "github.com/unikorn-cloud/region/pkg/monitor/health/volume"
+	mockproviders "github.com/unikorn-cloud/region/pkg/providers/mock"
+	providertypes "github.com/unikorn-cloud/region/pkg/providers/types"
+	mocktypes "github.com/unikorn-cloud/region/pkg/providers/types/mock"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testNamespace      = "test-ns"
+	testRegionID       = "region-1"
+	testIdentityID     = "identity-1"
+	testVolumeID       = "11111111-1111-4111-8111-111111111111"
+	testOrganizationID = "00000000-0000-4000-8000-000000000001"
+)
+
+var errProviderObservation = errors.New("provider observation failed")
+
+type captureSink struct {
+	entries   *[]map[string]any
+	presetKVs []any
+}
+
+func newCaptureSink() *captureSink {
+	entries := make([]map[string]any, 0)
+
+	return &captureSink{entries: &entries}
+}
+
+func (s *captureSink) Init(logr.RuntimeInfo)        {}
+func (s *captureSink) Enabled(int) bool             { return true }
+func (s *captureSink) WithName(string) logr.LogSink { return s }
+
+func (s *captureSink) WithValues(kvs ...any) logr.LogSink {
+	result := *s
+	result.presetKVs = append(append([]any{}, s.presetKVs...), kvs...)
+
+	return &result
+}
+
+func (s *captureSink) record(msg string, kvs ...any) {
+	entry := map[string]any{"_msg": msg}
+
+	for i := 0; i+1 < len(s.presetKVs); i += 2 {
+		entry[fmt.Sprint(s.presetKVs[i])] = s.presetKVs[i+1]
+	}
+
+	for i := 0; i+1 < len(kvs); i += 2 {
+		entry[fmt.Sprint(kvs[i])] = kvs[i+1]
+	}
+
+	*s.entries = append(*s.entries, entry)
+}
+
+func (s *captureSink) Info(_ int, msg string, kvs ...any) {
+	s.record(msg, kvs...)
+}
+
+func (s *captureSink) Error(err error, msg string, kvs ...any) {
+	s.record(msg, append(kvs, "error", err)...)
+}
+
+func (s *captureSink) entry(msg string) map[string]any {
+	for _, entry := range *s.entries {
+		if entry["_msg"] == msg {
+			return entry
+		}
+	}
+
+	return nil
+}
+
+func volumeFixture() *unikornv1.Volume {
+	volume := &unikornv1.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testVolumeID,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				coreconstants.OrganizationLabel: testOrganizationID,
+				constants.RegionLabel:           testRegionID,
+				constants.IdentityLabel:         testIdentityID,
+			},
+		},
+	}
+	volume.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "")
+
+	return volume
+}
+
+func fakeClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, unikornv1.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&unikornv1.Volume{}).
+		WithObjects(objects...).
+		Build()
+}
+
+func runCheck(t *testing.T, volume *unikornv1.Volume, observation *providertypes.VolumeObservation, observationErr error) (*unikornv1.Volume, *captureSink) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	provider := mocktypes.NewMockProvider(ctrl)
+	provider.EXPECT().ObserveVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(observation, observationErr)
+
+	providerSet := mockproviders.NewMockProviders(ctrl)
+	providerSet.EXPECT().LookupCloud(testRegionID).Return(provider, nil)
+
+	identity := &unikornv1.Identity{ObjectMeta: metav1.ObjectMeta{Name: testIdentityID, Namespace: testNamespace}}
+	k8sClient := fakeClient(t, identity, volume)
+	sink := newCaptureSink()
+	ctx := logr.NewContext(t.Context(), logr.New(sink))
+	require.NoError(t, volumehealth.New(k8sClient, testNamespace, providerSet).Check(ctx))
+
+	updated := &unikornv1.Volume{}
+	require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(volume), updated))
+
+	return updated, sink
+}
+
+func TestCheckProjectsEveryNeutralVolumeStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := map[providertypes.VolumeStatus]struct {
+		phase        unikornv1.VolumePhaseReason
+		activeStatus corev1.ConditionStatus
+		healthStatus corev1.ConditionStatus
+		healthReason unikornv1core.HealthConditionReason
+	}{
+		providertypes.VolumeStatusCreating:  {unikornv1.VolumePhaseReasonCreating, corev1.ConditionFalse, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
+		providertypes.VolumeStatusAvailable: {unikornv1.VolumePhaseReasonAvailable, corev1.ConditionTrue, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
+		providertypes.VolumeStatusAttaching: {unikornv1.VolumePhaseReasonAttaching, corev1.ConditionFalse, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
+		providertypes.VolumeStatusAttached:  {unikornv1.VolumePhaseReasonAttached, corev1.ConditionTrue, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
+		providertypes.VolumeStatusDetaching: {unikornv1.VolumePhaseReasonDetaching, corev1.ConditionFalse, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
+		providertypes.VolumeStatusUpdating:  {unikornv1.VolumePhaseReasonUpdating, corev1.ConditionFalse, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
+		providertypes.VolumeStatusDeleting:  {unikornv1.VolumePhaseReasonDeleting, corev1.ConditionFalse, corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy},
+		providertypes.VolumeStatusError:     {unikornv1.VolumePhaseReasonError, corev1.ConditionFalse, corev1.ConditionFalse, unikornv1core.ConditionReasonDegraded},
+		providertypes.VolumeStatusUnknown:   {unikornv1.VolumePhaseReasonUnknown, corev1.ConditionFalse, corev1.ConditionUnknown, unikornv1core.ConditionReasonUnknown},
+	}
+
+	for status, want := range tests {
+		t.Run(string(status), func(t *testing.T) {
+			t.Parallel()
+			updated, _ := runCheck(t, volumeFixture(), &providertypes.VolumeObservation{Size: resource.MustParse("20Gi"), Status: status}, nil)
+
+			require.NotNil(t, updated.Status.Size)
+			require.True(t, updated.Status.Size.Equal(resource.MustParse("20Gi")))
+
+			phase, err := unikornv1.GetVolumePhase(updated)
+			require.NoError(t, err)
+			require.Equal(t, want.phase, phase.Reason)
+			require.Equal(t, want.activeStatus, phase.Status)
+
+			health, err := unikornv1core.GetHealthyCondition(updated)
+			require.NoError(t, err)
+			require.Equal(t, want.healthStatus, health.Status)
+			require.Equal(t, want.healthReason, health.Reason)
+
+			available, err := unikornv1core.GetAvailableCondition(updated)
+			require.NoError(t, err)
+			require.Equal(t, unikornv1core.ConditionReasonProvisioned, available.Reason)
+		})
+	}
+}
+
+func TestCheckProjectsMissingProviderVolumeAndLogsTransition(t *testing.T) {
+	t.Parallel()
+
+	volume := volumeFixture()
+	size := resource.MustParse("10Gi")
+	volume.Status.Size = &size
+	volume.SetVolumePhase(unikornv1.VolumePhaseReasonAvailable)
+	volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "")
+
+	updated, sink := runCheck(t, volume, nil, coreerrors.ErrResourceNotFound)
+	require.Nil(t, updated.Status.Size)
+
+	phase, err := unikornv1.GetVolumePhase(updated)
+	require.NoError(t, err)
+	require.Equal(t, unikornv1.VolumePhaseReasonMissing, phase.Reason)
+
+	health, err := unikornv1core.GetHealthyCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, corev1.ConditionFalse, health.Status)
+	require.Equal(t, unikornv1core.ConditionReasonDegraded, health.Reason)
+
+	available, err := unikornv1core.GetAvailableCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, unikornv1core.ConditionReasonProvisioned, available.Reason)
+
+	entry := sink.entry("volume phase transition")
+	require.Equal(t, testVolumeID, entry["volume_id"])
+	require.Equal(t, testOrganizationID, entry["org_id"])
+	require.Equal(t, testRegionID, entry["region_id"])
+	require.Equal(t, string(unikornv1.VolumePhaseReasonAvailable), entry["from_phase"])
+	require.Equal(t, unikornv1.VolumePhaseReasonMissing, entry["to_phase"])
+}
+
+func TestCheckPreservesLastObservationOnProviderErrorAndLogs(t *testing.T) {
+	t.Parallel()
+
+	volume := volumeFixture()
+	size := resource.MustParse("10Gi")
+	volume.Status.Size = &size
+	volume.SetVolumePhase(unikornv1.VolumePhaseReasonAttached)
+	volume.SetHealthCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonHealthy, "")
+	updated, sink := runCheck(t, volume, nil, errProviderObservation)
+	require.NotNil(t, updated.Status.Size)
+	require.True(t, updated.Status.Size.Equal(size))
+
+	phase, err := unikornv1.GetVolumePhase(updated)
+	require.NoError(t, err)
+	require.Equal(t, unikornv1.VolumePhaseReasonAttached, phase.Reason)
+
+	health, err := unikornv1core.GetHealthyCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, corev1.ConditionTrue, health.Status)
+	require.Equal(t, unikornv1core.ConditionReasonHealthy, health.Reason)
+
+	available, err := unikornv1core.GetAvailableCondition(updated)
+	require.NoError(t, err)
+	require.Equal(t, unikornv1core.ConditionReasonProvisioned, available.Reason)
+
+	entry := sink.entry("failed to observe volume, skipping")
+	require.Equal(t, testVolumeID, entry["volume_id"])
+	require.Equal(t, testOrganizationID, entry["org_id"])
+	require.Equal(t, testRegionID, entry["region_id"])
+
+	loggedErr, ok := entry["error"].(error)
+	require.True(t, ok)
+	require.ErrorIs(t, loggedErr, errProviderObservation)
+}

--- a/pkg/monitor/health/volume/check_test.go
+++ b/pkg/monitor/health/volume/check_test.go
@@ -64,13 +64,16 @@ func volumeFixture() *unikornv1.Volume {
 	}}
 	volume.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "")
 	unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionActive, corev1.ConditionTrue, "legacy", "legacy condition")
+
 	return volume
 }
 
 func fakeClient(t *testing.T, objects ...client.Object) client.Client {
 	t.Helper()
-	scheme := runtime.NewScheme()
+	scheme := runtime.NewScheme() //nolint:wsl
+
 	require.NoError(t, unikornv1.AddToScheme(scheme))
+
 	return fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&unikornv1.Volume{}).WithObjects(objects...).Build()
 }
 
@@ -79,7 +82,7 @@ func runCheck(t *testing.T, volume *unikornv1.Volume, lookupErr, updateErr error
 	ctrl := gomock.NewController(t)
 	provider := mocktypes.NewMockProvider(ctrl)
 	providers := mockproviders.NewMockProviders(ctrl)
-	if lookupErr != nil {
+	if lookupErr != nil { //nolint:wsl
 		providers.EXPECT().LookupCloud(testRegionID).Return(nil, lookupErr)
 	} else {
 		providers.EXPECT().LookupCloud(testRegionID).Return(provider, nil)
@@ -87,20 +90,28 @@ func runCheck(t *testing.T, volume *unikornv1.Volume, lookupErr, updateErr error
 			if mutate != nil {
 				mutate(got)
 			}
+
 			return updateErr
 		})
 	}
+
 	identity := &unikornv1.Identity{ObjectMeta: metav1.ObjectMeta{Name: testIdentityID, Namespace: testNamespace}}
 	k8sClient := fakeClient(t, identity, volume)
+
 	require.NoError(t, volumehealth.New(k8sClient, testNamespace, providers).Check(t.Context()))
-	updated := &unikornv1.Volume{}
+	updated := &unikornv1.Volume{} //nolint:wsl
+
 	require.NoError(t, k8sClient.Get(t.Context(), client.ObjectKeyFromObject(volume), updated))
+
 	return updated
 }
 
 func TestCheckPersistsProviderProjection(t *testing.T) {
+	t.Parallel()
+
 	updated := runCheck(t, volumeFixture(), nil, nil, func(volume *unikornv1.Volume) {
-		volume.Status.Size = resource.MustParsePtr("20Gi")
+		size := resource.MustParse("20Gi")
+		volume.Status.Size = &size
 		unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionTrue, string(unikornv1core.ConditionReasonHealthy), "provider healthy")
 	})
 	require.NotNil(t, updated.Status.Size)
@@ -108,11 +119,14 @@ func TestCheckPersistsProviderProjection(t *testing.T) {
 	health, err := unikornv1core.GetHealthyCondition(updated)
 	require.NoError(t, err)
 	require.Equal(t, "provider healthy", health.Message)
+
 	_, err = unikornv1core.GetCondition(updated.Status.Conditions, unikornv1core.ConditionActive)
 	require.Error(t, err)
 }
 
 func TestCheckPreservesStateWhenProviderUnavailable(t *testing.T) {
+	t.Parallel()
+
 	volume := volumeFixture()
 	size := resource.MustParse("10Gi")
 	volume.Status.Size = &size
@@ -125,6 +139,8 @@ func TestCheckPreservesStateWhenProviderUnavailable(t *testing.T) {
 }
 
 func TestCheckPreservesStateWhenProviderObservationFails(t *testing.T) {
+	t.Parallel()
+
 	volume := volumeFixture()
 	unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionTrue, string(unikornv1core.ConditionReasonHealthy), "last state")
 	updated := runCheck(t, volume, nil, errProviderState, nil)
@@ -134,6 +150,8 @@ func TestCheckPreservesStateWhenProviderObservationFails(t *testing.T) {
 }
 
 func TestCheckPersistsProviderMissingProjection(t *testing.T) {
+	t.Parallel()
+
 	updated := runCheck(t, volumeFixture(), nil, nil, func(volume *unikornv1.Volume) {
 		volume.Status.Size = nil
 		unikornv1core.UpdateCondition(&volume.Status.Conditions, unikornv1core.ConditionHealthy, corev1.ConditionFalse, string(unikornv1core.ConditionReasonDegraded), "the provider volume is missing")

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/unikorn-cloud/core/pkg/options"
 	"github.com/unikorn-cloud/region/pkg/constants"
 	serverhealth "github.com/unikorn-cloud/region/pkg/monitor/health/server"
+	volumehealth "github.com/unikorn-cloud/region/pkg/monitor/health/volume"
 	"github.com/unikorn-cloud/region/pkg/providers"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,6 +84,7 @@ func Run(ctx context.Context, c client.Client, o *Options) error {
 
 	checkers := []Checker{
 		serverhealth.New(c, o.CoreOptions.Namespace, providerCache, serverMetrics),
+		volumehealth.New(c, o.CoreOptions.Namespace, providerCache),
 	}
 
 	for {

--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -80,8 +80,8 @@ packages are the concrete provider implementations.
     removal wait for provider convergence
   - its `resource.Quantity` size and one of the nine neutral lifecycle values
     (`creating`, `available`, `attaching`, `attached`, `detaching`, `updating`,
-    `deleting`, `error`, or `unknown`) let later consumers observe backing truth
-    without importing a provider SDK
+    `deleting`, `error`, or `unknown`) let the Volume monitor project backing
+    truth without importing a provider SDK
   - no backing resource maps to the shared `ErrResourceNotFound` sentinel;
     client/request failures remain Go errors, while successfully observed
     provider `error` and unrecognized/empty `unknown` lifecycle values remain

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -316,9 +316,10 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
     observations, not Go errors.
   - observation returns only the neutral size and lifecycle result. It neither
     writes `Volume.Status` nor introduces a mirrored provider-state CRD. The
-    later monitor projects observed provider size and lifecycle into Volume
-    status; the Volume controller separately owns create/delete intent and
-    generic provisioning conditions. VolumeClass inventory and Nova
+    Volume monitor projects observed provider size, lifecycle, and coarse
+    health into Volume status; the Volume controller separately owns
+    create/delete intent and the generic `Available` provisioning condition.
+    VolumeClass inventory and Nova
     attach/detach remain separate capabilities
 - Flavor export is a hybrid model: OpenStack discovers the flavor inventory, but
   region configuration can enrich or override user-facing flavor metadata such

--- a/pkg/providers/internal/openstack/provider_volume_observation_test.go
+++ b/pkg/providers/internal/openstack/provider_volume_observation_test.go
@@ -117,6 +117,7 @@ func TestUpdateVolumeStateMapsCinderStatuses(t *testing.T) {
 			t.Parallel()
 
 			identity, volume := identityFixture(), volumeFixture()
+
 			require.NoError(t, updateVolumeState(t, identity, volume, observedCinderVolume(identity, volume, cinderStatus, 20), nil))
 
 			health, err := unikornv1core.GetHealthyCondition(volume)
@@ -132,6 +133,7 @@ func TestUpdateVolumeStateHandlesMissingAfterProvisioning(t *testing.T) {
 	t.Parallel()
 
 	identity, volume := identityFixture(), volumeFixture()
+
 	volume.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "")
 
 	size := resource.MustParse("20Gi")
@@ -172,18 +174,16 @@ func TestUpdateVolumeStatePreservesStateOnProviderError(t *testing.T) {
 func TestUpdateVolumeStateRejectsInvalidProviderData(t *testing.T) {
 	t.Parallel()
 
-	identity, volume := identityFixture(), volumeFixture()
-
-	for _, size := range []int{-1, int(math.MaxInt64 >> 30)} {
-		if size == int(math.MaxInt64>>30) && strconv.IntSize < 64 {
-			continue
-		}
-
-		if size >= 0 {
-			size++
-		}
+	check := func(size int) {
+		identity, volume := identityFixture(), volumeFixture()
 
 		require.ErrorIs(t, updateVolumeState(t, identity, volume, observedCinderVolume(identity, volume, "available", size), nil), coreerrors.ErrConsistency)
+	}
+
+	check(-1)
+
+	if strconv.IntSize >= 64 {
+		check(int(math.MaxInt64>>30) + 1)
 	}
 }
 

--- a/pkg/providers/internal/openstack/provider_volume_observation_test.go
+++ b/pkg/providers/internal/openstack/provider_volume_observation_test.go
@@ -115,6 +115,7 @@ func TestUpdateVolumeStateMapsCinderStatuses(t *testing.T) {
 	for cinderStatus, want := range tests {
 		t.Run(cinderStatus, func(t *testing.T) {
 			t.Parallel()
+
 			identity, volume := identityFixture(), volumeFixture()
 			require.NoError(t, updateVolumeState(t, identity, volume, observedCinderVolume(identity, volume, cinderStatus, 20), nil))
 
@@ -132,6 +133,7 @@ func TestUpdateVolumeStateHandlesMissingAfterProvisioning(t *testing.T) {
 
 	identity, volume := identityFixture(), volumeFixture()
 	volume.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "")
+
 	size := resource.MustParse("20Gi")
 	volume.Status.Size = &size
 
@@ -171,13 +173,16 @@ func TestUpdateVolumeStateRejectsInvalidProviderData(t *testing.T) {
 	t.Parallel()
 
 	identity, volume := identityFixture(), volumeFixture()
+
 	for _, size := range []int{-1, int(math.MaxInt64 >> 30)} {
 		if size == int(math.MaxInt64>>30) && strconv.IntSize < 64 {
 			continue
 		}
+
 		if size >= 0 {
 			size++
 		}
+
 		require.ErrorIs(t, updateVolumeState(t, identity, volume, observedCinderVolume(identity, volume, "available", size), nil), coreerrors.ErrConsistency)
 	}
 }

--- a/pkg/providers/types/README.md
+++ b/pkg/providers/types/README.md
@@ -121,4 +121,4 @@ continue to be passed directly through many provider interface methods.
   consume these types when converting provider-derived information into API
   reads and actions
 - [../../monitor](../../monitor/README.md) consumes provider-neutral read-side
-  information such as flavors when observing runtime state
+  information, including `VolumeObservation`, when projecting runtime state

--- a/pkg/provisioners/managers/server/provisioner.go
+++ b/pkg/provisioners/managers/server/provisioner.go
@@ -244,7 +244,7 @@ func (p *Provisioner) eventRecorder(ctx context.Context) record.EventRecorder {
 	// and an action string on every call site, so it is a deployment change rather
 	// than a library bump.  Deprecated is not removed; controller-runtime suppresses
 	// the same warning internally.
-	return manager.FromContext(ctx).GetEventRecorderFor("server-controller") //nolint:staticcheck
+	return manager.FromContext(ctx).GetEventRecorderFor("server-controller")
 }
 
 func (p *Provisioner) recordProviderCreateRetryEvent(ctx context.Context, eventType, reason, logMessage, eventMessage string, attempt, maxAttempts int32) {

--- a/pkg/provisioners/managers/volume/README.md
+++ b/pkg/provisioners/managers/volume/README.md
@@ -13,6 +13,12 @@ deletion or operator intervention. This package does not check quota; the HTTP
 create handler allocates the requested capacity and stores the Identity
 allocation ID before the controller can observe the Volume.
 
+`Available=True/Provisioned` is also the durable create-completed latch. Later
+provision passes return before provider lookup or creation. If provider storage
+disappears, the monitor degrades health and the controller does not create a
+replacement under the same Region Volume ID. Users replace the Volume by
+deleting its Region resource and creating a new one.
+
 Deprovisioning deliberately has stricter ordering:
 
 1. resolve the provider and Identity through the shared provisioner lookup, then

--- a/pkg/provisioners/managers/volume/README.md
+++ b/pkg/provisioners/managers/volume/README.md
@@ -31,10 +31,12 @@ the referenced Region `Identity` available through this cleanup; a missing
 Identity remains an error and preserves the Volume finalizer.
 Provider lookup errors also preserve the allocation and finalizer for retry.
 
-General provider observation/status mapping, quota policy, Network
-graph-edge reconciliation, HTTP handlers, and server attachment reconciliation
-are outside this package. The provider-specific state classification needed to
-decide whether create has converged remains inside the provider implementation.
+Provider observation/status projection lives in
+[`pkg/monitor/health/volume`](../../../monitor/health/volume/README.md). Quota
+policy, Network graph-edge reconciliation, HTTP handlers, and server
+attachment reconciliation remain outside this package. The provider-specific
+state classification needed to decide whether create has converged remains
+inside the provider implementation.
 
 ## Cross-Package Context
 

--- a/pkg/provisioners/managers/volume/provisioner.go
+++ b/pkg/provisioners/managers/volume/provisioner.go
@@ -30,6 +30,8 @@ import (
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/providers"
 	"github.com/unikorn-cloud/region/pkg/provisioners/internal/base"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Options allows access to CLI options in the provisioner.
@@ -85,6 +87,11 @@ func (p *Provisioner) Object() unikornv1core.ManagableResourceInterface {
 
 // Provision reconciles the desired provider Volume.
 func (p *Provisioner) Provision(ctx context.Context) error {
+	available, err := unikornv1core.GetAvailableCondition(p.volume)
+	if err == nil && available.Status == corev1.ConditionTrue && available.Reason == unikornv1core.ConditionReasonProvisioned {
+		return nil
+	}
+
 	provider, identity, err := p.ProviderAndIdentity(ctx, p.volume)
 	if err != nil {
 		return err

--- a/pkg/provisioners/managers/volume/provisioner_test.go
+++ b/pkg/provisioners/managers/volume/provisioner_test.go
@@ -156,6 +156,18 @@ func TestProvisionCreatesVolume(t *testing.T) {
 	require.NoError(t, provisioner.Provision(controllerContext(t, resource, identity)))
 }
 
+func TestProvisionDoesNotRecreateProvisionedVolume(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	providerSet := mockproviders.NewMockProviders(ctrl)
+	resource := testVolume(false)
+	resource.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "provisioned")
+
+	provisioner := volume.NewForTest(resource, providerSet, nil)
+	require.NoError(t, provisioner.Provision(controllerContext(t, resource)))
+}
+
 func TestProvisionWaitsForIdentity(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## STO-127

Provider-backed Volume state can change independently of controller
reconciliation. Controller status alone cannot represent current provider
truth.

Poll the provider-neutral observation contract and project observed size and
health into Region status. The monitor owns `Healthy` and observed size only.
It removes the obsolete Volume `Active` condition and never writes the
controller-owned `Available` condition.

Treat provider error, unexpected deletion, and confirmed absence as degraded.
Confirmed absence clears observed size. Treat unknown provider state and
provider request failures as unknown health. Request failures retain the last
observed size, while structured logs retain the provider error and health
transition details.

Treat `Available=True/Provisioned` as the completion record for the one allowed
provider create. Later provisioning passes return before provider lookup or
creation, so provider loss cannot create empty replacement storage under the
same Region Volume ID. Replacement requires deleting the Region Volume and
creating a new one. Deprovisioning remains unconditional and provider-backed.

Grant the monitor only the Volume list, watch, and status patch permissions
required for observation.

## Verification

- `make touch`
- `make license`
- `make validate`
- `make lint`
- `make generate`
- generated-output and status inspection
- `make test-unit`

All checks passed with the repository-declared Go 1.25.8 toolchain.

## Stack

Depends on #639 (STO-123). This PR targets
`feat/STO-123-implement-openstack-volume-discovery-and-observation`, not
`main`.