### PR TITLE
Skip regions whose providers fail to initialize

### DIFF
--- a/pkg/monitor/README.md
+++ b/pkg/monitor/README.md
@@ -30,4 +30,9 @@ intended to allow additional monitor classes later.
 
 - This is polling by design. That makes it simpler and more decoupled, but also
   means timeliness and overhead are governed by poll period rather than watches.
-- Provider/cache readiness is part of monitor startup.
+- Provider/cache readiness is part of monitor startup, but a region whose
+  provider cannot be initialized is skipped rather than taking the process down;
+  see [providers](../providers/README.md). Servers in an unavailable region are
+  absent from that poll's checks and from the state gauge, and keep their last
+  known condition rather than being written to a wrong one, per
+  [health/server](./health/server/README.md).

--- a/pkg/providers/README.md
+++ b/pkg/providers/README.md
@@ -105,6 +105,25 @@ packages are the concrete provider implementations.
   than assuming client material is static for process lifetime.
   Credential rotation, secret refresh, and region configuration refresh are part
   of the provider contract, not incidental operational concerns.
+- Substrate health is a per-region concern, never a process-wide one. `New`
+  initializes every region's provider at startup, but a region that fails to
+  initialize is logged and skipped rather than failing the call:
+  - provider construction authenticates against a remote cloud, so failing the
+    call would let one region's outage decide whether the process runs at all,
+    taking every healthy region down with it and blocking deploys until somebody
+    else's substrate was repaired
+  - a startup check is also the wrong moment to establish substrate health,
+    because it is a runtime property: credentials and certificates can expire
+    while the process is up, where construction-time validation neither prevents
+    nor detects the failure
+  - a skipped region is in the same state as one created after startup: absent
+    from the cache, and retried on demand at the next lookup, so it recovers
+    without a restart
+  - the failure is not remembered, so a region whose substrate is permanently
+    misconfigured is re-initialized on every lookup. That is the accepted cost
+    of self-healing without a restart
+  - callers that want startup to gate on more than this own that policy
+    themselves; see `Options.WarmImageCache`
 - The provider layer is allowed to carry compensating local mechanisms where the
   underlying substrate is insufficient on its own:
   - OpenStack image caching exists because raw image API behaviour is too slow

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/unikorn-cloud/region/pkg/providers/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -75,11 +76,11 @@ type Options struct {
 // New creates and synchronously initializes all region providers. Startup-time region
 // discovery and provider construction use initClient so bootstrap reads can happen
 // before a controller manager cache has started, while the returned provider set retains
-// runtimeClient for normal cached operation after startup. The chosen behaviour is to
-// fail on initialization failure, the reasoning is that during upgrade an old version of
-// the service should be running to handle traffic, and we'd rather not have something
-// put into production that is known to be broken. Regions discovered after startup are
-// loaded on demand and then shared for subsequent lookups.
+// runtimeClient for normal cached operation after startup. A region whose provider fails
+// to initialize is logged and skipped rather than failing the call: provider construction
+// authenticates against a remote cloud, so the health of one region's substrate would
+// otherwise decide whether this process runs at all. Skipped regions, like regions
+// discovered after startup, are loaded on demand and then shared for subsequent lookups.
 func New(ctx context.Context, initClient client.Client, runtimeClient client.Client, namespace string, opts Options) (Providers, error) {
 	var regions unikornv1.RegionList
 
@@ -94,7 +95,9 @@ func New(ctx context.Context, initClient client.Client, runtimeClient client.Cli
 	for i := range regions.Items {
 		provider, err := newProvider(ctx, initClient, runtimeClient, &regions.Items[i], opts)
 		if err != nil {
-			return nil, err
+			log.FromContext(ctx).Error(err, "region provider initialization failed, region unavailable until it recovers", "region", regions.Items[i].Name)
+
+			continue
 		}
 
 		cache[regions.Items[i].Name] = provider

--- a/pkg/providers/providers_test.go
+++ b/pkg/providers/providers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package providers_test
 
 import (
+	"errors"
 	"testing"
 
 	unikornv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
@@ -26,11 +27,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestLookupCommonLoadsRegionOnMiss(t *testing.T) {
-	t.Parallel()
+// newTestClient builds a fake client seeded with the supplied objects.
+func newTestClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
 
 	scheme := runtime.NewScheme()
 
@@ -42,20 +45,31 @@ func TestLookupCommonLoadsRegionOnMiss(t *testing.T) {
 		t.Fatalf("adding unikorn scheme: %v", err)
 	}
 
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+// newTestRegion returns a region of the given provider kind.
+func newTestRegion(namespace, name string, provider unikornv1.Provider) *unikornv1.Region {
+	return &unikornv1.Region{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: unikornv1.RegionSpec{
+			Provider: provider,
+		},
+	}
+}
+
+func TestLookupCommonLoadsRegionOnMiss(t *testing.T) {
+	t.Parallel()
+
 	namespace := "test"
 	ctx := t.Context()
 
-	region := &unikornv1.Region{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      "sim-public",
-		},
-		Spec: unikornv1.RegionSpec{
-			Provider: unikornv1.ProviderSimulated,
-		},
-	}
+	region := newTestRegion(namespace, "sim-public", unikornv1.ProviderSimulated)
 
-	runtimeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	runtimeClient := newTestClient(t)
 
 	providerSet, err := providers.New(ctx, runtimeClient, runtimeClient, namespace, providers.Options{})
 	if err != nil {
@@ -76,5 +90,37 @@ func TestLookupCommonLoadsRegionOnMiss(t *testing.T) {
 
 	if _, err := providerSet.LookupCommon("sim-public"); err != nil {
 		t.Fatalf("lookup from cache after delete: %v", err)
+	}
+}
+
+// TestNewSkipsRegionsThatFailToInitialize asserts that one region failing to
+// initialize does not deny service to every other region. The broken region uses
+// an unimplemented provider kind, which fails construction deterministically with
+// no network involved; from New's point of view that is the same shape as a cloud
+// region whose endpoint is unreachable.
+func TestNewSkipsRegionsThatFailToInitialize(t *testing.T) {
+	t.Parallel()
+
+	namespace := "test"
+	ctx := t.Context()
+
+	healthy := newTestRegion(namespace, "sim-public", unikornv1.ProviderSimulated)
+	broken := newTestRegion(namespace, "broken", unikornv1.Provider("unimplemented"))
+
+	runtimeClient := newTestClient(t, healthy, broken)
+
+	providerSet, err := providers.New(ctx, runtimeClient, runtimeClient, namespace, providers.Options{})
+	if err != nil {
+		t.Fatalf("creating providers with a broken region: %v", err)
+	}
+
+	if _, err := providerSet.LookupCommon("sim-public"); err != nil {
+		t.Fatalf("lookup of the healthy region: %v", err)
+	}
+
+	// The broken region is absent from the cache rather than remembered as broken,
+	// so a lookup retries initialization and fails the same way until it recovers.
+	if _, err := providerSet.LookupCommon("broken"); !errors.Is(err, providers.ErrRegionProviderUnimplemented) {
+		t.Fatalf("lookup of the broken region: want %v, got %v", providers.ErrRegionProviderUnimplemented, err)
 	}
 }


### PR DESCRIPTION
Provider construction authenticates against a remote cloud, so any region
being unreachable failed the whole of providers.New. That took down every
process that builds a provider set: the API server (pkg/server/server.go),
the controller manager (pkg/managers/providers.go) and the monitor
(pkg/monitor/monitor.go). One region's expired certificate therefore meant
no API for any region, no reconciliation anywhere, in-flight provisioning
stalled and deletions hung on finalizers, with no way to restart into a
healthy state until somebody else's substrate was repaired.

Log and skip the region instead. That leaves it in the same state as a
region created after startup, absent from the cache, and the existing
on-demand path retries it at the next lookup, so it recovers without a
restart. Healthy regions still initialize eagerly, so rollout latency is
unchanged.

The fail-fast behaviour this replaces was justified by keeping a known
broken build out of production while the old version kept serving. That
reasoning does not survive contact with a remote dependency: substrate
health is a runtime property, and a certificate can expire while the
process is up, where a startup check neither prevents nor detects the
failure. It also means the service cannot be deployed at all while any
region is unwell.

Trade-offs accepted, deliberately:

- A permanent misconfiguration, a wrong key in the service account secret
  say, previously failed the deploy loudly. It now deploys green with one
  log line and that region stays broken. Errors are not classified here,
  so this is indistinguishable from a transient outage.
- Nothing surfaces a skipped region except that log line. Region already
  carries an Available condition; setting it is the natural follow-up and
  is not done here to keep this change small.
- The failure is not remembered, so a permanently broken region is
  re-initialized on every lookup rather than once. That is the cost of
  self-healing without a restart. Bounding it is a separate concern:
  gophercloud is left on its default HTTP client, which has no request
  timeout, so a substrate that accepts connections and then goes quiet
  will occupy the caller rather than failing fast.
