### PR TITLE
Reconcile Server volume attachments

### DIFF
--- a/charts/region/templates/server-controller/clusterrole.yaml
+++ b/charts/region/templates/server-controller/clusterrole.yaml
@@ -30,6 +30,7 @@ rules:
   resources:
   - networks
   - securitygroups
+  - volumes
   verbs:
   - list
   - watch

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -27,10 +27,11 @@ The useful way to read it is not as a directory tree, but as one system:
   A Cinder error is surfaced through a safe typed provisioning condition; quota
   admission, the public API, and general observed-state projection remain later
   lifecycle slices
-- `Server` now carries the internal attach-existing-only block volume intent
-  and observed per-volume attachment rows. The provider boundary and OpenStack
-  Nova attach/detach implementation exist; public API projection and
-  server-controller reconciliation remain separate follow-up work
+- `Server` carries attach-existing-only block volume intent and observed
+  per-volume attachment rows. Its controller atomically claims each Volume and
+  places its finalizer-backed deletion reference before provider attach, detaches
+  before releasing that ownership, and performs the same cleanup before Server
+  deletion. Public API projection remains separate follow-up work
 
 ## Recommended Reading Order
 

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -104,8 +104,8 @@ stored objects rely on for linkage, migration, and operational coordination.
   device name for later controller and monitor work. The provider layer now
   supplies a server-owned attach/detach boundary and the OpenStack provider
   realizes it with Nova, but this package still only owns the persisted shape;
-  reference placement, claim/locking behavior, controller reconciliation, and
-  public API projection live in later layers/tickets.
+  reference placement, claim/locking behavior, and attachment reconciliation
+  are owned by the Server controller. Public API projection remains deferred.
 - The `Network -> Volume` graph edge is declared as containment for future
   behavior: Network scope propagates to Volume; co-location is implicit; Volume
   holds a reverse deletion-blocking relationship to Network for its lifetime;

--- a/pkg/managers/server/README.md
+++ b/pkg/managers/server/README.md
@@ -5,7 +5,8 @@ This package is the controller factory for `Server` reconciliation.
 It is structurally standard, but it fronts the richest provisioner in the tree:
 [`pkg/provisioners/managers/server`](../../provisioners/managers/server/README.md),
 which maintains explicit resource-reference edges and SSH CA cloud-init
-augmentation.
+augmentation. The provisioner also owns Volume claim/finalizer ordering,
+provider attach/detach convergence, and `Server.status.volumes`.
 
 The watch is slightly broader than the other resource managers: besides server
 spec generation changes, it also wakes the controller when the monitor first

--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -68,8 +68,9 @@ packages are the concrete provider implementations.
   - lifecycle intent is the native Region `Volume` CRD
   - provider implementations rediscover their backing object internally before
     create or delete; rediscovery is not a public existence-only contract
-  - create success means the rediscovered backing volume is usable, not merely
-    that an asynchronous provider request was accepted. Providers return
+  - create success means the rediscovered backing volume is usable (`available`
+    or already `in-use`), not merely that an asynchronous provider request was
+    accepted. Providers return
     `provisioners.ErrYield` while creation is still converging and a safe typed
     terminal provisioning error when the backing object has entered an
     unrecoverable error state
@@ -96,7 +97,8 @@ packages are the concrete provider implementations.
     never realized. Callers must therefore never gate a delete on identity
     readiness or recorded status — that belongs to this layer.
 - `DetachVolume` follows the same absent-means-converged teardown rule: a
-  missing provider server, volume, or attachment is success. `AttachVolume`
+  missing provider server, volume, or attachment is success, while an accepted
+  detach yields until a later read confirms convergence. `AttachVolume`
   instead requires both backing resources and reports semantic not-found when
   either is absent. Concrete provider conflicts are normalized to the shared
   conflict sentinel; provider failures that are neither not-found nor conflict

--- a/pkg/providers/internal/openstack/README.md
+++ b/pkg/providers/internal/openstack/README.md
@@ -271,8 +271,10 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
     rather than duplicating it
   - an accepted Cinder create is partial progress rather than success: the
     provider yields after submission and on subsequent rediscovery until the
