### PR TITLE
Fix region-monitor crashing when polling endpoints with expired certs

### DIFF
--- a/pkg/monitor/README.md
+++ b/pkg/monitor/README.md
@@ -30,4 +30,11 @@ intended to allow additional monitor classes later.
 
 - This is polling by design. That makes it simpler and more decoupled, but also
   means timeliness and overhead are governed by poll period rather than watches.
-- Provider/cache readiness is part of monitor startup.
+- Provider/cache readiness is part of monitor startup, but unlike the API server
+  and controller manager this process opts into
+  `providers.Options.TolerateRegionInitErrors`. A single region with a broken
+  provider (e.g. an expired or invalid TLS certificate) is logged and skipped at
+  startup instead of crash-looping the whole process; that region is retried on
+  every subsequent lookup until it initializes cleanly. Servers in an
+  unavailable region are simply absent from that poll's checks, per
+  [health/server](./health/server/README.md).

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -62,7 +62,12 @@ type Checker interface {
 func Run(ctx context.Context, c client.Client, o *Options) error {
 	log := log.FromContext(ctx)
 
-	providerCache, err := providers.New(ctx, c, c, o.CoreOptions.Namespace, providers.Options{})
+	// A single region with a broken provider (e.g. an expired or invalid TLS
+	// certificate) must not take the whole monitor process down: unlike the API
+	// server or controller manager, this process has no in-flight traffic to
+	// protect by failing fast, and the broken region should instead show up as a
+	// logged, retried-on-poll problem for that region alone.
+	providerCache, err := providers.New(ctx, c, c, o.CoreOptions.Namespace, providers.Options{TolerateRegionInitErrors: true})
 	if err != nil {
 		log.Error(err, "failed to initialize providers")
 

--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -105,6 +105,16 @@ packages are the concrete provider implementations.
   than assuming client material is static for process lifetime.
   Credential rotation, secret refresh, and region configuration refresh are part
   of the provider contract, not incidental operational concerns.
+- `New` synchronously initializes every region's provider at startup and, by
+  default, fails entirely if any single region fails to initialize (e.g. an
+  expired or invalid TLS certificate). This is deliberate for the API server and
+  controller manager: during a rollout, an old pod that can still serve traffic
+  is preferable to a new one known to be partially broken. Callers with no
+  traffic to protect, such as the poll-only [region-monitor](../monitor/README.md),
+  should set `Options.TolerateRegionInitErrors` so a single broken region is
+  logged and skipped rather than taking the whole process down. A region skipped
+  this way, like one discovered after startup, is retried on demand the next
+  time it's looked up.
 - The provider layer is allowed to carry compensating local mechanisms where the
   underlying substrate is insufficient on its own:
   - OpenStack image caching exists because raw image API behaviour is too slow

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -70,16 +71,28 @@ type providersImpl struct {
 type Options struct {
 	// WarmImageCache enables startup-time image cache initialization.
 	WarmImageCache bool
+
+	// TolerateRegionInitErrors changes how New reacts to a single region failing
+	// to initialize (e.g. an expired or otherwise invalid provider TLS certificate).
+	// When false (the default) that failure aborts the entire call. When true, the
+	// failure is logged and that region is simply omitted from the initial cache;
+	// it is retried on demand the next time it's looked up (see load), so a single
+	// broken region degrades to "unavailable until fixed" rather than taking the
+	// whole process down.
+	TolerateRegionInitErrors bool
 }
 
 // New creates and synchronously initializes all region providers. Startup-time region
 // discovery and provider construction use initClient so bootstrap reads can happen
 // before a controller manager cache has started, while the returned provider set retains
-// runtimeClient for normal cached operation after startup. The chosen behaviour is to
+// runtimeClient for normal cached operation after startup. By default the behaviour is to
 // fail on initialization failure, the reasoning is that during upgrade an old version of
 // the service should be running to handle traffic, and we'd rather not have something
-// put into production that is known to be broken. Regions discovered after startup are
-// loaded on demand and then shared for subsequent lookups.
+// put into production that is known to be broken. Callers that instead want the process
+// to stay up and treat a broken region as a per-region problem (e.g. a poll-only monitor
+// that has no traffic to protect) should set Options.TolerateRegionInitErrors. Regions
+// discovered after startup, or skipped at startup under that option, are loaded on demand
+// and then shared for subsequent lookups.
 func New(ctx context.Context, initClient client.Client, runtimeClient client.Client, namespace string, opts Options) (Providers, error) {
 	var regions unikornv1.RegionList
 
@@ -94,7 +107,13 @@ func New(ctx context.Context, initClient client.Client, runtimeClient client.Cli
 	for i := range regions.Items {
 		provider, err := newProvider(ctx, initClient, runtimeClient, &regions.Items[i], opts)
 		if err != nil {
-			return nil, err
+			if !opts.TolerateRegionInitErrors {
+				return nil, err
+			}
+
+			log.FromContext(ctx).Error(err, "failed to initialize region provider, region will be unavailable until this is resolved", "region", regions.Items[i].Name)
+
+			continue
 		}
 
 		cache[regions.Items[i].Name] = provider

--- a/pkg/providers/providers_test.go
+++ b/pkg/providers/providers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package providers_test
 
 import (
+	"errors"
 	"testing"
 
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
@@ -26,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -76,5 +78,93 @@ func TestLookupCommonLoadsRegionOnMiss(t *testing.T) {
 
 	if _, err := providerSet.LookupCommon("sim-public"); err != nil {
 		t.Fatalf("lookup from cache after delete: %v", err)
+	}
+}
+
+// newTestClient builds a fake client seeded with two regions: a healthy simulated
+// region ("sim-public") and a region whose provider fails to construct ("broken").
+// An unimplemented provider kind is used to deterministically fail construction
+// without needing network or TLS fixtures — from providers.New's point of view this
+// is the same failure shape as an OpenStack region with an expired or otherwise
+// invalid TLS certificate: newProvider returns an error for that one region.
+func newTestClient(t *testing.T, namespace string) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("adding client-go scheme: %v", err)
+	}
+
+	if err := unikornv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("adding unikorn scheme: %v", err)
+	}
+
+	healthyRegion := &unikornv1.Region{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "sim-public",
+		},
+		Spec: unikornv1.RegionSpec{
+			Provider: unikornv1.ProviderSimulated,
+		},
+	}
+
+	brokenRegion := &unikornv1.Region{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "broken",
+		},
+		Spec: unikornv1.RegionSpec{
+			Provider: unikornv1.Provider("unimplemented"),
+		},
+	}
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(healthyRegion, brokenRegion).Build()
+}
+
+// TestNewFailsEntirelyByDefaultOnRegionInitError locks in the existing fail-fast
+// behaviour relied on by the API server and controller manager: a single broken
+// region aborts the whole call unless a caller opts out.
+func TestNewFailsEntirelyByDefaultOnRegionInitError(t *testing.T) {
+	t.Parallel()
+
+	namespace := "test"
+	ctx := t.Context()
+
+	cli := newTestClient(t, namespace)
+
+	if _, err := providers.New(ctx, cli, cli, namespace, providers.Options{}); err == nil {
+		t.Fatal("expected New to fail when a region provider fails to initialize")
+	}
+}
+
+// TestNewTolerateRegionInitErrorsSkipsBrokenRegion is the region-monitor case: a
+// region with a broken provider (e.g. expired/invalid TLS certificate) must not
+// prevent the process from starting and serving every other, healthy region.
+func TestNewTolerateRegionInitErrorsSkipsBrokenRegion(t *testing.T) {
+	t.Parallel()
+
+	namespace := "test"
+	ctx := t.Context()
+
+	cli := newTestClient(t, namespace)
+
+	providerSet, err := providers.New(ctx, cli, cli, namespace, providers.Options{TolerateRegionInitErrors: true})
+	if err != nil {
+		t.Fatalf("expected New to tolerate a single broken region, got: %v", err)
+	}
+
+	if _, err := providerSet.LookupCommon("sim-public"); err != nil {
+		t.Fatalf("expected the healthy region to be usable: %v", err)
+	}
+
+	_, err = providerSet.LookupCommon("broken")
+	if err == nil {
+		t.Fatal("expected lookup of the broken region to still fail")
+	}
+
+	if !errors.Is(err, providers.ErrRegionProviderUnimplemented) {
+		t.Fatalf("expected broken region lookup to retry initialization and surface the same error, got: %v", err)
 	}
 }


### PR DESCRIPTION
The region-monitor service dies when polling OpenStack endpoints at startup if it encounters one with an expired or invalid TLS certificate.

Skip the affected region and retry on subsequent polls.