### PR TITLE
Consolidate quota allocation helpers

### DIFF
--- a/pkg/handler/common/README.md
+++ b/pkg/handler/common/README.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-`pkg/handler/common` defines the shared constructor dependency bundle for the
-region handler layer.
+`pkg/handler/common` defines shared handler dependencies and Identity allocation
+delegation for the region handler layer.
 
-Its entire job is `ClientArgs`: a pragmatic package-level contract for the
-ambient capabilities most handlers need in order to do useful work.
+`ClientArgs` is a pragmatic package-level contract for the ambient capabilities
+that most handlers need.
 
 Those capabilities are:
 
@@ -14,11 +14,10 @@ Those capabilities are:
 - process namespace
 - provider lookup
 - outbound identity API access
+- Identity allocation create, update, and delete delegation
 
-This is not an especially pure abstraction. It is a practical way to keep
-handler construction uniform without hiding runtime dependencies in
-`context.Context` or forcing a much larger refactor around a dedicated handler
-runtime object.
+This package keeps handler construction uniform. It does not hide runtime
+dependencies in `context.Context` or require a separate handler runtime object.
 
 ## Main Component
 
@@ -26,6 +25,9 @@ runtime object.
 
 `ClientArgs` is the shared constructor shape used by most region handlers and
 their helper clients.
+
+It also delegates Identity allocation create, update, and delete calls. Concrete
+handlers keep their allocation requirements, compensation, and error handling.
 
 It carries:
 
@@ -41,7 +43,8 @@ ad hoc.
 
 ## Invariants And Guard Rails
 
-- This package owns wiring shape, not business logic.
+- This package owns shared wiring and Identity allocation delegation. It does
+  not own resource-specific allocation requirements or lifecycle behavior.
 - `ClientArgs` is a shared handler-layer constructor contract with wide fan-out
   across concrete handler packages and top-level server wiring.
 - The dependency bundle is intentionally coarse-grained for practicality, but it

--- a/pkg/handler/common/allocations.go
+++ b/pkg/handler/common/allocations.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+
+	identityclient "github.com/unikorn-cloud/identity/pkg/client"
+	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CreateAllocation creates an Identity allocation for a handler resource.
+func (c ClientArgs) CreateAllocation(ctx context.Context, resource client.Object, allocations identityapi.ResourceAllocationList) error {
+	return identityclient.NewAllocations(c.Client, c.Identity).Create(ctx, resource, allocations)
+}
+
+// UpdateAllocation updates an Identity allocation for a handler resource.
+func (c ClientArgs) UpdateAllocation(ctx context.Context, resource client.Object, allocations identityapi.ResourceAllocationList) error {
+	return identityclient.NewAllocations(c.Client, c.Identity).Update(ctx, resource, allocations)
+}
+
+// DeleteAllocation deletes an Identity allocation for a handler resource.
+func (c ClientArgs) DeleteAllocation(ctx context.Context, resource client.Object) error {
+	return identityclient.NewAllocations(c.Client, c.Identity).Delete(ctx, resource)
+}

--- a/pkg/handler/network/client_v2.go
+++ b/pkg/handler/network/client_v2.go
@@ -31,7 +31,6 @@ import (
 	"github.com/unikorn-cloud/core/pkg/server/errors"
 	"github.com/unikorn-cloud/core/pkg/server/saga"
 	coreutil "github.com/unikorn-cloud/core/pkg/server/util"
-	identityclient "github.com/unikorn-cloud/identity/pkg/client"
 	"github.com/unikorn-cloud/identity/pkg/handler/common"
 	identityids "github.com/unikorn-cloud/identity/pkg/ids"
 	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
@@ -424,7 +423,7 @@ func (s *createSaga) createAllocation(ctx context.Context) error {
 		},
 	}
 