-    volume reports `available`; all unrecognized non-error states also yield so
-    an unfamiliar provider state cannot be mistaken for convergence
+    volume reports `available` or `in-use`; `in-use` remains converged when the
+    Server controller's durable claim update requeues the Volume controller.
+    All unrecognized non-error states yield so an unfamiliar provider state
+    cannot be mistaken for convergence
   - a Cinder status beginning with `error` returns a typed terminal
     `Available=False`, `Reason=Errored` result with the user-safe message
     `provider volume entered an error state`; provider IDs, scheduler failures,
@@ -346,9 +348,11 @@ The full operator procedure lives in [./ADMIN.md](./ADMIN.md).
     creation of the same desired attachment becomes success, while an
     unresolved conflict maps to `ErrConflict`
   - detach calls Nova delete only when Cinder reports an attachment to the
-    requested server; a missing server, volume, requested-server attachment, or
-    Nova delete `404` is success because detached state already holds, including
-    when the volume remains attached only to another server
+    requested server; an accepted delete yields so the caller retains its claim
+    until a later read confirms convergence. A missing server, volume,
+    requested-server attachment, or Nova delete `404` is success because
+    detached state already holds, including when the volume remains attached
+    only to another server
   - a Nova delete `409 Conflict` maps to `ErrConflict`; other provider failures
     are preserved
   - detach also no-ops when the backing OpenStack identity was never realized,

