### PR TITLE
ci: publish OpenAPI spec to nscaledev/openapi

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -29,6 +29,19 @@ jobs:
       uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  PublishOpenAPISpec:
+    needs: Coverage
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Publish OpenAPI spec
+      uses: nscaledev/openapi/.github/actions/publish-spec@3c79a8b4cd3863a152456c1c2c729b245a79a1af # main
+      with:
+        service: region
+        spec-path: pkg/openapi/server.spec.yaml
+        version: main
+        token: ${{ secrets.OPENAPI_PUBLISH_TOKEN }}
   ContractDeployment:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,3 +95,10 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         name: Release ${{ github.ref_name }}
         tag_name: ${{ github.ref_name }}
+    - name: Publish OpenAPI spec
+      uses: nscaledev/openapi/.github/actions/publish-spec@3c79a8b4cd3863a152456c1c2c729b245a79a1af # main
+      with:
+        service: region
+        spec-path: pkg/openapi/server.spec.yaml
+        version: ${{ github.ref_name }}
+        token: ${{ secrets.OPENAPI_PUBLISH_TOKEN }}


### PR DESCRIPTION
Ports the change proven in [nscaledev/nks-core#45](https://github.com/nscaledev/nks-core/pull/45) to this repo. Companion PRs: [uni-identity#539](https://github.com/nscaledev/uni-identity/pull/539), [uni-compute#322](https://github.com/nscaledev/uni-compute/pull/322), [reservation#213](https://github.com/nscaledev/reservation/pull/213), uni-storage.

## Summary
- Adds a `PublishOpenAPISpec` job to `merge.yaml` — which already runs only on pushes to `main` (`tags-ignore: "*"`), so no extra event gate is needed — calling the shared [`nscaledev/openapi/.github/actions/publish-spec`](https://github.com/nscaledev/openapi/blob/main/.github/actions/publish-spec/action.yml) action with `version: main`. It `needs: Coverage` so a commit failing unit tests doesn't publish.
- Adds a final step to `release.yaml`'s `release` job calling the same action with `version: ${{ github.ref_name }}` on every tagged release.
- The action bundles (resolving the remote `unikorn-cloud/core` `$ref`s), sanitizes (strips internal-only operations/servers/vendor extensions), lints, and commits `pkg/openapi/server.spec.yaml` into `region/main/` or `region/vX.Y.Z/` in `nscaledev/openapi`. A plain `vX.Y.Z` release also updates `region/latest/`; prereleases get their own folder but never become `latest`. No-op if the spec hasn't changed since the last publish.
- `region/main/` and `region/v1.20.0/` are already backfilled in `nscaledev/openapi` from a manual one-off run; this PR is what makes it automatic going forward.
- Action pinned to the same SHA nks-core is running.

## Before this can actually work
This repo needs an `OPENAPI_PUBLISH_TOKEN` secret — a token with `contents: write` on `nscaledev/openapi` — under **Settings → Secrets and variables → Actions**. It is not set on this repo today (only nks-core has it).

## Test plan
- [ ] Add the `OPENAPI_PUBLISH_TOKEN` secret
- [ ] Merge this PR, confirm `PublishOpenAPISpec` succeeds on the resulting main-push run and `region/main/openapi.{yaml,json}` updates in `nscaledev/openapi`
- [ ] Cut a release tag, confirm the new step in `release.yaml` succeeds and `region/vX.Y.Z/` plus `region/latest/` update in `nscaledev/openapi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)