-	if err := identityclient.NewAllocations(s.client.Client, s.client.Identity).Create(ctx, s.network, required); err != nil {
+	if err := s.client.CreateAllocation(ctx, s.network, required); err != nil {
 		return err
 	}
 
@@ -432,7 +431,7 @@ func (s *createSaga) createAllocation(ctx context.Context) error {
 }
 
 func (s *createSaga) deleteAllocation(ctx context.Context) error {
-	if err := identityclient.NewAllocations(s.client.Client, s.client.Identity).Delete(ctx, s.network); err != nil {
+	if err := s.client.DeleteAllocation(ctx, s.network); err != nil {
 		return err
 	}
 

--- a/pkg/handler/storage/saga.go
+++ b/pkg/handler/storage/saga.go
@@ -28,7 +28,6 @@ import (
 	"github.com/unikorn-cloud/core/pkg/server/conversion"
 	"github.com/unikorn-cloud/core/pkg/server/errors"
 	"github.com/unikorn-cloud/core/pkg/server/saga"
-	identityclient "github.com/unikorn-cloud/identity/pkg/client"
 	"github.com/unikorn-cloud/identity/pkg/handler/common"
 	identityids "github.com/unikorn-cloud/identity/pkg/ids"
 	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
@@ -115,7 +114,7 @@ func (s *createSaga) createAllocation(ctx context.Context) error {
 	quantity := gibToQuantity(s.request.Spec.SizeGiB)
 	required := s.client.generateAllocation(quantity.Value())
 
-	if err := identityclient.NewAllocations(s.client.Client, s.client.Identity).Create(ctx, s.filestorage, required); err != nil {
+	if err := s.client.CreateAllocation(ctx, s.filestorage, required); err != nil {
 		return wrapAllocationError(err)
 	}
 
@@ -123,7 +122,7 @@ func (s *createSaga) createAllocation(ctx context.Context) error {
 }
 
 func (s *createSaga) deleteAllocation(ctx context.Context) error {
-	if err := identityclient.NewAllocations(s.client.Client, s.client.Identity).Delete(ctx, s.filestorage); err != nil {
+	if err := s.client.DeleteAllocation(ctx, s.filestorage); err != nil {
 		return wrapAllocationError(err)
 	}
 
@@ -292,7 +291,7 @@ func (s *updateSaga) generate(ctx context.Context) error {
 func (s *updateSaga) updateAllocation(ctx context.Context) error {
 	required := s.client.generateAllocation(s.updated.Spec.Size.Value())
 
-	if err := identityclient.NewAllocations(s.client.Client, s.client.Identity).Update(ctx, s.current, required); err != nil {
+	if err := s.client.UpdateAllocation(ctx, s.current, required); err != nil {
 		return wrapAllocationError(err)
 	}
 
@@ -302,7 +301,7 @@ func (s *updateSaga) updateAllocation(ctx context.Context) error {
 func (s *updateSaga) revertAllocation(ctx context.Context) error {
 	required := s.client.generateAllocation(s.current.Spec.Size.Value())
 
-	if err := identityclient.NewAllocations(s.client.Client, s.client.Identity).Update(ctx, s.current, required); err != nil {
+	if err := s.client.UpdateAllocation(ctx, s.current, required); err != nil {
 		return wrapAllocationError(err)
 	}
 

--- a/pkg/handler/volume/client.go
+++ b/pkg/handler/volume/client.go
@@ -29,7 +29,6 @@ import (
 	"github.com/unikorn-cloud/core/pkg/server/errors"
 	"github.com/unikorn-cloud/core/pkg/server/saga"
 	coreutil "github.com/unikorn-cloud/core/pkg/server/util"
-	identityclient "github.com/unikorn-cloud/identity/pkg/client"
 	identitycommon "github.com/unikorn-cloud/identity/pkg/handler/common"
 	identityids "github.com/unikorn-cloud/identity/pkg/ids"
 	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
@@ -271,14 +270,14 @@ type createSaga struct {
 }
 
 func (s *createSaga) createAllocation(ctx context.Context) error {
-	return identityclient.NewAllocations(s.client.Client, s.client.Identity).Create(ctx, s.volume, identityapi.ResourceAllocationList{{
+	return s.client.CreateAllocation(ctx, s.volume, identityapi.ResourceAllocationList{{
 		Kind:      "volumes",
 		Committed: int(s.volume.Spec.Size.Value()),
 	}})
 }
 
 func (s *createSaga) deleteAllocation(ctx context.Context) error {
-	return identityclient.NewAllocations(s.client.Client, s.client.Identity).Delete(ctx, s.volume)
+	return s.client.DeleteAllocation(ctx, s.volume)
 }
 
 func (s *createSaga) createVolume(ctx context.Context) error {


### PR DESCRIPTION
Consolidate Identity allocation delegation behind handler client arguments.

This removes repeated allocation-client construction while preserving each
resource's allocation requirements, compensation, and error handling.

Tests:
- go test ./pkg/handler/common ./pkg/handler/network ./pkg/handler/storage ./pkg/handler/volume -count=1