--- a/pkg/providers/internal/openstack/provider.go
+++ b/pkg/providers/internal/openstack/provider.go
@@ -2007,6 +2007,7 @@ func volumeMetadata(identity *unikornv1.Identity, volume *unikornv1.Volume) map[
 
 const (
 	volumeStatusAvailable   = "available"
+	volumeStatusInUse       = "in-use"
 	volumeStatusErrorPrefix = "error"
 )
 
@@ -2021,7 +2022,7 @@ func reconcileVolume(ctx context.Context, blockStorage VolumeInterface, identity
 			return provisioners.Terminal(unikornv1core.ConditionReasonErrored, "provider volume entered an error state")
 		}
 
-		if openstackVolume.Status != volumeStatusAvailable {
+		if openstackVolume.Status != volumeStatusAvailable && openstackVolume.Status != volumeStatusInUse {
 			return provisioners.ErrYield
 		}
 

--- a/pkg/providers/internal/openstack/provider_test.go
+++ b/pkg/providers/internal/openstack/provider_test.go
@@ -1888,6 +1888,20 @@ func TestReconcileVolume(t *testing.T) {
 		require.NoError(t, openstack.ReconcileVolume(t.Context(), blockStorage, identity, volume))
 	})
 
+	t.Run("ItIsInUse", func(t *testing.T) {
+		t.Parallel()
+
+		c := gomock.NewController(t)
+		blockStorage := mock.NewMockVolumeInterface(c)
+		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(&volumes.Volume{
+			ID:     openstackVolume.ID,
+			Name:   openstackVolume.Name,
+			Status: "in-use",
+		}, nil)
+
+		require.NoError(t, openstack.ReconcileVolume(t.Context(), blockStorage, identity, volume))
+	})
+
 	t.Run("ItIsCreating", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/providers/internal/openstack/provider_volume_attachment_test.go
+++ b/pkg/providers/internal/openstack/provider_volume_attachment_test.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	"github.com/unikorn-cloud/core/pkg/provisioners"
 	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack"
 	"github.com/unikorn-cloud/region/pkg/providers/internal/openstack/mock"
@@ -272,7 +273,8 @@ func TestDetachVolume(t *testing.T) {
 		blockStorage.EXPECT().GetVolume(t.Context(), volume).Return(attachedVolume, nil)
 		compute.EXPECT().DeleteVolumeAttachment(t.Context(), openstackServer.ID, cinderVolume.ID).Return(nil)
 
-		require.NoError(t, openstack.DetachVolumeWithClients(t.Context(), compute, blockStorage, server, volume))
+		err := openstack.DetachVolumeWithClients(t.Context(), compute, blockStorage, server, volume)
+		require.ErrorIs(t, err, provisioners.ErrYield)
 	})
 
 	t.Run("AlreadyDetachedIsIdempotent", func(t *testing.T) {

--- a/pkg/providers/internal/openstack/volume_attachment.go
+++ b/pkg/providers/internal/openstack/volume_attachment.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/volumeattach"
 
 	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	"github.com/unikorn-cloud/core/pkg/provisioners"
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 )
@@ -184,7 +185,7 @@ func detachVolume(ctx context.Context, compute ComputeInterface, blockStorage Vo
 		return err
 	}
 
-	return nil
+	return provisioners.ErrYield
 }
 
 func (p *Provider) AttachVolume(ctx context.Context, identity *unikornv1.Identity, server *unikornv1.Server, volume *unikornv1.Volume) (*types.ServerVolumeAttachment, error) {

--- a/pkg/provisioners/managers/server/README.md
+++ b/pkg/provisioners/managers/server/README.md
@@ -6,6 +6,13 @@ Distinctive behaviour:
 
 - maintains explicit reference edges from a server to consumed networks,
   security groups, and optional SSH certificate authority
+- claims each desired Volume with an optimistic write and a finalizer-backed
+  deletion reference before provider attach, then projects the provider-neutral
+  device and attachment state into `Server.status.volumes`
+- detaches claimed Volumes before releasing their claims and finalizer-backed
+  references, both when desired attachments are removed and before Server deletion
+- checks Volume readiness after provider server creation because readiness gates
+  attachment, not creation of the Server itself
 - blocks on identity readiness before provider create/delete
 - blocks provider create while any configured `providerCreateGates` remain
   unsatisfied
@@ -17,6 +24,8 @@ Distinctive behaviour:
   deleting the failed provider server before a bounded re-attempt, but only for
   servers that have never been successfully provisioned; once the attempt cap is
   reached it aborts terminally rather than retrying further
+- retries Volume attachment convergence independently and idempotently; attachment
+  failures never trigger destructive provider server delete-and-recreate recovery
 - clears or updates consumed-resource references during reprovision and teardown
 
 Create recovery and image rebuild recovery deliberately use different state:
@@ -98,6 +107,8 @@ This is the clearest controller-side expression of the lifecycle DAG model:
 - provider-create gates are pre-provider-create coordination points; they delay
   provider create but are not deletion blockers
 - provider-side server lifecycle is delegated
+- provider-side Volume attach/detach is delegated while claim and status
+  ownership remains in this controller
 - cloud-init augmentation translates higher-level SSH CA semantics into machine
   bootstrap material
 

--- a/pkg/provisioners/managers/server/provisioner.go
+++ b/pkg/provisioners/managers/server/provisioner.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -131,6 +132,225 @@ func (p *Provisioner) securityGroupIDs() []string {
 	}
 
 	return ids
+}
+
+func (p *Provisioner) volumeClaim() unikornv1.VolumeClaimRef {
+	return unikornv1.VolumeClaimRef{
+		Kind: unikornv1.VolumeClaimKindServer,
+		ID:   p.server.Name,
+	}
+}
+
+func (p *Provisioner) volumeClaimedByServer(volume *unikornv1.Volume) bool {
+	claim := p.volumeClaim()
+
+	return volume.Spec.ClaimRef != nil && *volume.Spec.ClaimRef == claim
+}
+
+func (p *Provisioner) setVolumeStatus(id string, status unikornv1.AttachmentProvisioningStatus, device *string, message string) {
+	for i := range p.server.Status.Volumes {
+		if p.server.Status.Volumes[i].ID == id {
+			p.server.Status.Volumes[i].ProvisioningStatus = status
+			p.server.Status.Volumes[i].Device = device
+			p.server.Status.Volumes[i].Message = message
+
+			return
+		}
+	}
+
+	p.server.Status.Volumes = append(p.server.Status.Volumes, unikornv1.ServerVolumeStatus{
+		ID:                 id,
+		ProvisioningStatus: status,
+		Device:             device,
+		Message:            message,
+	})
+}
+
+func (p *Provisioner) removeVolumeStatus(id string) {
+	for i := range p.server.Status.Volumes {
+		if p.server.Status.Volumes[i].ID == id {
+			p.server.Status.Volumes = append(p.server.Status.Volumes[:i], p.server.Status.Volumes[i+1:]...)
+
+			return
+		}
+	}
+}
+
+func (p *Provisioner) claimVolume(ctx context.Context, cli client.Client, volume *unikornv1.Volume, reference string) error {
+	claim := p.volumeClaim()
+
+	if volume.Spec.ClaimRef != nil && *volume.Spec.ClaimRef != claim {
+		return fmt.Errorf(
+			"%w: %w: volume %s is claimed by %s %s",
+			provisioners.Yield(unikornv1core.ConditionReasonDependencyNotReady, "volume is claimed by another server"),
+			coreerrors.ErrConflict,
+			volume.Name,
+			volume.Spec.ClaimRef.Kind,
+			volume.Spec.ClaimRef.ID,
+		)
+	}
+
+	if volume.DeletionTimestamp != nil && volume.Spec.ClaimRef == nil {
+		return fmt.Errorf("%w: volume %s is being deleted", coreerrors.ErrConflict, volume.Name)
+	}
+
+	updated := controllerutil.AddFinalizer(volume, reference)
+
+	if volume.Spec.ClaimRef == nil {
+		volume.Spec.ClaimRef = &claim
+		updated = true
+	}
+
+	if !updated {
+		return nil
+	}
+
+	if err := cli.Update(ctx, volume); err != nil {
+		if kerrors.IsConflict(err) {
+			return provisioners.ErrYield
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provisioner) releaseVolume(ctx context.Context, cli client.Client, volume *unikornv1.Volume, reference string) error {
+	if volume.Spec.ClaimRef != nil && !p.volumeClaimedByServer(volume) {
+		return fmt.Errorf("%w: volume %s claim changed ownership", coreerrors.ErrConflict, volume.Name)
+	}
+
+	updated := controllerutil.RemoveFinalizer(volume, reference)
+
+	if volume.Spec.ClaimRef != nil {
+		volume.Spec.ClaimRef = nil
+		updated = true
+	}
+
+	if !updated {
+		return nil
+	}
+
+	if err := cli.Update(ctx, volume); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+
+		if kerrors.IsConflict(err) {
+			return provisioners.ErrYield
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provisioner) detachUndesiredVolumes(ctx context.Context, cli client.Client, provider types.Provider, identity *unikornv1.Identity, reference string, volumes []unikornv1.Volume, desiredIDs map[string]struct{}) error {
+	for i := range volumes {
+		volume := &volumes[i]
+		if !p.volumeClaimedByServer(volume) {
+			continue
+		}
+
+		if _, ok := desiredIDs[volume.Name]; ok {
+			continue
+		}
+
+		p.setVolumeStatus(volume.Name, unikornv1.AttachmentDeprovisioning, nil, "detaching volume")
+
+		if err := provider.DetachVolume(ctx, identity, p.server, volume); err != nil {
+			if !errors.Is(err, provisioners.ErrYield) {
+				p.setVolumeStatus(volume.Name, unikornv1.AttachmentErrored, nil, "failed to detach volume")
+			}
+
+			return err
+		}
+
+		if err := p.releaseVolume(ctx, cli, volume, reference); err != nil {
+			return err
+		}
+
+		p.removeVolumeStatus(volume.Name)
+	}
+
+	return nil
+}
+
+func (p *Provisioner) attachDesiredVolumes(ctx context.Context, cli client.Client, provider types.Provider, identity *unikornv1.Identity, reference string, desired []unikornv1.ServerVolumeSpec, byID map[string]*unikornv1.Volume) error {
+	for _, attachment := range desired {
+		volume, ok := byID[attachment.ID]
+		if !ok {
+			p.setVolumeStatus(attachment.ID, unikornv1.AttachmentErrored, nil, "volume does not exist in the server identity")
+
+			return fmt.Errorf("%w: attempt to attach unknown volume ID %s", coreerrors.ErrConsistency, attachment.ID)
+		}
+
+		if err := p.claimVolume(ctx, cli, volume, reference); err != nil {
+			if errors.Is(err, provisioners.ErrYield) {
+				p.setVolumeStatus(attachment.ID, unikornv1.AttachmentProvisioning, nil, "waiting for volume claim")
+			} else {
+				p.setVolumeStatus(attachment.ID, unikornv1.AttachmentErrored, nil, "volume is claimed by another server")
+			}
+
+			return err
+		}
+
+		if err := p.classifyDependency(cli, volume); err != nil {
+			p.setVolumeStatus(attachment.ID, unikornv1.AttachmentProvisioning, nil, "waiting for volume to be provisioned")
+
+			return err
+		}
+
+		result, err := provider.AttachVolume(ctx, identity, p.server, volume)
+		if err != nil {
+			if errors.Is(err, provisioners.ErrYield) {
+				p.setVolumeStatus(attachment.ID, unikornv1.AttachmentProvisioning, nil, "attaching volume")
+			} else {
+				p.setVolumeStatus(attachment.ID, unikornv1.AttachmentErrored, nil, "failed to attach volume")
+			}
+
+			return err
+		}
+
+		if result == nil {
+			p.setVolumeStatus(attachment.ID, unikornv1.AttachmentErrored, nil, "provider returned an empty volume attachment")
+
+			return fmt.Errorf("%w: provider returned an empty volume attachment", coreerrors.ErrConsistency)
+		}
+
+		p.setVolumeStatus(attachment.ID, unikornv1.AttachmentProvisioned, result.Device, "volume attached")
+	}
+
+	return nil
+}
+
+func (p *Provisioner) reconcileVolumeAttachments(ctx context.Context, cli client.Client, provider types.Provider, identity *unikornv1.Identity, reference string, desired []unikornv1.ServerVolumeSpec) error {
+	volumes := &unikornv1.VolumeList{}
+	if err := cli.List(ctx, volumes, p.identityListOptions()); err != nil {
+		return err
+	}
+
+	byID := make(map[string]*unikornv1.Volume, len(volumes.Items))
+	for i := range volumes.Items {
+		byID[volumes.Items[i].Name] = &volumes.Items[i]
+	}
+
+	desiredIDs := make(map[string]struct{}, len(desired))
+	p.server.Status.Volumes = make([]unikornv1.ServerVolumeStatus, 0, len(desired))
+
+	for _, attachment := range desired {
+		desiredIDs[attachment.ID] = struct{}{}
+
+		p.setVolumeStatus(attachment.ID, unikornv1.AttachmentProvisioning, nil, "attaching volume")
+	}
+
+	if err := p.detachUndesiredVolumes(ctx, cli, provider, identity, reference, volumes.Items, desiredIDs); err != nil {
+		return err
+	}
+
+	return p.attachDesiredVolumes(ctx, cli, provider, identity, reference, desired, byID)
 }
 
 func (p *Provisioner) sshCertificateAuthorityKey() *client.ObjectKey {
@@ -562,12 +782,12 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 		return err
 	}
 
-	// Release any references to any resources we no longer consume.
-	if err := p.removeConsumedResourceReferences(ctx, cli, reference); err != nil {
+	if err := p.reconcileVolumeAttachments(ctx, cli, provider, identity, reference, p.server.Spec.Volumes); err != nil {
 		return err
 	}
 
-	return nil
+	// Release any references to any resources we no longer consume.
+	return p.removeConsumedResourceReferences(ctx, cli, reference)
 }
 
 // Deprovision implements the Provision interface.
@@ -582,16 +802,20 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 		return err
 	}
 
-	if err := provider.DeleteServer(ctx, identity, p.server); err != nil {
-		return err
-	}
-
-	// Once we know the server is gone, allow deletion of the security group.
 	reference, err := manager.GenerateResourceReference(cli, p.server)
 	if err != nil {
 		return err
 	}
 
+	if err := p.reconcileVolumeAttachments(ctx, cli, provider, identity, reference, nil); err != nil {
+		return err
+	}
+
+	if err := provider.DeleteServer(ctx, identity, p.server); err != nil {
+		return err
+	}
+
+	// Once we know the server is gone, allow deletion of the security group.
 	if err := p.clearConsumedResourceReferences(ctx, cli, reference); err != nil {
 		return err
 	}

--- a/pkg/provisioners/managers/server/provisioner_volume_test.go
+++ b/pkg/provisioners/managers/server/provisioner_volume_test.go
@@ -1,0 +1,309 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
+	coreclient "github.com/unikorn-cloud/core/pkg/client"
+	coreerrors "github.com/unikorn-cloud/core/pkg/errors"
+	"github.com/unikorn-cloud/core/pkg/manager"
+	"github.com/unikorn-cloud/core/pkg/provisioners"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	"github.com/unikorn-cloud/region/pkg/constants"
+	mockproviders "github.com/unikorn-cloud/region/pkg/providers/mock"
+	"github.com/unikorn-cloud/region/pkg/providers/types"
+	mocktypes "github.com/unikorn-cloud/region/pkg/providers/types/mock"
+	serverprovisioner "github.com/unikorn-cloud/region/pkg/provisioners/managers/server"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const attachmentVolumeID = "11111111-1111-4111-8111-111111111111"
+
+const replacementVolumeID = "22222222-2222-4222-8222-222222222222"
+
+func attachmentVolume() *regionv1.Volume {
+	volume := &regionv1.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      attachmentVolumeID,
+			Namespace: "default",
+			Labels: map[string]string{
+				constants.RegionLabel:   testRegionID,
+				constants.IdentityLabel: testIdentityID,
+			},
+		},
+	}
+	volume.SetProvisioningCondition(corev1.ConditionTrue, unikornv1core.ConditionReasonProvisioned, "")
+
+	return volume
+}
+
+func serverVolumeReference(t *testing.T, cli client.Client, server *regionv1.Server) string {
+	t.Helper()
+
+	reference, err := manager.GenerateResourceReference(cli, server)
+	require.NoError(t, err)
+
+	return reference
+}
+
+func claimVolumeForServer(volume *regionv1.Volume, server *regionv1.Server, reference string) {
+	volume.Spec.ClaimRef = &regionv1.VolumeClaimRef{
+		Kind: regionv1.VolumeClaimKindServer,
+		ID:   server.Name,
+	}
+	controllerutil.AddFinalizer(volume, reference)
+}
+
+func getAttachmentVolume(t *testing.T, cli client.Client) *regionv1.Volume {
+	t.Helper()
+
+	volume := &regionv1.Volume{}
+	require.NoError(t, cli.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: attachmentVolumeID}, volume))
+
+	return volume
+}
+
+func attachmentProvisioner(t *testing.T, server *regionv1.Server, provider *mocktypes.MockProvider) *serverprovisioner.Provisioner {
+	t.Helper()
+
+	providerSet := mockproviders.NewMockProviders(gomock.NewController(t))
+	providerSet.EXPECT().LookupCloud(testRegionID).Return(provider, nil).AnyTimes()
+
+	return serverprovisioner.NewForTest(server, providerSet, nil)
+}
+
+func TestProvisionClaimsVolumeBeforeAttach(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	server := testProvisionServer(func(server *regionv1.Server) {
+		server.Spec.Volumes = []regionv1.ServerVolumeSpec{{ID: attachmentVolumeID}}
+	})
+	volume := attachmentVolume()
+	cli := testProvisionClient(t, server, testProvisionIdentity(), volume)
+	reference := serverVolumeReference(t, cli, server)
+	device := "/dev/vdb"
+
+	provider := mocktypes.NewMockProvider(ctrl)
+	provider.EXPECT().CreateServer(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil)
+	provider.EXPECT().AttachVolume(gomock.Any(), gomock.Any(), server, gomock.Any()).DoAndReturn(
+		func(_ any, _ *regionv1.Identity, _ *regionv1.Server, _ *regionv1.Volume) (*types.ServerVolumeAttachment, error) {
+			stored := getAttachmentVolume(t, cli)
+			require.Equal(t, &regionv1.VolumeClaimRef{Kind: regionv1.VolumeClaimKindServer, ID: server.Name}, stored.Spec.ClaimRef)
+			require.True(t, controllerutil.ContainsFinalizer(stored, reference))
+
+			return &types.ServerVolumeAttachment{Device: &device}, nil
+		},
+	)
+
+	prov := attachmentProvisioner(t, server, provider)
+	require.NoError(t, prov.Provision(coreclient.NewContext(t.Context(), cli)))
+
+	require.Equal(t, []regionv1.ServerVolumeStatus{{
+		ID:                 attachmentVolumeID,
+		ProvisioningStatus: regionv1.AttachmentProvisioned,
+		Device:             &device,
+		Message:            "volume attached",
+	}}, server.Status.Volumes)
+}
+
+func TestProvisionConvergesAlreadyClaimedVolume(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	server := testProvisionServer(func(server *regionv1.Server) {
+		server.Spec.Volumes = []regionv1.ServerVolumeSpec{{ID: attachmentVolumeID}}
+	})
+	volume := attachmentVolume()
+	cli := testProvisionClient(t, server, testProvisionIdentity(), volume)
+	reference := serverVolumeReference(t, cli, server)
+	claimVolumeForServer(volume, server, reference)
+	cli = testProvisionClient(t, server, testProvisionIdentity(), volume)
+
+	provider := mocktypes.NewMockProvider(ctrl)
+	provider.EXPECT().CreateServer(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil)
+	provider.EXPECT().AttachVolume(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(&types.ServerVolumeAttachment{}, nil)
+
+	prov := attachmentProvisioner(t, server, provider)
+	require.NoError(t, prov.Provision(coreclient.NewContext(t.Context(), cli)))
+	require.Equal(t, regionv1.AttachmentProvisioned, server.Status.Volumes[0].ProvisioningStatus)
+	require.Equal(t, server.Name, getAttachmentVolume(t, cli).Spec.ClaimRef.ID)
+}
+
+func TestProvisionDetachRetainsClaimUntilConverged(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	server := testProvisionServer()
+	volume := attachmentVolume()
+	cli := testProvisionClient(t, server, testProvisionIdentity(), volume)
+	reference := serverVolumeReference(t, cli, server)
+	claimVolumeForServer(volume, server, reference)
+	cli = testProvisionClient(t, server, testProvisionIdentity(), volume)
+
+	provider := mocktypes.NewMockProvider(ctrl)
+	firstCreate := provider.EXPECT().CreateServer(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil)
+	firstDetach := provider.EXPECT().DetachVolume(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(provisioners.ErrYield).After(firstCreate)
+	secondCreate := provider.EXPECT().CreateServer(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil).After(firstDetach)
+	provider.EXPECT().DetachVolume(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil).After(secondCreate)
+
+	prov := attachmentProvisioner(t, server, provider)
+	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
+	require.ErrorIs(t, err, provisioners.ErrYield)
+	require.Equal(t, regionv1.AttachmentDeprovisioning, server.Status.Volumes[0].ProvisioningStatus)
+	require.NotNil(t, getAttachmentVolume(t, cli).Spec.ClaimRef)
+
+	require.NoError(t, prov.Provision(coreclient.NewContext(t.Context(), cli)))
+	stored := getAttachmentVolume(t, cli)
+	require.Nil(t, stored.Spec.ClaimRef)
+	require.False(t, controllerutil.ContainsFinalizer(stored, reference))
+	require.Empty(t, server.Status.Volumes)
+}
+
+func TestProvisionRejectsClaimConflictBeforeAttach(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	server := testProvisionServer(func(server *regionv1.Server) {
+		server.Spec.Volumes = []regionv1.ServerVolumeSpec{{ID: attachmentVolumeID}}
+	})
+	volume := attachmentVolume()
+	volume.Status.Conditions = nil
+	volume.Spec.ClaimRef = &regionv1.VolumeClaimRef{Kind: regionv1.VolumeClaimKindServer, ID: "another-server"}
+	cli := testProvisionClient(t, server, testProvisionIdentity(), volume)
+
+	provider := mocktypes.NewMockProvider(ctrl)
+	provider.EXPECT().CreateServer(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil)
+
+	prov := attachmentProvisioner(t, server, provider)
+	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
+	require.ErrorIs(t, err, provisioners.ErrYield)
+	require.ErrorIs(t, err, coreerrors.ErrConflict)
+	require.Equal(t, regionv1.AttachmentProvisioning, server.Status.Volumes[0].ProvisioningStatus)
+	require.Equal(t, "another-server", getAttachmentVolume(t, cli).Spec.ClaimRef.ID)
+}
+
+func TestProvisionDetachesRemovedVolumeBeforeWaitingForReplacement(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	server := testProvisionServer(func(server *regionv1.Server) {
+		server.Spec.Volumes = []regionv1.ServerVolumeSpec{{ID: replacementVolumeID}}
+	})
+	removed := attachmentVolume()
+	replacement := attachmentVolume()
+	replacement.Name = replacementVolumeID
+	replacement.Status.Conditions = nil
+	cli := testProvisionClient(t, server, testProvisionIdentity(), removed, replacement)
+	reference := serverVolumeReference(t, cli, server)
+	claimVolumeForServer(removed, server, reference)
+	cli = testProvisionClient(t, server, testProvisionIdentity(), removed, replacement)
+
+	provider := mocktypes.NewMockProvider(ctrl)
+	provider.EXPECT().CreateServer(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil)
+	provider.EXPECT().DetachVolume(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil)
+
+	prov := attachmentProvisioner(t, server, provider)
+	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
+	require.ErrorIs(t, err, provisioners.ErrYield)
+
+	stored := getAttachmentVolume(t, cli)
+	require.Nil(t, stored.Spec.ClaimRef)
+	require.False(t, controllerutil.ContainsFinalizer(stored, reference))
+	require.Equal(t, []regionv1.ServerVolumeStatus{{
+		ID:                 replacementVolumeID,
+		ProvisioningStatus: regionv1.AttachmentProvisioning,
+		Message:            "waiting for volume to be provisioned",
+	}}, server.Status.Volumes)
+}
+
+func TestProvisionRetriesVolumeAttachmentIndependently(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	server := testProvisionServer(func(server *regionv1.Server) {
+		server.Spec.Volumes = []regionv1.ServerVolumeSpec{{ID: attachmentVolumeID}}
+	})
+	volume := attachmentVolume()
+	cli := testProvisionClient(t, server, testProvisionIdentity(), volume)
+	reference := serverVolumeReference(t, cli, server)
+	device := "/dev/vdb"
+
+	provider := mocktypes.NewMockProvider(ctrl)
+	firstCreate := provider.EXPECT().CreateServer(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil)
+	firstAttach := provider.EXPECT().AttachVolume(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil, provisioners.ErrYield).After(firstCreate)
+	secondCreate := provider.EXPECT().CreateServer(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(nil).After(firstAttach)
+	provider.EXPECT().AttachVolume(gomock.Any(), gomock.Any(), server, gomock.Any()).Return(&types.ServerVolumeAttachment{Device: &device}, nil).After(secondCreate)
+
+	prov := attachmentProvisioner(t, server, provider)
+	err := prov.Provision(coreclient.NewContext(t.Context(), cli))
+	require.ErrorIs(t, err, provisioners.ErrYield)
+	require.Equal(t, regionv1.AttachmentProvisioning, server.Status.Volumes[0].ProvisioningStatus)
+	require.NotNil(t, getAttachmentVolume(t, cli).Spec.ClaimRef)
+	require.True(t, controllerutil.ContainsFinalizer(getAttachmentVolume(t, cli), reference))
+
+	require.NoError(t, prov.Provision(coreclient.NewContext(t.Context(), cli)))
+	require.Equal(t, regionv1.AttachmentProvisioned, server.Status.Volumes[0].ProvisioningStatus)
+	require.Equal(t, &device, server.Status.Volumes[0].Device)
+}
+
+func TestDeprovisionDetachesAndReleasesVolumesBeforeServerDelete(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	server := testProvisionServer(func(server *regionv1.Server) {
+		server.Spec.Volumes = []regionv1.ServerVolumeSpec{{ID: attachmentVolumeID}}
+	})
+	volume := attachmentVolume()
+	cli := testProvisionClient(t, server, testProvisionIdentity(), volume)
+	reference := serverVolumeReference(t, cli, server)
+	claimVolumeForServer(volume, server, reference)
+	cli = testProvisionClient(t, server, testProvisionIdentity(), volume)
+
+	provider := mocktypes.NewMockProvider(ctrl)
+	detach := provider.EXPECT().DetachVolume(gomock.Any(), gomock.Any(), server, gomock.Any()).DoAndReturn(
+		func(_ any, _ *regionv1.Identity, _ *regionv1.Server, _ *regionv1.Volume) error {
+			stored := getAttachmentVolume(t, cli)
+			require.NotNil(t, stored.Spec.ClaimRef)
+			require.True(t, controllerutil.ContainsFinalizer(stored, reference))
+
+			return nil
+		},
+	)
+	provider.EXPECT().DeleteServer(gomock.Any(), gomock.Any(), server).DoAndReturn(
+		func(_ any, _ *regionv1.Identity, _ *regionv1.Server) error {
+			stored := getAttachmentVolume(t, cli)
+			require.Nil(t, stored.Spec.ClaimRef)
+			require.False(t, controllerutil.ContainsFinalizer(stored, reference))
+
+			return nil
+		},
+	).After(detach)
+
+	prov := attachmentProvisioner(t, server, provider)
+	require.NoError(t, prov.Deprovision(coreclient.NewContext(t.Context(), cli)))
+}


### PR DESCRIPTION
## Context

Servers can declare existing Volumes, but the controller did not own the
attachment lifecycle. Concurrent Servers could race for one Volume, and
removing desired state or deleting a Server did not reconcile detach and
claim cleanup.

## Change

Make the Server controller claim and reference each Volume before attach,
retain ownership until detach converges, and report per-attachment state.
Treat attached Cinder volumes as provisioned and accepted Nova detach
requests as partial progress so retries preserve the ordering guarantee.

## Verification

- make touch
- make license
- make validate
- make lint
- make generate
- make test-unit

Fixes: STO-128